### PR TITLE
alter pe print

### DIFF
--- a/benchmark/transformer/static/predict.py
+++ b/benchmark/transformer/static/predict.py
@@ -20,6 +20,7 @@ FORMAT = '%(asctime)s-%(levelname)s: %(message)s'
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
+
 def cast_parameters_to_fp32(place, program, scope=None):
     all_parameters = []
     for block in program.blocks:
@@ -32,6 +33,7 @@ def cast_parameters_to_fp32(place, program, scope=None):
             'fp32' in str(param.dtype).lower():
             data = np.array(tensor)
             tensor.set(np.float32(data), place)
+
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
多卡训练时，benchmark 需要将结果打印的 ips 改为单卡打印，在静态图 PE 的情况下，默认 `return_merged=True` 打印的是多卡总的 ips 统计，故修改。
区分分布式和 PE ips 统计方式。