### PR TITLE
[PaddlePaddle Hackathon] 第55题

### DIFF
--- a/paddlenlp/transformers/roberta/convert_roberta_params.py
+++ b/paddlenlp/transformers/roberta/convert_roberta_params.py
@@ -1,0 +1,72 @@
+import paddle
+import torch
+import numpy as np
+from paddle.utils.download import get_path_from_url
+
+model_names = [
+    'roberta-large', 'roberta-base', 'deepset/roberta-base-squad2',
+    'uer/roberta-base-finetuned-chinanews-chinese',
+    'sshleifer/tiny-distilroberta-base',
+    'uer/roberta-base-finetuned-cluener2020-chinese',
+    'uer/roberta-base-chinese-extractive-qa'
+]
+
+for model_name in model_names:
+    torch_model_url = "https://huggingface.co/%s/resolve/main/pytorch_model.bin" % model_name
+    torch_model_path = get_path_from_url(torch_model_url, '.')
+    torch_state_dict = torch.load(torch_model_path)
+
+    paddle_model_path = "%s.pdparams" % model_name
+    paddle_state_dict = {}
+
+    # State_dict's keys mapping: from torch to paddle
+    keys_dict = {
+        # about embeddings
+        "embeddings.LayerNorm.gamma": "embeddings.layer_norm.weight",
+        "embeddings.LayerNorm.beta": "embeddings.layer_norm.bias",
+
+        # about encoder layer
+        'encoder.layer': 'encoder.layers',
+        'attention.self.query': 'self_attn.q_proj',
+        'attention.self.key': 'self_attn.k_proj',
+        'attention.self.value': 'self_attn.v_proj',
+        'attention.output.dense': 'self_attn.out_proj',
+        'attention.output.LayerNorm.gamma': 'norm1.weight',
+        'attention.output.LayerNorm.beta': 'norm1.bias',
+        'intermediate.dense': 'linear1',
+        'output.dense': 'linear2',
+        'output.LayerNorm.gamma': 'norm2.weight',
+        'output.LayerNorm.beta': 'norm2.bias',
+
+        # about cls predictions
+        'cls.predictions.transform.dense': 'cls.predictions.transform',
+        'cls.predictions.decoder.weight': 'cls.predictions.decoder_weight',
+        'cls.predictions.transform.LayerNorm.gamma':
+        'cls.predictions.layer_norm.weight',
+        'cls.predictions.transform.LayerNorm.beta':
+        'cls.predictions.layer_norm.bias',
+        'cls.predictions.bias': 'cls.predictions.decoder_bias'
+    }
+
+    for torch_key in torch_state_dict:
+        paddle_key = torch_key
+        for k in keys_dict:
+            if k in paddle_key:
+                paddle_key = paddle_key.replace(k, keys_dict[k])
+
+        if ('linear' in paddle_key) or ('proj' in paddle_key) or (
+                'vocab' in paddle_key and 'weight' in paddle_key) or (
+                    "dense.weight" in paddle_key) or (
+                        'transform.weight' in paddle_key) or (
+                            'seq_relationship.weight' in paddle_key):
+            paddle_state_dict[paddle_key] = paddle.to_tensor(torch_state_dict[
+                torch_key].cpu().numpy().transpose())
+        else:
+            paddle_state_dict[paddle_key] = paddle.to_tensor(torch_state_dict[
+                torch_key].cpu().numpy())
+
+        print("torch: ", torch_key, "\t", torch_state_dict[torch_key].shape)
+        print("paddle: ", paddle_key, "\t", paddle_state_dict[paddle_key].shape,
+              "\n")
+
+    paddle.save(paddle_state_dict, paddle_model_path)

--- a/paddlenlp/transformers/roberta/modeling.py
+++ b/paddlenlp/transformers/roberta/modeling.py
@@ -12,18 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import paddle
 import paddle.nn as nn
