### PR TITLE
Fix ctrl tokenizer vocab link

### DIFF
--- a/paddlenlp/transformers/ctrl/tokenizer.py
+++ b/paddlenlp/transformers/ctrl/tokenizer.py
@@ -142,9 +142,7 @@ class CTRLTokenizer(PretrainedTokenizer):
         },
     }
     pretrained_init_configuration = {
-        "ctrl": {
-            "max_len": 256
-        },
+        "ctrl": {},
         "sshleifer-tiny-ctrl": {
             "max_len": 256
         }

--- a/paddlenlp/transformers/ctrl/tokenizer.py
+++ b/paddlenlp/transformers/ctrl/tokenizer.py
@@ -127,21 +127,28 @@ class CTRLTokenizer(PretrainedTokenizer):
         "vocab_file": "vocab.json",
         "merges_file": "merges.txt",
     }
-    ctrl_vocab_link = (
-        "http://bj.bcebos.com/paddlenlp/models/transformers/ctrl/vocab.json")
-    ctrl_merges_link = (
-        "http://bj.bcebos.com/paddlenlp/models/transformers/ctrl/merges.txt")
     pretrained_resource_files_map = {
         "vocab_file": {
-            "ctrl": ctrl_vocab_link,
-            "sshleifer-tiny-ctrl": ctrl_merges_link,
+            "ctrl":
+            "http://bj.bcebos.com/paddlenlp/models/transformers/ctrl/vocab.json",
+            "sshleifer-tiny-ctrl":
+            "http://bj.bcebos.com/paddlenlp/models/transformers/sshleifer-tiny-ctrl/vocab.json",
         },
         "merges_file": {
-            "ctrl": ctrl_vocab_link,
-            "sshleifer-tiny-ctrl": ctrl_merges_link,
+            "ctrl":
+            "http://bj.bcebos.com/paddlenlp/models/transformers/ctrl/merges.txt",
+            "sshleifer-tiny-ctrl":
+            "http://bj.bcebos.com/paddlenlp/models/transformers/sshleifer-tiny-ctrl/merges.txt",
         },
     }
-    pretrained_init_configuration = {"ctrl": {}, "sshleifer-tiny-ctrl": {}}
+    pretrained_init_configuration = {
+        "ctrl": {
+            "max_len": 256
+        },
+        "sshleifer-tiny-ctrl": {
+            "max_len": 256
+        }
+    }
 
     CONTROL_CODES = CONTROL_CODES
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
CTRLTokenizer
### Description
<!-- Describe what this PR does -->
修复CTRLTokenizer的`vocab_file`和`merges_file`的链接错误(重新上传这两个文件)。