### PR TITLE
Fix breaking changes of paddle.sum

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
+++ b/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
@@ -125,6 +125,7 @@ class FasterTransformer(TransformerModel):
 
         mem_seq_lens = paddle.sum(paddle.cast(
             src_word != self.bos_id, dtype="int32"),
+                                  dtype="int32",
                                   axis=1)
         ids = self.decoding(enc_output, mem_seq_lens)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
因 develop 升级，使 `paddle.sum` 对齐 numpy 和 pytorch 行为，在输入类型是 `[bool, int32, int64]` 且未指明 `dtype` 的时候，输出的类型会被默认设置成 `int64`，是一个不兼容升级，导致 FasterTransformer 这边调用报错。
之前的行为是，如果没有指明 `dtype`，输出的类型将与输入的类型一致。
相关 PR：[PaddlePaddle #34313](https://github.com/PaddlePaddle/Paddle/pull/34313)