### PR TITLE
update paddle version in readme when using amp training

### DIFF
--- a/examples/machine_translation/transformer/README.md
+++ b/examples/machine_translation/transformer/README.md
@@ -44,6 +44,8 @@ Decoder 具有和 Encoder 类似的结构，只是相比于组成 Encoder 的 la
 
 安装命令：`pip install attrdict pyyaml`
 
+**注意：如果需要使用混合精度训练，需要使用基于 PaddlePaddle develop 分支编译的包。**
+
 ## 数据准备
 
 公开数据集：WMT 翻译大赛是机器翻译领域最具权威的国际评测大赛，其中英德翻译任务提供了一个中等规模的数据集，这个数据集是较多论文中使用的数据集，也是 Transformer 论文中用到的一个数据集。我们也将[WMT'14 EN-DE 数据集](http://www.statmt.org/wmt14/translation-task.html)作为示例提供。

--- a/examples/machine_translation/transformer/train.py
+++ b/examples/machine_translation/transformer/train.py
@@ -154,10 +154,8 @@ def do_train(args):
         print("loaded from pre-trained model.")
 
     # for amp training
-    amp_level = 'O1'
-    if args.use_amp and args.use_pure_fp16:
-        amp_level = 'O2'
     if args.use_amp:
+        amp_level = 'O2' if args.use_pure_fp16 else 'O1'
         scaler = paddle.amp.GradScaler(
             enable=True, init_loss_scaling=args.scale_loss)
         transformer = paddle.amp.decorate(models=transformer, level=amp_level)

--- a/examples/machine_translation/transformer/util/to_static.py
+++ b/examples/machine_translation/transformer/util/to_static.py
@@ -20,14 +20,14 @@ from paddle.jit import to_static
 from paddle.static import InputSpec
 import paddle
 
+
 def create_input_specs():
     src_word = paddle.static.InputSpec(
         name="src_word", shape=[None, None], dtype="int64")
     trg_word = paddle.static.InputSpec(
         name="trg_word", shape=[None, None], dtype="int64")
-    return [
-        src_word, trg_word
-    ]
+    return [src_word, trg_word]
+
 
 def apply_to_static(config, model):
     support_to_static = config.get('to_static', False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what this PR does -->
Add description in `README` to point out corresponding version of PaddlePaddle when using AMP. 