### PR TITLE
[BUGFIX] Change RELU to GELU for FT GPT

### DIFF
--- a/paddlenlp/ops/patches/FasterTransformer/open_decoder.h
+++ b/paddlenlp/ops/patches/FasterTransformer/open_decoder.h
@@ -96,7 +96,8 @@ public:
               int size_per_head,
               int memory_hidden_units,
               bool normalization_before = true,
-              ActivationType act = ActivationType::RELU)
+              ActivationType act = ActivationType::GELU)
+      // Activation function default to GELU for GPT.
       : batch_size_(batch_size),
         max_seq_len_(seq_len),
         head_num_(head_num),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- Change FasterTransformer default activation function from RELU to GELU. All tests(including `Transformer Decoding`/`Transformer Decoder`/`BART`/`GPT`) passed. 