### PR TITLE
[BUGFIX] Do broadcast right

### DIFF
--- a/examples/text_summarization/bart/README.md
+++ b/examples/text_summarization/bart/README.md
@@ -216,6 +216,7 @@ python generate.py \
     --faster \
     --use_fp16_decoding \
     --decoding_lib=../../../paddlenlp/ops/build/lib/libdecoding_op.so \
+    --alpha=0.0 \
     --device=gpu
 ```
 其中新增参数释义如下：

--- a/examples/text_summarization/bart/generate.py
+++ b/examples/text_summarization/bart/generate.py
@@ -26,7 +26,7 @@ from paddlenlp.transformers import BartForConditionalGeneration, BartTokenizer
 from paddlenlp.ops import FasterBART
 from utils import convert_example, compute_metrics
 
-summarization_name_mapping = {"cnn_dailymail": ("article", "highlights"), }
+summarization_name_mapping = {"cnn_dailymail": ("article", "highlights")}
 
 
 def parse_args():

--- a/examples/text_summarization/bart/run_summarization.py
+++ b/examples/text_summarization/bart/run_summarization.py
@@ -32,7 +32,7 @@ from paddlenlp.datasets import load_dataset
 from paddlenlp.data import Tuple, Stack
 from utils import convert_example, compute_metrics
 
-summarization_name_mapping = {"cnn_dailymail": ("article", "highlights"), }
+summarization_name_mapping = {"cnn_dailymail": ("article", "highlights")}
 
 
 def parse_args():

--- a/examples/text_summarization/bart/utils.py
+++ b/examples/text_summarization/bart/utils.py
@@ -106,6 +106,7 @@ def compute_metrics(preds, labels, tokenizer, ignore_pad_token_for_loss=True):
         return seq
 
     if ignore_pad_token_for_loss:
+        labels = np.asarray(labels)
         labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
     decoded_preds, decoded_labels = [], []
     for pred, label in zip(preds, labels):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- In `labels = np.where(labels != -100, labels, tokenizer.pad_token_id)`, `labels != -100` requires type of `labels` should be  `numpy.ndarray`
- In faster mode, `alpha==0` means no length_penalty and keeps same with normal mode.