### PR TITLE
Fix PretrainedTokenizer vocabulary saving.

### DIFF
--- a/paddlenlp/data/vocab.py
+++ b/paddlenlp/data/vocab.py
@@ -215,7 +215,7 @@ class Vocab(object):
 
         tokens = []
         for idx in indices:
-            if not isinstance(idx, int):
+            if not isinstance(idx, (int, np.integer)):
                 warnings.warn(
                     "The type of `to_tokens()`'s input `indices` is not `int` which will be forcibly transfered to `int`. "
                 )

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -379,9 +379,12 @@ class PretrainedModel(Layer, GenerationMixin):
                 # reload from save_directory
                 model = BertForSequenceClassification.from_pretrained('./trained_model/')
         """
-        assert os.path.isdir(
-            save_dir), "save_dir ({}) is not available.".format(save_dir)
-        # Save model config 
+        assert not os.path.isfile(
+            save_dir
+        ), "Saving directory ({}) should be a directory, not a file".format(
+            save_dir)
+        os.makedirs(save_dir, exist_ok=True)
+        # Save model config
         self.save_model_config(save_dir)
         # Save model
         file_name = os.path.join(save_dir,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Resolve #643 .  Fix PretrainedTokenizer vocabulary saving by saving input file directly rather than `Vocab.idx_to_token`.