### PR TITLE
Fix text_classification examples multi_label.

### DIFF
--- a/examples/text_classification/multi_label/data.py
+++ b/examples/text_classification/multi_label/data.py
@@ -16,7 +16,7 @@ import re
 import numpy as np
 import pandas as pd
 import paddle
-from paddlenlp.datasets import load_dataset
+
 
 def convert_example(example, tokenizer, max_seq_length=512, is_test=False):
     """
@@ -59,6 +59,7 @@ def convert_example(example, tokenizer, max_seq_length=512, is_test=False):
         return input_ids, token_type_ids, label
     return input_ids, token_type_ids
 
+
 def create_dataloader(dataset,
                       mode='train',
                       batch_size=1,
@@ -81,6 +82,7 @@ def create_dataloader(dataset,
         collate_fn=batchify_fn,
         return_list=True)
 
+
 def read_custom_data(filename, is_test=False):
     """Reads data."""
     data = pd.read_csv(filename)
@@ -90,12 +92,14 @@ def read_custom_data(filename, is_test=False):
             yield {"text": clean_text(text), "label": ""}
         else:
             text, label = line[1], line[2:]
-            yield {"text": clean_text(text), "label": label}     
+            yield {"text": clean_text(text), "label": label}
+
 
 def clean_text(text):
     text = text.replace("\r", "").replace("\n", "")
     text = re.sub(r"\\n\n", ".", text)
     return text
+
 
 def write_test_results(filename, results, label_info):
     """write test results"""

--- a/examples/text_classification/multi_label/deploy/python/predict.py
+++ b/examples/text_classification/multi_label/deploy/python/predict.py
@@ -14,10 +14,8 @@
 
 import argparse
 
-import numpy as np
 import paddle
 import paddle.nn.functional as F
-from paddle import inference
 from paddlenlp.data import Tuple, Pad
 from paddlenlp.transformers import BertTokenizer
 
@@ -27,7 +25,6 @@ from data import convert_example
 parser = argparse.ArgumentParser()
 parser.add_argument("--model_file", type=str, required=True, default='./static_graph_params.pdmodel', help="The path to model info in static graph.")
 parser.add_argument("--params_file", type=str, required=True, default='./static_graph_params.pdiparams', help="The path to parameters in static graph.")
-
 parser.add_argument("--max_seq_length", default=128, type=int, help="The maximum total input sequence length after tokenization. "
     "Sequences longer than this will be truncated, sequences shorter will be padded.")
 parser.add_argument("--threshold", default=0.5, type=float, help="The threshold for converting probabilities to labels")
@@ -35,6 +32,7 @@ parser.add_argument("--batch_size", default=2, type=int, help="Batch size per GP
 parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
 args = parser.parse_args()
 # yapf: enable
+
 
 class Predictor(object):
     def __init__(self, model_file, params_file, device, max_seq_length):
@@ -131,4 +129,3 @@ if __name__ == "__main__":
         print('Data: \t {}'.format(text))
         for i, k in enumerate(label_info):
             print('{}: \t {}'.format(k, results[idx][i]))
-

--- a/examples/text_classification/multi_label/export_model.py
+++ b/examples/text_classification/multi_label/export_model.py
@@ -14,14 +14,9 @@
 
 import argparse
 import os
-from functools import partial
 
-import numpy as np
 import paddle
-import paddle.nn.functional as F
 import paddlenlp as ppnlp
-from paddlenlp.transformers import BertTokenizer
-from paddlenlp.data import Stack, Tuple, Pad
 
 from model import MultiLabelClassifier
 

--- a/examples/text_classification/multi_label/metric.py
+++ b/examples/text_classification/multi_label/metric.py
@@ -15,14 +15,13 @@
 import numpy as np
 from sklearn.metrics import roc_auc_score, f1_score
 
-import paddle
 from paddle.metric import Metric
+
 
 class MultiLabelReport(Metric):
     """
     AUC and F1Score for multi-label text classification task.
     """
-
     def __init__(self, name='MultiLabelReport', average='micro'):
         super(MultiLabelReport, self).__init__()
         self.average = average

--- a/examples/text_classification/multi_label/predict.py
+++ b/examples/text_classification/multi_label/predict.py
@@ -27,14 +27,15 @@ from model import MultiLabelClassifier
 
 # yapf: disable
 parser = argparse.ArgumentParser()
-parser.add_argument("--params_path", type=str, required=True, help="The path to model parameters to be loaded.")
-parser.add_argument("--max_seq_length", default=128, type=int, help="The maximum total input sequence length after tokenization. "
+parser.add_argument("--params_path", type=str, required=True, default='./checkpoint/model_800/model_state.pdparams', help="The path to model parameters to be loaded.")
+parser.add_argument("--max_seq_length", type=int, default=128, help="The maximum total input sequence length after tokenization. "
     "Sequences longer than this will be truncated, sequences shorter will be padded.")
-parser.add_argument("--batch_size", default=32, type=int, help="Batch size per GPU/CPU for training.")
+parser.add_argument("--batch_size", type=int, default=32, help="Batch size per GPU/CPU for training.")
 parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
 parser.add_argument("--data_path", type=str, default="./data", help="The path of datasets to be loaded")
 args = parser.parse_args()
 # yapf: enable
+
 
 def predict(model, data_loader, batch_size=1):
     """