+import paddle.nn.functional as F
 
 from .. import PretrainedModel, register_base_model
 
 __all__ = [
-    'RobertaModel',
-    'RobertaPretrainedModel',
-    'RobertaForSequenceClassification',
-    'RobertaForTokenClassification',
-    'RobertaForQuestionAnswering',
+    'RobertaModel', 'RobertaPretrainedModel',
+    'RobertaForSequenceClassification', 'RobertaForTokenClassification',
+    'RobertaForQuestionAnswering', 'RobertaForMultipleChoice',
+    'RobertaForMaskedLM', 'RobertaForCausalLM'
 ]
+
+
+def mish(x):
+    return x * F.tanh(F.softplus(x))
+
+
+def linear_act(x):
+    return x
+
+
+def swish(x):
+    return x * F.sigmoid(x)
+
+
+def gelu_new(x):
+    """
+    Implementation of the GELU activation function currently in Google BERT repo (identical to OpenAI GPT). Also see
+    the Gaussian Error Linear Units paper: https://arxiv.org/abs/1606.08415
+    """
+    return 0.5 * x * (1.0 + paddle.tanh(
+        math.sqrt(2.0 / math.pi) * (x + 0.044715 * paddle.pow(x, 3.0))))
+
+
+ACT2FN = {
+    "relu": F.relu,
+    "gelu": F.gelu,
+    "gelu_new": gelu_new,
+    "tanh": F.tanh,
+    "sigmoid": F.sigmoid,
+    "mish": mish,
+    "linear": linear_act,
+    "swish": swish,
+}
 
 
 class RobertaEmbeddings(nn.Layer):
@@ -150,6 +185,104 @@ class RobertaPretrainedModel(PretrainedModel):
             "vocab_size": 21128,
             "pad_token_id": 0
         },
+        "roberta-base": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 768,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 514,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 50265,
+            "pad_token_id": 1
+        },
+        "roberta-large": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 1024,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 514,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 50265,
+            "pad_token_id": 1
+        },
+        "roberta-base-squad2": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 768,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 514,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 50265,
+            "pad_token_id": 1
+        },
+        "roberta-base-finetuned-chinanews-chinese": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 768,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 512,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 21128,
+            "pad_token_id": 0
+        },
+        "tiny-distilroberta-base": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 2,
+            "initializer_range": 0.02,
+            "intermediate_size": 2,
+            "max_position_embeddings": 514,
+            "num_attention_heads": 2,
+            "num_hidden_layers": 2,
+            "type_vocab_size": 1,
+            "vocab_size": 50265,
+            "pad_token_id": 1
+        },
+        "roberta-base-finetuned-cluener2020-chinese": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 768,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 512,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 21128,
+            "pad_token_id": 0
+        },
+        "roberta-base-chinese-extractive-qa": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "gelu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 768,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,
+            "max_position_embeddings": 512,
+            "num_attention_heads": 12,
+            "num_hidden_layers": 12,
+            "type_vocab_size": 1,
+            "vocab_size": 21128,
+            "pad_token_id": 0
+        }
     }
     resource_files_names = {"model_state": "model_state.pdparams"}
     pretrained_resource_files_map = {
@@ -162,6 +295,17 @@ class RobertaPretrainedModel(PretrainedModel):
             "https://paddlenlp.bj.bcebos.com/models/transformers/rbt3/rbt3_chn_large.pdparams",
             "rbtl3":
             "https://paddlenlp.bj.bcebos.com/models/transformers/rbtl3/rbtl3_chn_large.pdparams",
+            "roberta-base": "roberta-base.pdparams",  # 从百度网盘下载
+            "roberta-large": "roberta-large.pdparams",  # 从百度网盘下载
+            "roberta-base-squad2": "roberta-base-squad2.pdparams",  # 从百度网盘下载
+            "roberta-base-finetuned-chinanews-chinese":
+            "roberta-base-finetuned-chinanews-chinese.pdparams",  # 从百度网盘下载
+            "tiny-distilroberta-base":
+            "tiny-distilroberta-base.pdparams",  # 从百度网盘下载
+            "roberta-base-finetuned-cluener2020-chinese":
+            "roberta-base-finetuned-cluener2020-chinese.pdparams",  # 从百度网盘下载
+            "roberta-base-chinese-extractive-qa":
+            "roberta-base-chinese-extractive-qa.pdparams",  # 从百度网盘下载
         }
     }
     base_model_prefix = "roberta"
