### PR TITLE
fix ernie-ctm tokenizer bug

### DIFF
--- a/paddlenlp/transformers/ernie_ctm/tokenizer.py
+++ b/paddlenlp/transformers/ernie_ctm/tokenizer.py
@@ -263,4 +263,4 @@ class ErnieCtmTokenizer(PretrainedTokenizer):
         Returns:
             List(str): A list of string representing converted tokens.
         """
-        return self._tokenize(text, kwargs)
+        return self._tokenize(text, **kwargs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
fix the tokenize method of ernie-ctm tokenizer

Before:
![image](https://user-images.githubusercontent.com/10826371/132617144-752b8595-8cf8-428a-8e2a-984eeca08da5.png)

Now:
![image](https://user-images.githubusercontent.com/10826371/132617151-01fce8ab-fa16-429e-908d-b4ea0f969d49.png)
