### PR TITLE
Fix FasterGeneration(FasterEncoder) when loading a lib without fusion_encoder to use FasterEncoder

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/decoder.py
+++ b/paddlenlp/ops/faster_transformer/transformer/decoder.py
@@ -121,7 +121,7 @@ class InferTransformerDecoder(nn.Layer):
                 logger.warning(
                     "The specified decoder_lib does not exist, and it will be built automatically."
                 )
-            load("FasterTransformer", verbose=True)
+            load("FasterTransformer", verbose=True, opnames=["fusion_decoder"])
 
         super(InferTransformerDecoder, self).__init__()
         self.n_head = n_head

--- a/paddlenlp/ops/faster_transformer/transformer/decoding.py
+++ b/paddlenlp/ops/faster_transformer/transformer/decoding.py
@@ -501,7 +501,10 @@ class InferTransformerDecoding(nn.Layer):
                 logger.warning(
                     "The specified decoding_lib does not exist, and it will be built automatically."
                 )
-            load("FasterTransformer", verbose=True)
+            load(
+                "FasterTransformer",
+                verbose=True,
+                opnames=["fusion_decoding", "fusion_force_decoding"])
 
         super(InferTransformerDecoding, self).__init__()
         for arg, value in locals().items():
@@ -725,7 +728,7 @@ class InferGptDecoding(nn.Layer):
                 logger.warning(
                     "The specified decoding_lib does not exist, and it will be built automatically."
                 )
-            load("FasterTransformer", verbose=True)
+            load("FasterTransformer", verbose=True, opnames=["fusion_gpt"])
 
         super(InferGptDecoding, self).__init__()
 
@@ -903,7 +906,10 @@ class InferUnifiedDecoding(nn.Layer):
                 logger.warning(
                     "The specified decoding_lib does not exist, and it will be built automatically."
                 )
-            load("FasterTransformer", verbose=True)
+            load(
+                "FasterTransformer",
+                verbose=True,
+                opnames=["fusion_unified_decoding"])
 
         super(InferUnifiedDecoding, self).__init__()
         for arg, value in locals().items():
@@ -1280,7 +1286,10 @@ class InferBartDecoding(nn.Layer):
                 logger.warning(
                     "The specified decoding_lib does not exist, and it will be built automatically."
                 )
-            load("FasterTransformer", verbose=True)
+            load(
+                "FasterTransformer",
+                verbose=True,
+                opnames=["fusion_bart_decoding"])
 
         super(InferBartDecoding, self).__init__()
         for arg, value in locals().items():

--- a/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
+++ b/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
@@ -1083,11 +1083,11 @@ class FasterBART(BartPretrainedModel):
             self._model, 'eos_token_id', None)
         pad_token_id = pad_token_id if pad_token_id is not None else getattr(
             self._model, 'pad_token_id', None)
-        self.encoder = enable_faster_encoder(self.encoder, need_build=False)
         if encoder_output is None:
+            self.encoder = enable_faster_encoder(self.encoder, need_build=False)
             assert input_ids is not None, "You have to specify either input_ids or encoder_output."
             encoder_output = self.encoder(input_ids)
-        self.encoder = disable_faster_encoder(self.encoder)
+            self.encoder = disable_faster_encoder(self.encoder)
         if seq_len is None:
             assert input_ids is not None, "You have to specify either input_ids when generating seq_len."
             seq_len = paddle.sum(paddle.cast(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
Fix FasterGeneration(FasterEncoder) when load a lib without fusion_encoder to use FasterEncoder. 

After loading a custom op lib in `enable_faster_encoder()`, the original `TransformerEncoder`'s `forward` will be replaced by the faster version. 
However, if there is no `fusion_encoder` in the lib, the replacement cannot be undo. 