### PR TITLE
Fix length penalty in beam search v2.

### DIFF
--- a/paddlenlp/transformers/transformer/modeling.py
+++ b/paddlenlp/transformers/transformer/modeling.py
@@ -1192,7 +1192,7 @@ class InferTransformerModel(TransformerModel):
 
             # Length penalty is given by = (5+len(decode)/6) ^ -\alpha. Pls refer to
             # https://arxiv.org/abs/1609.08144.
-            length_penalty = paddle.pow(5.0 + (i + 1.0) / 6.0, alpha)
+            length_penalty = paddle.pow((5.0 + i + 1.0) / 6.0, alpha)
             curr_scores = log_probs / length_penalty
             flat_curr_scores = paddle.reshape(curr_scores, [batch_size, -1])
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix length penalty in beam search v2.