### PR TITLE
add keep_extend_vocab_only option

### DIFF
--- a/examples/word_embedding/README.md
+++ b/examples/word_embedding/README.md
@@ -35,20 +35,8 @@ wget https://paddlenlp.bj.bcebos.com/data/dict.txt
 
 我们以中文情感分类公开数据集ChnSentiCorp为示例数据集，可以运行下面的命令，在训练集（train.tsv）上进行模型训练，并在验证集（dev.tsv）验证。
 
-CPU 启动：
-
+启动训练：
 ```
-# 使用paddlenlp.embeddings.TokenEmbedding
-python train.py --vocab_path='./dict.txt' --use_gpu=False --lr=5e-4 --batch_size=64 --epochs=20 --use_token_embedding=True --vdl_dir='./vdl_dir'
-
-# 使用paddle.nn.Embedding
-python train.py --vocab_path='./dict.txt' --use_gpu=False --lr=1e-4 --batch_size=64 --epochs=20 --use_token_embedding=False --vdl_dir='./vdl_dir'
-```
-
-GPU 启动：
-```
-export CUDA_VISIBLE_DEVICES=0
-
 # 使用paddlenlp.embeddings.TokenEmbedding
 python train.py --vocab_path='./dict.txt' --use_gpu=True --lr=5e-4 --batch_size=64 --epochs=20 --use_token_embedding=True --vdl_dir='./vdl_dir'
 

--- a/paddlenlp/embeddings/token_embedding.py
+++ b/paddlenlp/embeddings/token_embedding.py
@@ -58,8 +58,8 @@ class TokenEmbedding(nn.Embedding):
             The file path of extended vocabulary.
         trainable (object: `bool`, optional, default to True):
             Whether the weight of embedding can be trained.
-        keep_extend_vocab_only (object: `bool`, optional, default to True):
-            Whether keep the extend vocabulary only, only effective if provides extended_vocab_path
+        keep_extended_vocab_only (object: `bool`, optional, default to True):
+            Whether keep the extended vocabulary only, will be effective only if provides extended_vocab_path
     """
 
     def __init__(self,
@@ -68,7 +68,7 @@ class TokenEmbedding(nn.Embedding):
                  unknown_token_vector=None,
                  extended_vocab_path=None,
                  trainable=True,
-                 keep_extend_vocab_only=False):
+                 keep_extended_vocab_only=False):
         vector_path = osp.join(EMBEDDING_HOME, embedding_name + ".npz")
         if not osp.exists(vector_path):
             # download
@@ -91,7 +91,7 @@ class TokenEmbedding(nn.Embedding):
         if extended_vocab_path is not None:
             embedding_table = self._extend_vocab(extended_vocab_path, vector_np,
                                                  pad_vector, unk_vector,
-                                                 keep_extend_vocab_only)
+                                                 keep_extended_vocab_only)
             trainable = True
         else:
             embedding_table = self._init_without_extend_vocab(
@@ -142,7 +142,7 @@ class TokenEmbedding(nn.Embedding):
         return vocab_list
 
     def _extend_vocab(self, extended_vocab_path, vector_np, pad_vector,
-                      unk_vector, keep_extend_vocab_only):
+                      unk_vector, keep_extended_vocab_only):
         """
         Construct index to word list, word to index dict and embedding weight using
         extended vocab.
@@ -186,7 +186,7 @@ class TokenEmbedding(nn.Embedding):
         embedding_table[
             extend_vocab_intersect_index] = pretrained_embedding_table[
                 pretrained_vocab_intersect_index]
-        if not keep_extend_vocab_only:
+        if not keep_extended_vocab_only:
             for idx in pretrained_vocab_subtract_index:
                 word = pretrained_idx_to_word[idx]
                 self._idx_to_word.append(word)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
* add keep_extend_vocab_only option
* simplify the embedding example doc