### PR TITLE
Optimize FasterTransformer using fp16

### DIFF
--- a/paddlenlp/ops/faster_transformer/src/fusion_decoding_op.cu
+++ b/paddlenlp/ops/faster_transformer/src/fusion_decoding_op.cu
@@ -112,8 +112,14 @@ std::vector<paddle::Tensor> decoding_kernel(
   decoding_params.stream = stream;
   fastertransformer::Allocator<AllocatorType::PD> allocator_(stream);
 
+  paddle::Tensor input_D = paddle::Tensor(paddle::PlaceType::kGPU);
+  if (input.type() != D) {
+    input_D = input.cast(D);
+  } else {
+    input_D = input;
+  }
   decoding_params.memory_tensor =
-      reinterpret_cast<const DataType_*>(input.data<data_t_>());
+      reinterpret_cast<const DataType_*>(input_D.data<data_t_>());
   decoding_params.memory_sequence_length = memory_sequence_length.data<int>();
 
   DecoderInitParam<DataType_>* params =

--- a/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
+++ b/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
@@ -120,9 +120,6 @@ class FasterTransformer(TransformerModel):
             training=False) if self.dropout else src_emb
         enc_output = self.transformer.encoder(enc_input, src_slf_attn_bias)
 
-        if self.use_fp16_decoding:
-            enc_output = paddle.cast(enc_output, dtype="float16")
-
         mem_seq_lens = paddle.sum(paddle.cast(
             src_word != self.bos_id, dtype="int32"),
                                   axis=1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
【此 PR 暂不合入，因框架修复仅在 develop，直接到 2.2rc，不会进入 2.1】
方案一：
如，此 PR 修改：
Optimize FasterTransformer using fp16. 
| batch_size = 1 & beam size = 1 | ms/batch |
| -- | -- |
| before this PR | 41.9541 |
| after this PR | 34.3388 |

方案二：
修改 FasterTransformer 代码
![image](https://user-images.githubusercontent.com/7160927/128023588-3fca25c2-2af5-4fd3-b32d-66490556f1bf.png)
修改以上 gemm 传入数据的 type，直接修改为 `CUDA_R_32F`。
问题是：
修改、新增的 patch 文件比较多，涉及 `open_decoder.h/.cu`，`decoding_beamsearch.h`，`decoding_sampling.h`
