### PR TITLE
Fix paddle.sum in FasterGPT

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
+++ b/paddlenlp/ops/faster_transformer/transformer/faster_transformer.py
@@ -676,7 +676,7 @@ class FasterGPT(GPTPretrainedModel):
                                  dtype="int32")
 
             if bos_token_id == pad_token_id and paddle.sum(
-                    paddle.any(input_ids == pad_token_id)) > 0:
+                    paddle.any(input_ids == pad_token_id), dtype="int64") > 0:
                 seq_len = seq_len + 1
 
         if num_return_sequences > 1:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
The returned type of `paddle.sum` is `bool` when input is `bool` in previous paddle.
Fix #1395 