### PR TITLE
Refine some remain issue in hf beam search

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/decoding.py
+++ b/paddlenlp/ops/faster_transformer/transformer/decoding.py
@@ -1223,7 +1223,11 @@ class InferUnifiedDecoding(nn.Layer):
                 "lm_ln_bias"] = [self._model.lm_head.layer_norm.bias]
             self.sub_modules[
                 "linear_weight"] = [self._model.lm_head.decoder_weight.t()]
-            self.sub_modules["linear_bias"] = [self._model.lm_head.decoder_bias]
+
+            # NOTE: Fix self._model.lm_head.decoder_bias been changed in FT.
+            self.sub_modules["linear_bias"] = [
+                paddle.assign(self._model.lm_head.decoder_bias)
+            ]
 
     def forward(self,
                 cache_k,

--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/online_softmax_beamsearch_kernels.cu
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/online_softmax_beamsearch_kernels.cu
@@ -1100,7 +1100,7 @@ __launch_bounds__(THREADBLOCK_SIZE) __global__
           sequence_length[MAX_K / 2 + alive_num] = step;
           finished[MAX_K / 2 + alive_num] = 0;
           alive_finished[alive_num] = 0;
-          alive_num += 1;
+          alive_num++;
         }
       }
     }
@@ -1155,7 +1155,7 @@ __launch_bounds__(THREADBLOCK_SIZE) __global__
         }
         for (int i = MAX_K / 2; i < MAX_K; ++i) {
           finish_stop.insert(output_cum_log_probs[i] / length_penalty,
-                             word_ids[i],
+                             word_ids[i - MAX_K / 2],
                              output_parent_ids[i],
                              step);
         }

--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_beamsearch.h
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_beamsearch.h
@@ -923,7 +923,7 @@ public:
         } else {
           if (keep_alive_beam_ == true) {
             update_logits_v2(tmp_logits_buf_,
-                             decoding_params.embedding_bias,
+                             embedding_bias_ptr,
                              args_.end_id_,
                              finished_buf_,
                              m,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
* 修复 hf beam search 生成到最大长度的情况下，最后一位解码结果的问题。
* 绕过因 bias 变化，导致 case “你好啊，你今年多大了，我住在北京，你呢” 在不同 beam size 下生成结果不一致。