### PR TITLE
Added last LayerNorm when set normalize_before=True

### DIFF
--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -321,7 +321,8 @@ class BertModel(BertPretrainedModel):
                  max_position_embeddings=512,
                  type_vocab_size=16,
                  initializer_range=0.02,
-                 pad_token_id=0):
+                 pad_token_id=0,
+                 normalize_before=False):
         super(BertModel, self).__init__()
         self.pad_token_id = pad_token_id
         self.initializer_range = initializer_range
@@ -336,7 +337,10 @@ class BertModel(BertPretrainedModel):
             activation=hidden_act,
             attn_dropout=attention_probs_dropout_prob,
             act_dropout=0)
-        self.encoder = nn.TransformerEncoder(encoder_layer, num_hidden_layers)
+        if normalize_before:
+            self.encoder = nn.TransformerEncoder(encoder_layer, num_hidden_layers, norm=LayerNorm(hidden_size))
+        else:
+            self.encoder = nn.TransformerEncoder(encoder_layer, num_hidden_layers)
         self.pooler = BertPooler(hidden_size)
         self.apply(self.init_weights)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
This is a fix of [issue453](https://github.com/PaddlePaddle/PaddleNLP/issues/453) - BERT Training encounters loss NaN with AMP and TransformerEncoderLayer.normalize_before=True.

[MegatronLM](https://github.com/NVIDIA/Megatron-LM) proposed a BERT-based architecture called Pre-LayerNorm, which put LayerNorm layer before residual connection in each Transformer block, and experiments show Pre-LayerNorm is helpful on stabilize training, especially when model get larger and larger.

There is a option in [Paddle/TransformerEncoderLayer](https://github.com/PaddlePaddle/Paddle/blob/69d237c22ddc083d5e03f5ad5009f976569e1f16/python/paddle/nn/layer/transformer.py#L431), `normalize_before`. It will put LayerNorm before  residual connection, like Pre-LayerNorm did. However, when we turn on this option, it would lack last LayerNorm in last TransformerEncoderLayer and lead training diverse. To address this issue, it should add last LayerNorm in [TransformerEncoder](https://github.com/PaddlePaddle/Paddle/blob/69d237c22ddc083d5e03f5ad5009f976569e1f16/python/paddle/nn/layer/transformer.py#L607) when set this argument as True.

This PR fixed the above issues and successfully trained BERT with `normalize_before=True` to converge to average 1.74 loss.
```
tobal step: 963000, epoch: 1, batch: 248, loss: 1.883960, avg_reader_cost: 0.00008 sec, avg_batch_cost: 0.03740 sec, avg_samples: 3.98400, ips: 106.52383 sequences/sec
tobal step: 964000, epoch: 1, batch: 1248, loss: 1.679320, avg_reader_cost: 0.00006 sec, avg_batch_cost: 0.15016 sec, avg_samples: 16.00000, ips: 106.55215 sequences/sec
tobal step: 965000, epoch: 1, batch: 2248, loss: 1.888636, avg_reader_cost: 0.00007 sec, avg_batch_cost: 0.15012 sec, avg_samples: 16.00000, ips: 106.57806 sequences/sec
tobal step: 966000, epoch: 1, batch: 58, loss: 1.734341, avg_reader_cost: 0.00006 sec, avg_batch_cost: 0.00888 sec, avg_samples: 0.94400, ips: 106.27584 sequences/sec
tobal step: 967000, epoch: 1, batch: 1058, loss: 1.761488, avg_reader_cost: 0.00006 sec, avg_batch_cost: 0.15329 sec, avg_samples: 16.00000, ips: 104.38048 sequences/sec
tobal step: 968000, epoch: 1, batch: 2058, loss: 1.837119, avg_reader_cost: 0.00006 sec, avg_batch_cost: 0.15049 sec, avg_samples: 16.00000, ips: 106.32283 sequences/sec
tobal step: 969000, epoch: 1, batch: 44, loss: 1.777481, avg_reader_cost: 0.00011 sec, avg_batch_cost: 0.00762 sec, avg_samples: 0.72000, ips: 94.54114 sequences/sec
tobal step: 970000, epoch: 1, batch: 1044, loss: 1.817858, avg_reader_cost: 0.00008 sec, avg_batch_cost: 0.15986 sec, avg_samples: 16.00000, ips: 100.08993 sequences/sec
tobal step: 971000, epoch: 1, batch: 2044, loss: 1.646863, avg_reader_cost: 0.00139 sec, avg_batch_cost: 0.25473 sec, avg_samples: 16.00000, ips: 62.81186 sequences/sec
```
