### PR TITLE
[FasterTransformer] Fix compiling error by use abs path

### DIFF
--- a/paddlenlp/ops/CMakeLists.txt
+++ b/paddlenlp/ops/CMakeLists.txt
@@ -305,11 +305,11 @@ if(ON_INFER AND WITH_GPT AND WITH_SP)
   )
   
   include_directories(
-    ${THIRD_PATH}/source/sentencepiece/src/
+    ${CMAKE_BINARY_DIR}/${THIRD_PATH}/source/sentencepiece/src/
   )
 
   link_directories(
-    ${THIRD_PATH}/build/sentencepiece/src/
+    ${CMAKE_BINARY_DIR}/${THIRD_PATH}/build/sentencepiece/src/
   )
 
   add_definitions(-DGPT_ON_SENTENCEPIECE)

--- a/paddlenlp/ops/faster_transformer/src/CMakeLists.txt
+++ b/paddlenlp/ops/faster_transformer/src/CMakeLists.txt
@@ -161,6 +161,7 @@ if(ON_INFER)
 
   if(WITH_GPT AND WITH_SP)
     set(DEPS ${DEPS} sentencepiece)
+    add_dependencies(decoding_infer_op extern_sentencepiece)
   endif()
 
   if(WIN32)

--- a/paddlenlp/ops/faster_transformer/src/CMakeLists.txt
+++ b/paddlenlp/ops/faster_transformer/src/CMakeLists.txt
@@ -146,7 +146,7 @@ if(ON_INFER)
   endif(NOT WIN32)
 
   cuda_add_library(decoding_infer_op ${decoding_op_files} ${decoder_op_files} SHARED)
-  add_dependencies(decoding_infer_op extern_${THIRD_PARTY_NAME})
+  add_dependencies(decoding_infer_op extern_${THIRD_PARTY_NAME} boost)
 
   string(REPLACE "/" ";" DEMO_PATH ${DEMO})
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Fix compiling error by using abs path. In some env, relative path cannot work correctly. 