### PR TITLE
fix get_logits_processor missing kwargs

### DIFF
--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -802,7 +802,8 @@ class GenerationMixin(object):
             forced_eos_token_id=forced_eos_token_id,
             num_beams=num_beams,
             num_beam_groups=num_beam_groups,
-            diversity_rate=diversity_rate)
+            diversity_rate=diversity_rate,
+            repetition_penalty=repetition_penalty)
 
         if decode_strategy == 'greedy_search':
             if num_return_sequences > 1:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
调用`get_logits_processor`的时候 ，缺少了`repetition_penalty`这个参数。