### PR TITLE
fix gpt static check_nan_inf

### DIFF
--- a/examples/language_model/gpt/run_pretrain_static.py
+++ b/examples/language_model/gpt/run_pretrain_static.py
@@ -20,14 +20,6 @@ import os
 import random
 import time
 
-os.environ['FLAGS_enable_parallel_graph'] = "0"
-os.environ['FLAGS_fraction_of_gpu_memory_to_use'] = "0.1"
-os.environ['FLAGS_sync_nccl_allreduce'] = "1"
-os.environ['FLAGS_eager_delete_tensor_gb'] = "0"
-os.environ['FLAGS_fuse_parameter_memory_size'] = "32"
-os.environ['FLAGS_fuse_parameter_groups_size'] = "50"
-os.environ['FLAGS_check_nan_inf'] = "1"
-os.environ['FLAGS_enable_sequential_execution'] = "1"
 os.path.expandvars('$HOME')
 os.path.expanduser('~')
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
remove os.environ from run_pretrain_static.py  to close FLAGS_check_nan_inf