### PR TITLE
change the position encoding in the ernie-ctm

### DIFF
--- a/examples/information_extraction/msra_ner/train.py
+++ b/examples/information_extraction/msra_ner/train.py
@@ -28,6 +28,7 @@ from paddlenlp.transformers import LinearDecayWithWarmup
 from paddlenlp.metrics import ChunkEvaluator
 from paddlenlp.datasets import load_dataset
 from paddlenlp.transformers import BertForTokenClassification, BertTokenizer
+from paddlenlp.transformers import ErnieCtmForTokenClassification, ErnieCtmTokenizer
 from paddlenlp.data import Stack, Tuple, Pad, Dict
 
 parser = argparse.ArgumentParser()
@@ -51,6 +52,7 @@ parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu", 
 # yapf: enable
 
 
+@paddle.no_grad()
 def evaluate(model, loss_fct, metric, data_loader, label_num):
     model.eval()
     metric.reset()
@@ -100,6 +102,7 @@ def do_train(args):
         'msra_ner', splits=('train', 'test'), lazy=False)
 
     tokenizer = BertTokenizer.from_pretrained(args.model_name_or_path)
+    #tokenizer = ErnieCtmTokenizer.from_pretrained("ernie-ctm")
 
     label_list = train_ds.label_list
     label_num = len(label_list)
@@ -144,6 +147,8 @@ def do_train(args):
     # Define the model netword and its loss
     model = BertForTokenClassification.from_pretrained(
         args.model_name_or_path, num_classes=label_num)
+    #model = ErnieCtmForTokenClassification.from_pretrained(
+    #    args.model_name_or_path, num_classes=label_num)
     if paddle.distributed.get_world_size() > 1:
         model = paddle.DataParallel(model)
 

--- a/examples/text_to_knowledge/wordtag/predictor.py
+++ b/examples/text_to_knowledge/wordtag/predictor.py
@@ -96,9 +96,9 @@ URLS = {
     "TermTree.V1.0":
     "https://kg-concept.bj.bcebos.com/TermTree/TermTree.V1.0.tar.gz",
     "termtree_type.csv":
-    "https://paddlenlp.bj.bcebos.com/paddlenlp/resource/termtree_type.csv",
+    "https://paddlenlp.bj.bcebos.com/models/transformers/ernie_ctm/termtree_type.csv",
     "termtree_tags.txt":
-    "https://paddlenlp.bj.bcebos.com/paddlenlp/resource/termtree_tags.txt",
+    "https://paddlenlp.bj.bcebos.com/models/transformers/ernie_ctm/termtree_tags_pos.txt",
 }
 
 
@@ -274,10 +274,8 @@ class WordtagPredictor(object):
         short_input_texts = self._split_long_text2short_text_list(
             input_texts, max_predict_len)
         for text in short_input_texts:
-            tokens = ["[CLS%i]" % i
-                      for i in range(1, self.summary_num)] + list(text)
             tokenized_input = self._tokenizer(
-                tokens,
+                list(text),
                 return_length=True,
                 is_split_into_words=True,
                 max_seq_len=max_seq_len)

--- a/paddlenlp/transformers/ernie_ctm/tokenizer.py
+++ b/paddlenlp/transformers/ernie_ctm/tokenizer.py
@@ -71,10 +71,12 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
     }
     pretrained_init_configuration = {
         "ernie-ctm": {
-            "do_lower_case": True
+            "do_lower_case": True,
+            "summary_num": 2
         },
         "wordtag": {
-            "do_lower_case": True
+            "do_lower_case": True,
+            "summary_num": 2
         }
     }
 

--- a/paddlenlp/transformers/ernie_ctm/tokenizer.py
+++ b/paddlenlp/transformers/ernie_ctm/tokenizer.py
@@ -50,7 +50,7 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
             The token used for padding, for example when batching sequences of different lengths. Defaults to `"[PAD]"`
         cls_token_template (`str`, optional)
             The template of summary token for multiple summary placeholders. Defauts to `"[CLS{}]"`
-        summary_num (`int`, optional):
+        cls_num (`int`, optional):
             Summary placeholder used in ernie-ctm model. For catching a sentence global feature from multiple aware.
             Defaults to 1
         mask_token (`str`, optional):
@@ -72,11 +72,11 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
     pretrained_init_configuration = {
         "ernie-ctm": {
             "do_lower_case": True,
-            "summary_num": 2
+            "cls_num": 2
         },
         "wordtag": {
             "do_lower_case": True,
-            "summary_num": 2
+            "cls_num": 2
         }
     }
 
@@ -88,7 +88,7 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
                  sep_token="[SEP]",
                  pad_token="[PAD]",
                  cls_token_template="[CLS{}]",
-                 summary_num=1,
+                 cls_num=1,
                  mask_token="[MASK]",
                  **kwargs):
         if not os.path.isfile(vocab_file):
@@ -99,7 +99,7 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
                 .format(vocab_file))
         self.do_lower_case = do_lower_case
         self.cls_token_template = cls_token_template
-        self.summary_num = summary_num
+        self.cls_num = cls_num
         self.vocab = self.load_vocabulary(vocab_file, unk_token=unk_token)
 
     @property
@@ -129,7 +129,7 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
         """
         cls_token_ids = [
             self.convert_tokens_to_ids(self.cls_token_template.format(sid))
-            for sid in range(self.summary_num)
+            for sid in range(self.cls_num)
         ]
         if token_ids_1 is None:
             return cls_token_ids + token_ids_0 + [self.sep_token_id]
@@ -210,8 +210,8 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
         """
         sep = [self.sep_token_id]
         if token_ids_1 is None:
-            return (self.summary_num + len(token_ids_0 + sep)) * [0]
-        return (self.summary_num + len(token_ids_0 + sep)
+            return (self.cls_num + len(token_ids_0 + sep)) * [0]
+        return (self.cls_num + len(token_ids_0 + sep)
                 ) * [0] + len(token_ids_1 + sep) * [1]
 
     def num_special_tokens_to_add(self, pair=False):
@@ -231,9 +231,9 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
             int: Number of tokens added to sequences.
         """
         if pair is True:
-            return self.summary_num + 2
+            return self.cls_num + 2
         else:
-            return self.summary_num + 1
+            return self.cls_num + 1
 
     def _tokenize(self, text, **kwargs):
         r"""


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
Models

### Description
change the position encoding in the ernie-ctm

在ernie-ctm的模型中使用了双CLS的结构，在之前的模型结构中0号和1号位的CLS的position分别是0，1，在新版的模型中使用了两个CLS的pos都是0，来增加模型效果
