### PR TITLE
fix problem of max_steps

### DIFF
--- a/benchmark/bert/run_glue.py
+++ b/benchmark/bert/run_glue.py
@@ -400,6 +400,8 @@ def do_train(args):
                     os.makedirs(output_dir)
                 paddle.fluid.io.save_params(exe, output_dir)
                 tokenizer.save_pretrained(output_dir)
+            if global_step >= num_training_steps:
+                break
 
 
 if __name__ == "__main__":

--- a/examples/benchmark/glue/run_glue.py
+++ b/examples/benchmark/glue/run_glue.py
@@ -375,6 +375,8 @@ def do_train(args):
                         model, paddle.DataParallel) else model
                     model_to_save.save_pretrained(output_dir)
                     tokenizer.save_pretrained(output_dir)
+            if global_step >= num_training_steps:
+                break
 
 
 def print_arguments(args):

--- a/examples/language_model/bert/run_glue.py
+++ b/examples/language_model/bert/run_glue.py
@@ -394,6 +394,8 @@ def do_train(args):
                         model, paddle.DataParallel) else model
                     model_to_save.save_pretrained(output_dir)
                     tokenizer.save_pretrained(output_dir)
+            if global_step >= num_training_steps:
+                break
 
 
 def print_arguments(args):

--- a/examples/language_model/electra/run_glue.py
+++ b/examples/language_model/electra/run_glue.py
@@ -375,6 +375,8 @@ def do_train(args):
                         model, paddle.DataParallel) else model
                     model_to_save.save_pretrained(output_dir)
                     tokenizer.save_pretrained(output_dir)
+            if global_step >= num_training_steps:
+                break
 
 
 def print_arguments(args):

--- a/examples/language_model/electra/run_pretrain.py
+++ b/examples/language_model/electra/run_pretrain.py
@@ -640,6 +640,8 @@ def do_train(args):
                             for log in log_list:
                                 if len(log.strip()) > 0:
                                     f.write(log.strip() + '\n')
+            if global_step >= num_training_steps:
+                break
 
 
 def print_arguments(args):


### PR DESCRIPTION
修复run_glue.py的1个问题：如果配置了 max_steps，且其小于 len(train_data_loader) * num_train_epochs，则fine-tune在达到max_steps不会停止，会继续训练。