### PR TITLE
fix lac spawn error

### DIFF
--- a/examples/lexical_analysis/eval.py
+++ b/examples/lexical_analysis/eval.py
@@ -18,8 +18,9 @@ import ast
 import math
 import argparse
 
-import paddle
 import numpy as np
+import paddle
+from paddle.static import InputSpec
 from paddlenlp.data import Pad, Tuple, Stack
 from paddlenlp.metrics import ChunkEvaluator
 
@@ -67,7 +68,9 @@ def evaluate(args):
     # Define the model network and metric evaluator
     network = BiGruCrf(args.emb_dim, args.hidden_size, test_dataset.vocab_size,
                        test_dataset.num_labels)
-    model = paddle.Model(network)
+    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
+    model = paddle.Model(network, inputs=[inputs, lengths])
     chunk_evaluator = ChunkEvaluator(
         label_list=test_dataset.label_vocab.keys(), suffix=True)
     model.prepare(None, None, chunk_evaluator)

--- a/examples/lexical_analysis/eval.py
+++ b/examples/lexical_analysis/eval.py
@@ -68,8 +68,8 @@ def evaluate(args):
     # Define the model network and metric evaluator
     network = BiGruCrf(args.emb_dim, args.hidden_size, test_dataset.vocab_size,
                        test_dataset.num_labels)
-    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
-    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
+    inputs = InputSpec(shape=(-1, ), dtype="int16", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int16", name='lengths')
     model = paddle.Model(network, inputs=[inputs, lengths])
     chunk_evaluator = ChunkEvaluator(
         label_list=test_dataset.label_vocab.keys(), suffix=True)

--- a/examples/lexical_analysis/predict.py
+++ b/examples/lexical_analysis/predict.py
@@ -19,6 +19,7 @@ import argparse
 
 import numpy as np
 import paddle
+from paddle.static import InputSpec
 from paddlenlp.data import Pad, Tuple, Stack
 from paddlenlp.metrics import ChunkEvaluator
 
@@ -66,7 +67,9 @@ def infer(args):
     # Define the model network
     network = BiGruCrf(args.emb_dim, args.hidden_size, infer_dataset.vocab_size,
                        infer_dataset.num_labels)
-    model = paddle.Model(network)
+    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
+    model = paddle.Model(network, inputs=[inputs, lengths])
     model.prepare()
 
     # Load the model and start predicting

--- a/examples/lexical_analysis/predict.py
+++ b/examples/lexical_analysis/predict.py
@@ -67,8 +67,8 @@ def infer(args):
     # Define the model network
     network = BiGruCrf(args.emb_dim, args.hidden_size, infer_dataset.vocab_size,
                        infer_dataset.num_labels)
-    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
-    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
+    inputs = InputSpec(shape=(-1, ), dtype="int16", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int16", name='lengths')
     model = paddle.Model(network, inputs=[inputs, lengths])
     model.prepare()
 

--- a/examples/lexical_analysis/train.py
+++ b/examples/lexical_analysis/train.py
@@ -85,9 +85,9 @@ def train(args):
     network = BiGruCrf(args.emb_dim, args.hidden_size, train_dataset.vocab_size,
                        train_dataset.num_labels)
 
-    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
-    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
-    labels = InputSpec(shape=(-1, ), dtype="int8", name='labels')
+    inputs = InputSpec(shape=(-1, ), dtype="int16", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int16", name='lengths')
+    labels = InputSpec(shape=(-1, ), dtype="int16", name='labels')
     model = paddle.Model(network, inputs=[inputs, lengths, labels])
 
     # Prepare optimizer, loss and metric evaluator

--- a/examples/lexical_analysis/train.py
+++ b/examples/lexical_analysis/train.py
@@ -19,13 +19,14 @@ import argparse
 
 import numpy as np
 import paddle
-
-from data import LacDataset
-from model import BiGruCrf
+from paddle.static import InputSpec
 from paddlenlp.data import Pad, Tuple, Stack
 from paddlenlp.layers.crf import LinearChainCrfLoss, ViterbiDecoder
 from paddlenlp.metrics import ChunkEvaluator
 import distutils.util
+
+from data import LacDataset
+from model import BiGruCrf, get_loss
 
 # yapf: disable
 parser = argparse.ArgumentParser(__doc__)
@@ -83,15 +84,18 @@ def train(args):
     # Define the model netword and its loss
     network = BiGruCrf(args.emb_dim, args.hidden_size, train_dataset.vocab_size,
                        train_dataset.num_labels)
-    model = paddle.Model(network)
+
+    inputs = InputSpec(shape=(-1, ), dtype="int8", name='inputs')
+    lengths = InputSpec(shape=(-1, ), dtype="int8", name='lengths')
+    labels = InputSpec(shape=(-1, ), dtype="int8", name='labels')
+    model = paddle.Model(network, inputs=[inputs, lengths, labels])
 
     # Prepare optimizer, loss and metric evaluator
     optimizer = paddle.optimizer.Adam(
         learning_rate=args.base_lr, parameters=model.parameters())
-    crf_loss = LinearChainCrfLoss(network.crf)
     chunk_evaluator = ChunkEvaluator(
         label_list=train_dataset.label_vocab.keys(), suffix=True)
-    model.prepare(optimizer, crf_loss, chunk_evaluator)
+    model.prepare(optimizer, get_loss, chunk_evaluator)
     if args.init_checkpoint:
         model.load(args.init_checkpoint)
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Describe
**LAC报多卡错误**：https://github.com/PaddlePaddle/PaddleNLP/issues/61
**问题复现**：在2.0正式版中必现，在2.0rc1中运行正常
**问题原因**：对于一般loss，例如交叉熵损失函数，它在计算loss的时候是不会引入新参数的。但是crf在计算loss的时候会引入新参数：状态转移矩阵。目前的实现是 network (bigru) → paddle.Model → loss → prepare → fit。DataParallel封装network forward的时候，没有检测到有状态转移矩阵参与计算，因此不会同步状态转移矩阵的反向。但在计算loss的时候，又发现要计算状态转移矩阵的反向，因此发生了错误（2.0正式版新增错误检测）。
**问题解决**：将crfloss在network就计算出来。传给paddle.Model的loss改成一个简单的直接返回函数
