### PR TITLE
Fix import paddlenlp which caused by funnel/modeling.py

### DIFF
--- a/paddlenlp/transformers/funnel/modeling.py
+++ b/paddlenlp/transformers/funnel/modeling.py
@@ -15,7 +15,6 @@
 
 from .. import register_base_model
 import math
-from packaging import version
 from dataclasses import dataclass
 from dataclasses import fields
 from collections import OrderedDict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
应该是生态模型引入的 Bug，`import paddlenlp` 会报错，而且似乎没有用到，目前是做删除处理了。