### PR TITLE
fix 2.0.1 crf bug

### DIFF
--- a/examples/information_extraction/waybill_ie/run_bigru_crf.py
+++ b/examples/information_extraction/waybill_ie/run_bigru_crf.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     test_ds.map(trans_func)
 
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=word_vocab.get('OOV', 0), dtype='int64'),  # token_ids
+        Pad(axis=0, pad_val=word_vocab.get('OOV', 0), dtype='int32'),  # token_ids
         Stack(dtype='int64'),  # seq_len
         Pad(axis=0, pad_val=label_vocab.get('O', 0), dtype='int64')  # label_ids
     ): fn(samples)

--- a/examples/information_extraction/waybill_ie/run_bigru_crf.py
+++ b/examples/information_extraction/waybill_ie/run_bigru_crf.py
@@ -87,9 +87,9 @@ if __name__ == '__main__':
     test_ds.map(trans_func)
 
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=word_vocab.get('OOV', 0)),  # token_ids
-        Stack(),  # seq_len
-        Pad(axis=0, pad_val=label_vocab.get('O', 0))  # label_ids
+        Pad(axis=0, pad_val=word_vocab.get('OOV', 0), dtype='int64'),  # token_ids
+        Stack(dtype='int64'),  # seq_len
+        Pad(axis=0, pad_val=label_vocab.get('O', 0), dtype='int64')  # label_ids
     ): fn(samples)
 
     train_loader = paddle.io.DataLoader(

--- a/examples/information_extraction/waybill_ie/run_ernie.py
+++ b/examples/information_extraction/waybill_ie/run_ernie.py
@@ -83,10 +83,10 @@ if __name__ == '__main__':
 
     ignore_label = -1
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=tokenizer.pad_token_id),  # input_ids
-        Pad(axis=0, pad_val=tokenizer.pad_token_type_id),  # token_type_ids
-        Stack(),  # seq_len
-        Pad(axis=0, pad_val=ignore_label)  # labels
+        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int64'),  # input_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int64'),  # token_type_ids
+        Stack(dtype='int64'),  # seq_len
+        Pad(axis=0, pad_val=ignore_label, dtype='int64')  # labels
     ): fn(samples)
 
     train_loader = paddle.io.DataLoader(

--- a/examples/information_extraction/waybill_ie/run_ernie.py
+++ b/examples/information_extraction/waybill_ie/run_ernie.py
@@ -83,8 +83,8 @@ if __name__ == '__main__':
 
     ignore_label = -1
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int64'),  # input_ids
-        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int64'),  # token_type_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int32'),  # input_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int32'),  # token_type_ids
         Stack(dtype='int64'),  # seq_len
         Pad(axis=0, pad_val=ignore_label, dtype='int64')  # labels
     ): fn(samples)

--- a/examples/information_extraction/waybill_ie/run_ernie_crf.py
+++ b/examples/information_extraction/waybill_ie/run_ernie_crf.py
@@ -81,10 +81,10 @@ if __name__ == '__main__':
     test_ds.map(trans_func)
 
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=tokenizer.pad_token_id),  # input_ids
-        Pad(axis=0, pad_val=tokenizer.pad_token_type_id),  # token_type_ids
-        Stack(),  # seq_len
-        Pad(axis=0, pad_val=label_vocab.get("O", 0))  # labels
+        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int64'),  # input_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int64'),  # token_type_ids
+        Stack(dtype='int64'),  # seq_len
+        Pad(axis=0, pad_val=label_vocab.get("O", 0), dtype='int64')  # labels
     ): fn(samples)
 
     train_loader = paddle.io.DataLoader(

--- a/examples/information_extraction/waybill_ie/run_ernie_crf.py
+++ b/examples/information_extraction/waybill_ie/run_ernie_crf.py
@@ -81,8 +81,8 @@ if __name__ == '__main__':
     test_ds.map(trans_func)
 
     batchify_fn = lambda samples, fn=Tuple(
-        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int64'),  # input_ids
-        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int64'),  # token_type_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_id, dtype='int32'),  # input_ids
+        Pad(axis=0, pad_val=tokenizer.pad_token_type_id, dtype='int32'),  # token_type_ids
         Stack(dtype='int64'),  # seq_len
         Pad(axis=0, pad_val=label_vocab.get("O", 0), dtype='int64')  # labels
     ): fn(samples)

--- a/paddlenlp/layers/crf.py
+++ b/paddlenlp/layers/crf.py
@@ -395,8 +395,7 @@ class ViterbiDecoder(nn.Layer):
         # avoid call fill_constant in iteration
         zeros = paddle.zeros([1], dtype='int64')
         ones = paddle.ones([1], dtype='int64')
-        emission = paddle.slice(inputs_t, [0], [0], [max_seq_len])
-        for i, logit in enumerate(emission):
+        for i, logit in enumerate(inputs_t[:max_seq_len]):
             # if not with_start_stop_tag, the first label has not antecedent tag.
             if i == 0 and not self.with_start_stop_tag:
                 alpha = logit

--- a/paddlenlp/layers/crf.py
+++ b/paddlenlp/layers/crf.py
@@ -395,7 +395,8 @@ class ViterbiDecoder(nn.Layer):
         # avoid call fill_constant in iteration
         zeros = paddle.zeros([1], dtype='int64')
         ones = paddle.ones([1], dtype='int64')
-        for i, logit in enumerate(inputs_t[:max_seq_len]):
+        emission = paddle.slice(inputs_t, [0], [0], [max_seq_len])
+        for i, logit in enumerate(emission):
             # if not with_start_stop_tag, the first label has not antecedent tag.
             if i == 0 and not self.with_start_stop_tag:
                 alpha = logit


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
1. fix slice error in paddle 2.0.1
2. Pad, Stack function will return int32 data when input's type is int, which will lead to training error in Windows. Specify the  dtype as int64 to fix it.