### PR TITLE
[BUGFIX] Fix mem_seq_lens dtype

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/decoder.py
+++ b/paddlenlp/ops/faster_transformer/transformer/decoder.py
@@ -374,7 +374,8 @@ class FasterDecoder(nn.Layer):
         mem_seq_lens = paddle.sum(paddle.cast(
             src_word != self.bos_id, dtype="int32"),
                                   axis=-1,
-                                  keepdim=True)
+                                  keepdim=True,
+                                  dtype="int32")
 
         src_slf_attn_bias = paddle.cast(
             src_word == self.bos_id,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- Fix mem_seq_lens dtype for paddlepaddle develop
- paddlepaddle develop forces to convert dtype `int32` to `int64`