### PR TITLE
Update clue dataset, and remove useless argment for run_clue

### DIFF
--- a/examples/model_compression/minilmv2/run_clue.py
+++ b/examples/model_compression/minilmv2/run_clue.py
@@ -83,13 +83,6 @@ def parse_args():
                 for classes in MODEL_CLASSES.values()
             ], [])), )
     parser.add_argument(
-        "--output_dir",
-        default=None,
-        type=str,
-        required=True,
-        help="The output directory where the model predictions and checkpoints will be written.",
-    )
-    parser.add_argument(
         "--max_seq_length",
         default=128,
         type=int,

--- a/paddlenlp/datasets/clue.py
+++ b/paddlenlp/datasets/clue.py
@@ -193,7 +193,7 @@ class Clue(DatasetBuilder):
         'cluewsc2020': {
             'url':
             'https://storage.googleapis.com/cluebenchmark/tasks/cluewsc2020_public.zip',
-            'md5': '17abe1be3f7dd3bad5f114ba4c40ee9b',
+            'md5': '2e387e20e93eeab0ffaded5b0d2dfd3d',
             'splits': {
                 'train': [
                     os.path.join('cluewsc2020_public', 'train.json'),
@@ -204,6 +204,10 @@ class Clue(DatasetBuilder):
                     'bad8cd6fa0916fc37ac96b8ce316714a',
                 ],
                 'test': [
+                    os.path.join('cluewsc2020_public', 'test.json'),
+                    '27614454cc26be6fcab5bbd9a45967ff',
+                ],
+                'test1.0': [
                     os.path.join('cluewsc2020_public', 'test.json'),
                     '0e9e8ffd8ee90ddf1f58d6dc2e02de7b',
                 ]


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models && APIs
### Description
<!-- Describe what this PR does -->

1.更新clue CLUEWSC2020测试集
  - 原有测试集更名为test1.0.json，新的测试集命名为test.json（具体版本为1.1）
  - 2021年8月29日之后，新提交的测试集，需在新的测试集(test.json)上做预测并提交。其中提交的文件命名没有变化，还是wsc_predict.json。


2. 移除`run_clue.py`中多余的参数 `output_dir`