### PR TITLE
[Bugfix] Fix ci breaking for paddle2.1.2

### DIFF
--- a/examples/simultaneous_translation/stacl/train.py
+++ b/examples/simultaneous_translation/stacl/train.py
@@ -118,11 +118,8 @@ def do_train(args):
         batch_id = 0
         batch_start = time.time()
         for input_data in train_loader:
-            if args.max_iter and step_idx == args.max_iter:
-                return
             train_reader_cost = time.time() - batch_start
             (src_word, trg_word, lbl_word) = input_data
-
             if args.use_amp:
                 scaler = paddle.amp.GradScaler(
                     init_loss_scaling=args.scale_loss)
@@ -143,6 +140,9 @@ def do_train(args):
 
                 optimizer.step()
                 optimizer.clear_grad()
+
+            if args.max_iter and step_idx == args.max_iter:
+                return
 
             tokens_per_cards = token_num.numpy()
 

--- a/examples/simultaneous_translation/stacl/train.py
+++ b/examples/simultaneous_translation/stacl/train.py
@@ -141,7 +141,7 @@ def do_train(args):
                 optimizer.step()
                 optimizer.clear_grad()
 
-            if args.max_iter and step_idx == args.max_iter:
+            if args.max_iter and step_idx + 1 == args.max_iter:
                 return
 
             tokens_per_cards = token_num.numpy()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- Fix ci breaking due to max_iter on PaddlePaddle 2.1.2
- All tests pass: waitk=-1/1/3/5/7