@@ -616,3 +760,234 @@ class RobertaForTokenClassification(RobertaPretrainedModel):
         sequence_output = self.dropout(sequence_output)
         logits = self.classifier(sequence_output)
         return logits
+
+
+class RobertaForMultipleChoice(RobertaPretrainedModel):
+    """
+    Roberta Model with a token classification head on top (a linear layer on top of the hidden-states output) e.g.
+    for Named-Entity-Recognition (NER) tasks.
+    Args:
+        roberta (:class:`RobertaModel`):
+            An instance of RobertaModel.
+        num_choices (int, optional):
+            The number of choices. Defaults to `2`.
+        dropout (float, optional):
+            The dropout probability for output of ROBERTA.
+            If None, use the same value as `hidden_dropout_prob` of `RobertaModel`
+            instance `roberta`. Defaults to None.
+    """
+
+    def __init__(self, roberta, num_choices=2, dropout=None):
+        super(RobertaForMultipleChoice, self).__init__()
+        self.roberta = roberta  # allow roberta to be config
+        self.num_choices = num_choices
+        self.dropout = nn.Dropout(dropout if dropout is not None else
+                                  self.roberta.config["hidden_dropout_prob"])
+        self.classifier = nn.Linear(self.roberta.config["hidden_size"], 1)
+        self.apply(self.init_weights)
+
+    def forward(self, input_ids, position_ids=None, attention_mask=None):
+        r"""
+        The RobertaForMultipleChoice forward method, overrides the __call__() special method.
+        Args:
+            input_ids (Tensor):
+                See :class:`RobertaModel` and shape as [batch_size, num_choice, sequence_length].
+            position_ids(Tensor, optional):
+                See :class:`RobertaModel` and shape as [batch_size, num_choice, sequence_length].
+            attention_mask (list, optional):
+                See :class:`RobertaModel` and shape as [batch_size, num_choice, sequence_length].
+
+        Returns:
+            Tensor: Returns tensor `reshaped_logits`, a tensor of the multiple choice classification logits.
+            Shape as `[batch_size, num_choice]` and dtype as float32.
+        Example:
+            .. code-block::
+                import paddle
+                from paddlenlp.transformers import RobertaForMultipleChoice, RobertaTokenizer
+
+                tokenizer = RobertaTokenizer.from_pretrained('roberta-base-uncased')
+                model = RobertaForTokenClassification.from_pretrained('roberta-base-uncased')
+
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
+
+                outputs = model(**inputs)
+        """
+        # input_ids: [bs, num_choice, seq_l]
+        input_ids = input_ids.reshape(shape=(
+            -1, input_ids.shape[-1]))  # flat_input_ids: [bs*num_choice,seq_l]
+
+        if position_ids is not None:
+            position_ids = position_ids.reshape(shape=(-1,
+                                                       position_ids.shape[-1]))
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.reshape(
+                shape=(-1, attention_mask.shape[-1]))
+
+        _, pooled_output = self.roberta(
+            input_ids, position_ids=position_ids, attention_mask=attention_mask)
+
+        pooled_output = self.dropout(pooled_output)
+
+        logits = self.classifier(pooled_output)  # logits: (bs*num_choice,1)
+        reshaped_logits = logits.reshape(
+            shape=(-1, self.num_choices))  # logits: (bs, num_choice)
+
+        return reshaped_logits
+
+
+class RobertaLMHead(nn.Layer):
+    """
+    Roberta Model with a `language modeling` head on top.
+    """
+
+    def __init__(self,
+                 hidden_size,
+                 vocab_size,
+                 activation="gelu",
+                 embedding_weights=None):
+        super(RobertaLMHead, self).__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size)
+        self.activation = ACT2FN[activation]
+        self.layer_norm = nn.LayerNorm(hidden_size)
+
+        self.decoder_weight = embedding_weights
+        self.decoder_bias = self.create_parameter(
+            shape=[vocab_size], dtype=self.decoder_weight.dtype, is_bias=True)
+
+    def forward(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        hidden_states = self.layer_norm(hidden_states)
+
+        hidden_states = (paddle.matmul(
+            hidden_states, self.decoder_weight, transpose_y=True) +
+                         self.decoder_bias)
+
+        return hidden_states
+
+
+class RobertaForMaskedLM(RobertaPretrainedModel):
+    """
+    Roberta Model with pretraining tasks on top.
+    Args:
+        Roberta (:class:`RobertaModel`):
+            An instance of :class:`RobertaModel`.
+    """
+
+    def __init__(self, roberta):
+        super(RobertaForMaskedLM, self).__init__()
+        self.roberta = roberta
+        self.lm_head = RobertaLMHead(
+            self.roberta.config["hidden_size"],
+            self.roberta.config["vocab_size"],
+            self.roberta.config["hidden_act"],
+            self.roberta.embeddings.word_embeddings.weight)
+
+        self.apply(self.init_weights)
+
+    def forward(self,
+                input_ids,
+                position_ids=None,
+                attention_mask=None,
+                labels=None):
+        r"""
+        Args:
+            input_ids (Tensor):
+                See :class:`RobertaModel`.
+            position_ids(Tensor, optional):
+                See :class:`RobertaModel`.
+            attention_mask (list, optional):
+                See :class:`RobertaModel`.
+            labels (Tensor, optional):
+                The Labels for computing the masked language modeling loss. Indices should be in ``[-100, 0, ..., vocab_size]`` Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels in ``[0, ..., vocab_size]`` Its shape is [batch_size, sequence_length].
+        Returns:
+            tuple: Returns tuple (`masked_lm_loss`, `prediction_scores`, ``sequence_output`).
+            With the fields:
+            - `masked_lm_loss` (Tensor):
+                The masked lm loss. Its data type should be float32 and its shape is [1].
+            - `prediction_scores` (Tensor):
+                The scores of masked token prediction. Its data type should be float32. Its shape is [batch_size, sequence_length, vocab_size].
+            - `sequence_output` (Tensor):
+                Sequence of hidden-states at the last layer of the model. Its data type should be float32. Its shape is `[batch_size, sequence_length, hidden_size]`.
+        """
+        sequence_output, _ = self.roberta(
+            input_ids, position_ids=position_ids, attention_mask=attention_mask)
+        prediction_scores = self.lm_head(sequence_output)
+
+        masked_lm_loss = None
+
+        if labels is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            masked_lm_loss = loss_fct(
+                prediction_scores.reshape(shape=(
+                    -1, self.roberta.config["vocab_size"])),
+                labels.reshape(shape=(-1, )), )
+            return masked_lm_loss, prediction_scores, sequence_output
+
+        return prediction_scores, sequence_output
+
+
+class RobertaForCausalLM(RobertaPretrainedModel):
+    """
+    Roberta Model for casual language model task.
+    Args:
+        Roberta (:class:`RobertaModel`):
+            An instance of :class:`RobertaModel`.
+    """
+
+    def __init__(self, roberta):
+        super(RobertaForCausalLM, self).__init__()
+        self.roberta = roberta
+        self.lm_head = RobertaLMHead(
+            self.roberta.config["hidden_size"],
+            self.roberta.config["vocab_size"],
+            self.roberta.config["hidden_act"],
+            self.roberta.embeddings.word_embeddings.weight)
+
+        self.apply(self.init_weights)
+
+    def forward(self,
+                input_ids,
+                position_ids=None,
+                attention_mask=None,
+                labels=None):
+        r"""
+        Args:
+            input_ids (Tensor):
+                See :class:`RobertaModel`.
+            position_ids(Tensor, optional):
+                See :class:`RobertaModel`.
+            attention_mask (list, optional):
+                See :class:`RobertaModel`.
+            labels (Tensor, optional):
+                The Labels for computing the masked language modeling loss. Indices should be in ``[-100, 0, ..., vocab_size]`` Tokens with indices set to ``-100`` are ignored (masked), the loss is only computed for the tokens with labels in ``[0, ..., vocab_size]`` Its shape is [batch_size, sequence_length].
+        Returns:
+            tuple: Returns tuple (`masked_lm_loss`, `prediction_scores`, ``sequence_output`).
+            With the fields:
+            - `masked_lm_loss` (Tensor):
+                The masked lm loss. Its data type should be float32 and its shape is [1].
+            - `prediction_scores` (Tensor):
+                The scores of masked token prediction. Its data type should be float32. Its shape is [batch_size, sequence_length, vocab_size].
+            - `sequence_output` (Tensor):
+                Sequence of hidden-states at the last layer of the model. Its data type should be float32. Its shape is `[batch_size, sequence_length, hidden_size]`.
+        """
+        sequence_output, _ = self.roberta(
+            input_ids, position_ids=position_ids, attention_mask=attention_mask)
+        prediction_scores = self.lm_head(sequence_output)
+
+        lm_loss = None
+        if labels is not None:
+            # we are doing next-token prediction; shift prediction scores and input ids by one
+            shifted_prediction_scores = prediction_scores[:, :-1, :]
+            labels = labels[:, 1:]
+            loss_fct = nn.CrossEntropyLoss()
+            lm_loss = loss_fct(
+                paddle.reshape(shifted_prediction_scores,
+                               [-1, self.roberta.config['vocab_size']]),
+                paddle.reshape(labels, [-1]))
+
+            return lm_loss, prediction_scores, sequence_output
+
+        return prediction_scores, sequence_output

--- a/tests/transformers/roberta/test_modeling.py
+++ b/tests/transformers/roberta/test_modeling.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import os
+import unittest
+import paddle
+import copy
+
+from paddlenlp.transformers import RobertaModel, RobertaForQuestionAnswering, \
+    RobertaForSequenceClassification, RobertaForTokenClassification, \
+    RobertaForMultipleChoice, RobertaForMaskedLM, RobertaForCausalLM
+
+from common_test import CommonTest
+from util import softmax_with_cross_entropy, slow
+import unittest
+
+
+def create_input_data(config, seed=None):
+    '''
+    the generated input data will be same if a specified seed is set 
+    '''
+    if seed is not None:
+        np.random.seed(seed)
+
+    input_ids = np.random.randint(
+        low=0,
+        high=config['vocab_size'],
+        size=(config["batch_size"], config["seq_len"]))
+    num_to_predict = int(config["seq_len"] * 0.15)
+    masked_lm_positions = np.random.choice(
+        config["seq_len"], (config["batch_size"], num_to_predict),
+        replace=False)
+    masked_lm_positions = np.sort(masked_lm_positions)
+    pred_padding_len = config["seq_len"] - num_to_predict
+    temp_masked_lm_positions = np.full(
+        masked_lm_positions.size, 0, dtype=np.int32)
+    mask_token_num = 0
+    for i, x in enumerate(masked_lm_positions):
+        for j, pos in enumerate(x):
+            temp_masked_lm_positions[mask_token_num] = i * config[
+                "seq_len"] + pos
+            mask_token_num += 1
+    masked_lm_positions = temp_masked_lm_positions
+    return input_ids, masked_lm_positions
+
+
+class NpRobertaPretrainingCriterion(object):
+    def __init__(self, vocab_size):
+        self.vocab_size = vocab_size
+
+    def __call__(self, prediction_scores, seq_relationship_score,
+                 masked_lm_labels, next_sentence_labels, masked_lm_scale):
+        masked_lm_loss = softmax_with_cross_entropy(
+            prediction_scores, masked_lm_labels, ignore_index=-1)
+        masked_lm_loss = masked_lm_loss / masked_lm_scale
+        next_sentence_loss = softmax_with_cross_entropy(seq_relationship_score,
+                                                        next_sentence_labels)
+        return np.sum(masked_lm_loss) + np.mean(next_sentence_loss)
+
+
+class TestRobertaForSequenceClassification(CommonTest):
+    def set_input(self):
+        self.config = copy.deepcopy(RobertaModel.pretrained_init_configuration[
+            'roberta-wwm-ext'])
+        self.config['num_hidden_layers'] = 2
+        self.config['vocab_size'] = 512
+        self.config['attention_probs_dropout_prob'] = 0.0
+        self.config['hidden_dropout_prob'] = 0.0
+        self.config['intermediate_size'] = 1024
+        self.config['seq_len'] = 64
+        self.config['batch_size'] = 3
+        self.config['max_position_embeddings'] = 512
+        self.input_ids, self.masked_lm_positions = create_input_data(
+            self.config)
+
+    def set_output(self):
+        self.expected_shape = (self.config['batch_size'], 2)
+
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForSequenceClassification
+
+    def setUp(self):
+        self.set_model_class()
+        self.set_input()
+        self.set_output()
+
+    def check_testcase(self):
+        self.check_output_equal(self.output.numpy().shape, self.expected_shape)
+
+    def test_forward(self):
+        config = copy.deepcopy(self.config)
+        del config['batch_size']
+        del config['seq_len']
+
+        roberta = RobertaModel(**config)
+        model = self.TEST_MODEL_CLASS(roberta)
+        input_ids = paddle.to_tensor(self.input_ids)
+        self.output = model(input_ids)
+        self.check_testcase()
+
+
+class TestRobertaForTokenClassification(TestRobertaForSequenceClassification):
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForTokenClassification
+
+    def set_output(self):
+        self.expected_shape = (self.config['batch_size'],
+                               self.config['seq_len'], 2)
+
+
+class TestRobertaForQuestionAnswering(TestRobertaForSequenceClassification):
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForQuestionAnswering
+
+    def set_output(self):
+        self.expected_start_logit_shape = (self.config['batch_size'],
+                                           self.config['seq_len'])
+        self.expected_end_logit_shape = (self.config['batch_size'],
+                                         self.config['seq_len'])
+
+    def check_testcase(self):
+        self.check_output_equal(self.output[0].numpy().shape,
+                                self.expected_start_logit_shape)
+        self.check_output_equal(self.output[1].numpy().shape,
+                                self.expected_end_logit_shape)
+
+
+class TestRobertaFromPretrain(CommonTest):
+    @slow
+    def test_roberta_base_uncased(self):
+        model = RobertaModel.from_pretrained(
+            'roberta-wwm-ext',
+            attention_probs_dropout_prob=0.0,
+            hidden_dropout_prob=0.0)
+        self.config = copy.deepcopy(model.config)
+        self.config['seq_len'] = 32
+        self.config['batch_size'] = 3
+
+        input_ids, _ = create_input_data(self.config, 102)
+        input_ids = paddle.to_tensor(input_ids)
+        output = model(input_ids)
+
+        expected_seq_shape = (self.config['batch_size'], self.config['seq_len'],
+                              self.config['hidden_size'])
+        expected_pooled_shape = (self.config['batch_size'],
+                                 self.config['hidden_size'])
+        self.check_output_equal(output[0].numpy().shape, expected_seq_shape)
+        self.check_output_equal(output[1].numpy().shape, expected_pooled_shape)
+        expected_seq_slice = np.array([[0.17383946, 0.09206937, 0.45788339],
+                                       [-0.28287640, 0.06244858, 0.54864359],
+                                       [-0.54589444, 0.04811822, 0.50559914]])
+        # There's output diff about 1e-6 between cpu and gpu
+        self.check_output_equal(
+            output[0].numpy()[0, 0:3, 0:3], expected_seq_slice, atol=1e-6)
+
+        expected_pooled_slice = np.array(
+            [[-0.67418981, -0.07148759, 0.85799801],
+             [-0.62072051, -0.08452632, 0.96691507],
+             [-0.74019802, -0.10187808, 0.95353240]])
+        self.check_output_equal(
+            output[1].numpy()[0:3, 0:3], expected_pooled_slice, atol=1e-6)
+
+
+class TestRobertaForMultipleChoice(CommonTest):
+    def set_input(self):
+        self.config = copy.deepcopy(RobertaModel.pretrained_init_configuration[
+            'roberta-wwm-ext'])
+        self.config['num_hidden_layers'] = 2
+        self.config['vocab_size'] = 1024
+        self.config['attention_probs_dropout_prob'] = 0.0
+        self.config['hidden_dropout_prob'] = 0.0
+        self.config['intermediate_size'] = 1024
+        self.config['seq_len'] = 1024
+        self.config['batch_size'] = 2
+        self.config['max_position_embeddings'] = 2048
+        self.input_ids, self.masked_lm_positions = [], []
+        self.num_choices = 2
+        for i in range(self.num_choices):
+            input_ids, masked_lm_positions = create_input_data(self.config)
+            self.input_ids.append(input_ids)
+            self.masked_lm_positions.append(masked_lm_positions)
+        self.input_ids = np.array(self.input_ids).swapaxes(0, 1)
+        self.masked_lm_positions = np.array(self.masked_lm_positions).swapaxes(
+            0, 1)
+
+    def set_output(self):
+        self.expected_shape = (self.config['batch_size'], self.num_choices)
+
+    def setUp(self):
+        self.set_model_class()
+        self.set_input()
+        self.set_output()
+
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForMultipleChoice
+
+    def test_forward(self):
+        config = copy.deepcopy(self.config)
+        del config['batch_size']
+        del config['seq_len']
+        roberta = RobertaModel(**config)
+        model = self.TEST_MODEL_CLASS(roberta, num_choices=self.num_choices)
+        input_ids = paddle.to_tensor(self.input_ids)
+        output = model(input_ids)
+        self.check_output_equal(self.expected_shape, output.numpy().shape)
+
+
+class TestRobertaForMaskedLM(CommonTest):
+    def set_input(self):
+        self.config = copy.deepcopy(RobertaModel.pretrained_init_configuration[
+            'roberta-wwm-ext'])
+        self.config['num_hidden_layers'] = 2
+        self.config['vocab_size'] = 1024
+        self.config['attention_probs_dropout_prob'] = 0.0
+        self.config['hidden_dropout_prob'] = 0.0
+        self.config['intermediate_size'] = 1024
+        self.config['seq_len'] = 1024
+        self.config['batch_size'] = 2
+        self.config['max_position_embeddings'] = 2048
+        self.input_ids, self.masked_lm_positions = create_input_data(
+            self.config)
+        self.labels = np.random.randint(
+            low=0,
+            high=self.config['vocab_size'],
+            size=(self.config["batch_size"], self.config["seq_len"]))
+
+    def set_output(self):
+        self.expected_shape1 = (1, )
+        self.expected_shape2 = (self.config['batch_size'],
+                                self.config['seq_len'],
+                                self.config['vocab_size'])
+        self.expected_shape3 = (self.config['batch_size'],
+                                self.config['seq_len'],
+                                self.config['hidden_size'])
+
+    def setUp(self):
+        self.set_model_class()
+        self.set_input()
+        self.set_output()
+
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForMaskedLM
+
+    def test_forward(self):
+        config = copy.deepcopy(self.config)
+        del config['batch_size']
+        del config['seq_len']
+        roberta = RobertaModel(**config)
+        model = self.TEST_MODEL_CLASS(roberta)
+        input_ids = paddle.to_tensor(self.input_ids)
+        labels = paddle.to_tensor(self.labels)
+        masked_lm_loss, prediction_scores, sequence_output = model(
+            input_ids, labels=labels)
+        self.check_output_equal(self.expected_shape1,
+                                masked_lm_loss.numpy().shape)
+        self.check_output_equal(self.expected_shape2,
+                                prediction_scores.numpy().shape)
+        self.check_output_equal(self.expected_shape3,
+                                sequence_output.numpy().shape)
+
+
+class TestRobertaForCausalLM(CommonTest):
+    def set_input(self):
+        self.config = copy.deepcopy(RobertaModel.pretrained_init_configuration[
+            'roberta-wwm-ext'])
+        self.config['num_hidden_layers'] = 2
+        self.config['vocab_size'] = 1024
+        self.config['attention_probs_dropout_prob'] = 0.0
+        self.config['hidden_dropout_prob'] = 0.0
+        self.config['intermediate_size'] = 1024
+        self.config['seq_len'] = 1024
+        self.config['batch_size'] = 2
+        self.config['max_position_embeddings'] = 2048
+        self.input_ids, self.masked_lm_positions = create_input_data(
+            self.config)
+        self.labels = np.random.randint(
+            low=0,
+            high=self.config['vocab_size'],
+            size=(self.config["batch_size"], self.config["seq_len"]))
+
+    def set_output(self):
+        self.expected_shape1 = (1, )
+        self.expected_shape2 = (self.config['batch_size'],
+                                self.config['seq_len'],
+                                self.config['vocab_size'])
+        self.expected_shape3 = (self.config['batch_size'],
+                                self.config['seq_len'],
+                                self.config['hidden_size'])
+
+    def setUp(self):
+        self.set_model_class()
+        self.set_input()
+        self.set_output()
+
+    def set_model_class(self):
+        self.TEST_MODEL_CLASS = RobertaForCausalLM
+
+    def test_forward(self):
+        config = copy.deepcopy(self.config)
+        del config['batch_size']
+        del config['seq_len']
+        roberta = RobertaModel(**config)
+        model = self.TEST_MODEL_CLASS(roberta)
+        input_ids = paddle.to_tensor(self.input_ids)
+        labels = paddle.to_tensor(self.labels)
+        masked_lm_loss, prediction_scores, sequence_output = model(
+            input_ids, labels=labels)
+        self.check_output_equal(self.expected_shape1,
+                                masked_lm_loss.numpy().shape)
+        self.check_output_equal(self.expected_shape2,
+                                prediction_scores.numpy().shape)
+        self.check_output_equal(self.expected_shape3,
+                                sequence_output.numpy().shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
Models

### Description
https://github.com/PaddlePaddle/PaddleNLP/issues/1075
1. 在PaddleNLP的Roberta模型代码中，新增 RobertaForMultipleChoice，RobertaForMaskedLM 和 RobertaForCausalLM这三个类。
2. 新增 roberta-large，roberta-base，deepset/roberta-base-squad2，uer/roberta-base-finetuned-chinanews-chinese，sshleifer/tiny-distilroberta-base，uer/roberta-base-finetuned-cluener2020-chinese 和 uer/roberta-base-chinese-extractive-qa 7个模型参数权重。
3. 包含代码+注释 + 项目单测文件 + 贡献模型权重（百度网盘下载）+权重转换代码