### PR TITLE
Simplify transformer yaml

### DIFF
--- a/examples/machine_translation/transformer/configs/transformer.base.yaml
+++ b/examples/machine_translation/transformer/configs/transformer.base.yaml
@@ -105,8 +105,5 @@ use_amp: False
 use_pure_fp16: False
 scale_loss: 128.0
 
-# Whether to use multi-card/multi-node distributed training.
-# Only works for static graph for now.
-is_distributed: False
 # Maximum iteration for training. 
 max_iter: None

--- a/examples/machine_translation/transformer/configs/transformer.big.yaml
+++ b/examples/machine_translation/transformer/configs/transformer.big.yaml
@@ -105,8 +105,5 @@ use_amp: False
 use_pure_fp16: False
 scale_loss: 128.0
 
-# Whether to use multi-card/multi-node distributed training.
-# Only works for static graph for now.
-is_distributed: False
 # Maximum iteration for training. 
 max_iter: None


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Simplify transformer yaml and delete `distributed` option, cause it can be replaced by `argparser` in `train.py`.