### PR TITLE
Fix sampling randomly fail in FasterTransformer

### DIFF
--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/topk_kernels.cu
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/topk_kernels.cu
@@ -564,6 +564,10 @@ __global__ void topk_stage_2_opt3_sampling(
         ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
         break;
       }
+      if (i == k - 1) {
+        ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
+        break;
+      }
     }
     if (finished_buf != nullptr) {
       if (sequence_length != nullptr) {
@@ -2143,6 +2147,10 @@ __global__ void topk_topp_sampling_kernel_v2(
     for (int i = 0; i < k; i++) {
       rand_num = rand_num - (float)s_val2[s_id[i]];
       if (rand_num <= 0.0f) {
+        ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
+        break;
+      }
+      if (i == k - 1) {
         ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
         break;
       }

--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/topk_kernels.cu
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/cuda/topk_kernels.cu
@@ -560,11 +560,7 @@ __global__ void topk_stage_2_opt3_sampling(
     rand_num = (float)curand_uniform(curandstate + blockIdx.x) * s_sum;
     for (int i = 0; i < k; i++) {
       rand_num = rand_num - (float)s_val2[s_id[i]];
-      if (rand_num <= 0.0f) {
-        ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
-        break;
-      }
-      if (i == k - 1) {
+      if (rand_num <= 0.0f || i == k - 1) {
         ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
         break;
       }
@@ -2146,11 +2142,7 @@ __global__ void topk_topp_sampling_kernel_v2(
                (float)prob_threshold * s_sum;
     for (int i = 0; i < k; i++) {
       rand_num = rand_num - (float)s_val2[s_id[i]];
-      if (rand_num <= 0.0f) {
-        ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
-        break;
-      }
-      if (i == k - 1) {
+      if (rand_num <= 0.0f || i == k - 1) {
         ids[batch_id] = topk_tmp_id_buf[batch_id * size + s_id[i]] % vocab_size;
         break;
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
修复 FT `sampling` 代码 bug。原 `sampling` 代码没做足够的考虑，导致随机性出现个别 id 为空，故导致最后生成乱码的情况。新增相应的程序保护，保证 `sampling` 策略鲁棒性。