### PR TITLE
[NPU] npu support modification for bert and ernie-1.0

### DIFF
--- a/examples/language_model/bert/run_glue.py
+++ b/examples/language_model/bert/run_glue.py
@@ -157,8 +157,9 @@ def parse_args():
         "--device",
         default="gpu",
         type=str,
-        choices=["cpu", "gpu", "xpu"],
-        help="The device to select to train the model, is must be cpu/gpu/xpu.")
+        choices=["cpu", "gpu", "xpu", "npu"],
+        help="The device to select to train the model, is must be cpu/gpu/xpu/npu."
+    )
     parser.add_argument(
         "--use_amp",
         type=distutils.util.strtobool,

--- a/examples/text_classification/pretrained_models/train.py
+++ b/examples/text_classification/pretrained_models/train.py
@@ -40,7 +40,7 @@ parser.add_argument("--epochs", default=3, type=int, help="Total number of train
 parser.add_argument("--warmup_proportion", default=0.0, type=float, help="Linear warmup proption over the training process.")
 parser.add_argument("--init_from_ckpt", type=str, default=None, help="The path of checkpoint to be loaded.")
 parser.add_argument("--seed", type=int, default=1000, help="random seed for initialization")
-parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
+parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu', 'npu'], default="gpu", help="Select which device to train model, defaults to gpu.")
 args = parser.parse_args()
 # yapf: enable
 

--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -54,7 +54,10 @@ class BertEmbeddings(Layer):
     def forward(self, input_ids, token_type_ids=None, position_ids=None):
         if position_ids is None:
             ones = paddle.ones_like(input_ids, dtype="int64")
-            seq_length = paddle.cumsum(ones, axis=-1)
+            if paddle.is_compiled_with_npu():
+                seq_length = paddle.cumsum(ones, axis=-1, dtype='int32')
+            else:
+                seq_length = paddle.cumsum(ones, axis=-1)
 
             position_ids = seq_length - ones
             position_ids.stop_gradient = True

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -58,7 +58,10 @@ class ErnieEmbeddings(nn.Layer):
             # maybe need use shape op to unify static graph and dynamic graph
             #seq_length = input_ids.shape[1]
             ones = paddle.ones_like(input_ids, dtype="int64")
-            seq_length = paddle.cumsum(ones, axis=1)
+            if paddle.is_compiled_with_npu():
+                seq_length = paddle.cumsum(ones, axis=1, dtype='int32')
+            else:
+                seq_length = paddle.cumsum(ones, axis=1)
             position_ids = seq_length - ones
             position_ids.stop_gradient = True
         if token_type_ids is None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
1. Bert and ernie-1.0 support NPU device
2. When compiled with npu, cumsum use int32 because CANN operator doesn't support int64_t.