### PR TITLE
Fix CUDA_HOME in Windows CPU breaking import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ PaddleNLP基于PaddlePaddle 2.0全新API体系，提供了丰富的应用场景�
 更多教程参见[PaddleNLP on AI Studio](https://aistudio.baidu.com/aistudio/personalcenter/thirdview/574995)。
 
 
+
+## 最近更新（自2.0.0版本）
+
+### paddlenlp文本领域API
+
+- 修复Windows CPU环境下的import问题
+
 ## 社区贡献与技术交流
 
 ### 特殊兴趣小组

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ PaddleNLP基于PaddlePaddle 2.0全新API体系，提供了丰富的应用场景�
 
 ### paddlenlp文本领域API
 
-- 修复Windows CPU环境下的import问题
+- 修复Windows CPU环境下的import问题。
 
 ## 社区贡献与技术交流
 

--- a/paddlenlp/ops/ext_utils.py
+++ b/paddlenlp/ops/ext_utils.py
@@ -1,4 +1,17 @@
-# -*- coding: utf-8 -*-
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import subprocess
@@ -16,9 +29,9 @@ from paddle.utils.cpp_extension.cpp_extension import (
 from paddlenlp.utils.env import PPNLP_HOME
 from paddlenlp.utils.log import logger
 
-if not os.path.exists(CUDA_HOME):
-    # CUDA_HOME is only None when `core.is_compiled_with_cuda()` is True in
-    # find_cuda_home. Clear it for paddle cpu version.
+if CUDA_HOME and not os.path.exists(CUDA_HOME):
+    # CUDA_HOME is only None for Windows CPU version in paddle `find_cuda_home`.
+    # Clear it for other non-CUDA situations.
     CUDA_HOME = None
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix CUDA_HOME in Windows CPU breaking import. When using PaddlePaddle in Windows CPU, `CUDA_HOME` from paddlepaddle is None, which causes errors here. 