### PR TITLE
Fix bug on windows, default convert labels to int64.

### DIFF
--- a/examples/language_model/gpt/dataset.py
+++ b/examples/language_model/gpt/dataset.py
@@ -363,6 +363,7 @@ class GPTDataset(paddle.io.Dataset):
 
         attention_mask = (attention_mask - 1.0) * 1e9
         attention_mask = attention_mask.astype("float32")
+        labels = np.array(labels, dtype="int64")
         return [tokens, loss_mask, attention_mask, position_ids, labels]
 
     def _get_single_sample_from_idx(self, doc_index_f, doc_index_l, offset_f,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix bug on windows, default convert labels to int64.