### PR TITLE
Class Vocab to_token supports numpy ndarray

### DIFF
--- a/examples/dialogue/unified_transformer/utils.py
+++ b/examples/dialogue/unified_transformer/utils.py
@@ -192,7 +192,7 @@ def select_response(ids,
                     max_dec_len=None,
                     num_return_sequences=1,
                     keep_space=True):
-    ids = ids.numpy().tolist()
+    ids = ids.numpy()
     scores = scores.numpy()
 
     if len(ids) != len(scores) or (len(ids) % num_return_sequences) != 0:

--- a/paddlenlp/data/vocab.py
+++ b/paddlenlp/data/vocab.py
@@ -173,7 +173,7 @@ class Vocab(object):
 
         Args:
             indices (int|list[int]|tuple[int]|numpy.ndarray): The input indice(s) for mapping.
-            Must be an `int` or 1D list[int]|tuple[int]|numpy.ndarray.
+            Must be an `int` or 1D `list[int]`|`tuple[int]`|`numpy.ndarray`.
 
         Returns:
             str|list[str]: Obtained token(s). If `indices` is an integer, it 

--- a/paddlenlp/data/vocab.py
+++ b/paddlenlp/data/vocab.py
@@ -172,7 +172,8 @@ class Vocab(object):
         Maps the input indices to token list.
 
         Args:
-            indices (int|list[int]|tuple[int]): The input indice(s) for mapping.
+            indices (int|list[int]|tuple[int]|numpy.ndarray): The input indice(s) for mapping.
+            Must be an `int` or 1D list[int]|tuple[int]|numpy.ndarray.
 
         Returns:
             str|list[str]: Obtained token(s). If `indices` is an integer, it 

--- a/paddlenlp/data/vocab.py
+++ b/paddlenlp/data/vocab.py
@@ -15,6 +15,7 @@
 import collections
 import io
 import json
+import numpy as np
 import os
 import warnings
 
@@ -195,9 +196,16 @@ class Vocab(object):
                 # ['[PAD]', '[UNK]', '一斤三', '意面屋']
         """
         to_reduce = False
-        if not isinstance(indices, (list, tuple)):
+        if not isinstance(indices, (list, tuple, np.ndarray)):
             indices = [indices]
             to_reduce = True
+        elif isinstance(indices, (list, tuple)):
+            indices = np.asarray(indices)
+
+        if len(indices.shape) > 1:
+            raise ValueError(
+                'Token indices is invalid. Expected 1D array, but received {}D array. '.
+                format(len(indices.shape)))
 
         max_idx = len(self._idx_to_token) - 1
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
Class `Vocab` `to_token` method supports `numpy` `ndarray`.