### PR TITLE
bug fix: tokenizer cannot convert numpy ids to tokens

### DIFF
--- a/examples/dialogue/unified_transformer/utils.py
+++ b/examples/dialogue/unified_transformer/utils.py
@@ -164,7 +164,7 @@ def post_process_response(token_ids, tokenizer):
             eos_pos = i
             break
     token_ids = token_ids[:eos_pos]
-    tokens = tokenizer.convert_ids_to_tokens(token_ids)
+    tokens = tokenizer.convert_ids_to_tokens(token_ids.tolist())
     tokens = tokenizer.merge_subword(tokens)
     return token_ids, tokens
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->


```bash

python3 interaction.py \
    --model_name_or_path=plato-mini \
    --min_dec_len=1 \
    --max_dec_len=64 \
    --num_return_sequences=20 \
    --decode_strategy=sampling \
    --top_k=5 \
    --device=cpu
-----------  Configuration Arguments -----------
decode_strategy: sampling
device: cpu
early_stopping: False
length_penalty: 1.0
max_dec_len: 64
min_dec_len: 1
model_name_or_path: plato-mini
num_beams: 0
num_return_sequences: 20
seed: None
temperature: 1.0
top_k: 5
top_p: 1.0
------------------------------------------------
[2021-06-24 00:03:11,103] [    INFO] - Already cached /Users/Yam/.paddlenlp/models/plato-mini/plato-mini.pdparams
[2021-06-24 00:03:20,310] [    INFO] - Found /Users/Yam/.paddlenlp/models/plato-mini/plato-mini-vocab.txt
[2021-06-24 00:03:20,313] [    INFO] - Found /Users/Yam/.paddlenlp/models/plato-mini/plato-mini- utils.py+                                                                             buffers
spm.model
Enter [EXIT] to quit the interaction, [NEXT] to start a new conversation.
[Human]: 你好
Building prefix dict from the default dictionary ...
Loading model from cache /var/folders/xt/mpcnl_9151dbq43hptdlv2jr0000gn/T/jieba.cache
Loading model cost 0.730 seconds.
Prefix dict has been built successfully.
/usr/local/lib/python3.8/site-packages/paddle/tensor/creation.py:125: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. To silence this warning, use `object` by itself. Doing this will not modify any behavior and is safe.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  if data.dtype == np.object:
/usr/local/lib/python3.8/site-packages/paddle/fluid/framework.py:689: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  elif dtype == np.bool:
/usr/local/lib/python3.8/site-packages/paddlenlp/data/vocab.py:207: UserWarning: The type of `to_tokens()`'s input `indices` is not `int` which will be forcibly transfered to `int`.
  warnings.warn(
Traceback (most recent call last):
  File "interaction.py", line 101, in <module>
    main(args)
  File "interaction.py", line 95, in main
    interaction(args, model, tokenizer)
  File "interaction.py", line 66, in interaction
    bot_response = select_response(
  File "/Users/Yam/Documents/Play/PaddleNLP/examples/dialogue/unified_transformer/utils.py", line 206, in select_response
    pred_token_ids, pred_tokens = post_process_response(pred, tokenizer)
  File "/Users/Yam/Documents/Play/PaddleNLP/examples/dialogue/unified_transformer/utils.py", line 167, in post_process_response
    tokens = tokenizer.convert_ids_to_tokens(token_ids)
  File "/usr/local/lib/python3.8/site-packages/paddlenlp/transformers/tokenizer_utils.py", line 399, in convert_ids_to_tokens
    tokens = self.vocab.to_tokens(ids)
  File "/usr/local/lib/python3.8/site-packages/paddlenlp/data/vocab.py", line 210, in to_tokens
    idx = int(idx)
TypeError: only size-1 arrays can be converted to Python scalars
```
