### PR TITLE
Fix the bug when batch size of crf input equal to 1.

### DIFF
--- a/paddlenlp/layers/crf.py
+++ b/paddlenlp/layers/crf.py
@@ -145,7 +145,7 @@ class LinearChainCrf(nn.Layer):
         if self.with_start_stop_tag:
             # The last one step
             alpha += self.transitions[self.stop_idx].unsqueeze(0)
-        norm_score = log_sum_exp(alpha, 1).squeeze(-1)
+        norm_score = log_sum_exp(alpha, 1)  #.squeeze(-1)
         return norm_score
 
     def gold_score(self, inputs, labels, lengths):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->

Remove squeeze to avoid changing 1D-tensor to scalar

Tested in ErnieCtmModel, waybill, lac. 