@@ -102,7 +103,7 @@ if __name__ == "__main__":
         print("Loaded parameters from %s" % args.params_path)
 
     results = predict(model, test_data_loader, args.batch_size)
-    filename = os.path.join(args.data_path, dataset_name)
+    filename = os.path.join(args.data_path, file_name)
 
     # Write test result into csv file
     write_test_results(filename, results, label_info)

--- a/examples/text_classification/multi_label/train.py
+++ b/examples/text_classification/multi_label/train.py
@@ -48,11 +48,13 @@ parser.add_argument("--data_path", type=str, default="./data", help="The path of
 args = parser.parse_args()
 # yapf: enable
 
+
 def set_seed(seed):
     """sets random seed"""
     random.seed(seed)
     np.random.seed(seed)
     paddle.seed(seed)
+
 
 @paddle.no_grad()
 def evaluate(model, criterion, metric, data_loader):
@@ -80,6 +82,7 @@ def evaluate(model, criterion, metric, data_loader):
     model.train()
     metric.reset()
 
+
 def do_train():
     paddle.set_device(args.device)
     rank = paddle.distributed.get_rank()
@@ -93,12 +96,7 @@ def do_train():
     train_ds = load_dataset(read_custom_data, filename=os.path.join(
         args.data_path, file_name), is_test=False, lazy=False)
 
-    # If you wanna use ernie pretrained model,
-    # pretrained_model = ppnlp.transformers.ErnieModel.from_pretrained("ernie-2.0-en")
     pretrained_model = ppnlp.transformers.BertModel.from_pretrained("bert-base-uncased")
-
-    # If you wanna use ernie pretrained model,
-    # tokenizer = ppnlp.transformers.ErnieTokenizer.from_pretrained("ernie-2.0-en")
     tokenizer = ppnlp.transformers.BertTokenizer.from_pretrained('bert-base-uncased')
 
     trans_func = partial(
@@ -134,7 +132,7 @@ def do_train():
         p.name for n, p in model.named_parameters()
         if not any(nd in n for nd in ["bias", "norm"])
     ]
-    
+
     optimizer = paddle.optimizer.AdamW(
         learning_rate=lr_scheduler,
         parameters=model.parameters(),
@@ -173,6 +171,7 @@ def do_train():
                 save_param_path = os.path.join(save_dir, "model_state.pdparams")
                 paddle.save(model.state_dict(), save_param_path)
                 tokenizer.save_pretrained(save_dir)
+
 
 if __name__ == "__main__":
     do_train()

--- a/examples/text_classification/rnn/train.py
+++ b/examples/text_classification/rnn/train.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     # Loads dataset.
     train_ds, dev_ds = load_dataset("chnsenticorp", splits=["train", "dev"])
 
-    # Constructs the newtork.
+    # Constructs the network.
     network = args.network.lower()
     vocab_size = len(vocab)
     num_classes = len(train_ds.label_list)


### PR DESCRIPTION
1. code fix: dataset_name -> file_name in predict.py
2. add default value for params_path in predict.py
3. remove misleading comments in train.py: we have no demo for ernie in the multi_label example.
4. remove unused imports.
5. run yapf formatter on touch files.
