### PR TITLE
Fix add_bias_input in FT.

### DIFF
--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/transformer_kernels.cu
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/transformer_kernels.cu
@@ -465,11 +465,12 @@ __global__ void add_bias_input(
   // This kernel can run with any block size and grid size
   // Since the hidden dimension of GPT-3 would be larger than 1024
   const int bid = blockIdx.x;
-  const int blocks_per_row = n / blockDim.x;
-  const int col_index = (bid % blocks_per_row) * blockDim.x + threadIdx.x;
-  T bias_val = __ldg(&bias[col_index]);
+  // const int blocks_per_row = n / blockDim.x;
+  // const int col_index = (bid % blocks_per_row) * blockDim.x + threadIdx.x;
+  // T bias_val = __ldg(&bias[col_index]);
   for (int index = bid * blockDim.x + threadIdx.x; index < m * n;
        index += blockDim.x * gridDim.x) {
+    T bias_val = __ldg(&bias[index % n]);
     output[index] = output[index] + input[index] + bias_val;
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix add_bias_input in FT.  

This bug is from NV FT, which results to errors when `hidden_size > 1024` and causes `gpt-large-en` in PaddleNLP generating different sequences when using topk sampling with `k=1` and `batch_size=4`. 

```text
========== Sample-0 ==========
The first time I saw the movie, I was in a theater in New York City, and I
========== Sample-1 ==========
The U.S. Supreme Court on Monday declined to hear a challenge to a federal law that requires
========== Sample-2 ==========
The U.S. Department of Justice has filed a civil rights lawsuit against the city of Chicago for
========== Sample-3 ==========
The U.S. Supreme Court on Monday declined to hear a challenge to a law that requires people
```

After this fix:

```text
========== Sample-0 ==========
The U.S. Department of Justice has filed a civil rights lawsuit against the city of Ferguson,
========== Sample-1 ==========
The U.S. Department of Justice has filed a civil rights lawsuit against the city of Ferguson,
========== Sample-2 ==========
The U.S. Department of Justice has filed a civil rights lawsuit against the city of Ferguson,
========== Sample-3 ==========
The U.S. Department of Justice has filed a civil rights lawsuit against the city of Ferguson,
```