### PR TITLE
update doc, add virtualenv to use "python"

### DIFF
--- a/examples/machine_translation/transformer/faster_transformer/README.md
+++ b/examples/machine_translation/transformer/faster_transformer/README.md
@@ -22,6 +22,9 @@
 首先，因为需要基于当前环境重新编译，当前的 paddlenlp 的 python 包里面并不包含 Faster Transformer 相关 lib，需要克隆一个 PaddleNLP，并重新编译:
 ``` sh
 git clone https://github.com/PaddlePaddle/PaddleNLP.git
+# 新建一个 python 的虚拟环境
+python3.7 -m virtualenv faster-transformer
+source faster-transformer/bin/activate
 ```
 
 其次，配置环境变量，让我们可以使用当前 clone 的 paddlenlp，并进入到自定义 OP 的路径，准备后续的编译操作：

--- a/examples/machine_translation/transformer/faster_transformer/README.md
+++ b/examples/machine_translation/transformer/faster_transformer/README.md
@@ -22,9 +22,6 @@
 首先，因为需要基于当前环境重新编译，当前的 paddlenlp 的 python 包里面并不包含 Faster Transformer 相关 lib，需要克隆一个 PaddleNLP，并重新编译:
 ``` sh
 git clone https://github.com/PaddlePaddle/PaddleNLP.git
-# 新建一个 python 的虚拟环境
-python3.7 -m virtualenv faster-transformer
-source faster-transformer/bin/activate
 ```
 
 其次，配置环境变量，让我们可以使用当前 clone 的 paddlenlp，并进入到自定义 OP 的路径，准备后续的编译操作：
@@ -43,12 +40,12 @@ cd PaddleNLP/paddlenlp/ext_op/
 ``` sh
 mkdir build
 cd build/
-cmake .. -DSM=xx -DCMAKE_BUILD_TYPE=Release
+cmake .. -DSM=xx -DCMAKE_BUILD_TYPE=Release -DPY_CMD=python3.x
 make -j
 cd ../
 ```
 
-注意：`xx` 是指的所用 GPU 的 compute capability。举例来说，可以将之指定为 70(V100) 或是 75(T4)。
+注意：`xx` 是指的所用 GPU 的 compute capability。举例来说，可以将之指定为 70(V100) 或是 75(T4)。若未指定 `-DPY_CMD` 将会默认使用系统命令 `python` 对应的 Python。
 
 最终，编译会在 `./build/lib/` 路径下，产出 `libdecoding_op.so`，即需要的 Faster Transformer decoding 执行的库。
 

--- a/paddlenlp/ext_op/CMakeLists.txt
+++ b/paddlenlp/ext_op/CMakeLists.txt
@@ -98,7 +98,11 @@ include_directories(
   ${FT_INCLUDE_PATH}
 )
 
-set(PYTHON_PATH "python" CACHE STRING "Python path")
+if(NOT ${PY_CMD})
+  set(PYTHON_PATH "python" CACHE STRING "Python path")
+else()
+  set(PYTHON_PATH ${PY_CMD} CACHE STRING "Python path")
+endif()
 
 execute_process(COMMAND ${PYTHON_PATH} "-c" "from __future__ import print_function; import paddle; print(paddle.sysconfig.get_include())"
                 RESULT_VARIABLE _INC_PYTHON_SUCCESS

--- a/paddlenlp/ext_op/README.md
+++ b/paddlenlp/ext_op/README.md
@@ -29,6 +29,9 @@
 首先，因为需要基于当前环境重新编译，当前的 paddlenlp 的 python 包里面并不包含 Faster Transformer 相关 lib，需要克隆一个 PaddleNLP，并重新编译:
 ``` sh
 git clone https://github.com/PaddlePaddle/PaddleNLP.git
+# 新建一个 python 的虚拟环境
+python3.7 -m virtualenv faster-transformer
+source faster-transformer/bin/activate
 ```
 
 其次，配置环境变量，让我们可以使用当前 clone 的 paddlenlp，并进入到自定义 OP 的路径，准备后续的编译操作：

--- a/paddlenlp/ext_op/README.md
+++ b/paddlenlp/ext_op/README.md
@@ -29,9 +29,6 @@
 首先，因为需要基于当前环境重新编译，当前的 paddlenlp 的 python 包里面并不包含 Faster Transformer 相关 lib，需要克隆一个 PaddleNLP，并重新编译:
 ``` sh
 git clone https://github.com/PaddlePaddle/PaddleNLP.git
-# 新建一个 python 的虚拟环境
-python3.7 -m virtualenv faster-transformer
-source faster-transformer/bin/activate
 ```
 
 其次，配置环境变量，让我们可以使用当前 clone 的 paddlenlp，并进入到自定义 OP 的路径，准备后续的编译操作：
@@ -50,12 +47,12 @@ cd PaddleNLP/paddlenlp/ext_op/
 ``` sh
 mkdir build
 cd build/
-cmake .. -DSM=xx -DCMAKE_BUILD_TYPE=Release
+cmake .. -DSM=xx -DCMAKE_BUILD_TYPE=Release -DPY_CMD=python3.x
 make -j
 cd ../
 ```
 
-注意：`xx` 是指的所用 GPU 的 compute capability。举例来说，可以将之指定为 70(V100) 或是 75(T4)。
+注意：`xx` 是指的所用 GPU 的 compute capability。举例来说，可以将之指定为 70(V100) 或是 75(T4)。若未指定 `-DPY_CMD` 将会默认使用系统命令 `python` 对应的 Python。
 
 最终，编译会在 `./build/lib/` 路径下，产出 `libdecoding_op.so`，即需要的 Faster Transformer decoding 执行的库。
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Since faster transformer uses "python" to compile. It's necessary to make python be associated with corresponding python, such as, python3.7. 