### PR TITLE
[PRETRAIN] Add ernie-1.0 dygraph training script.

### DIFF
--- a/examples/language_model/data_tools/dataset_utils.py
+++ b/examples/language_model/data_tools/dataset_utils.py
@@ -25,7 +25,11 @@ import collections
 
 import numpy as np
 import paddle
-import paddle.distributed.fleet as fleet
+
+
+def get_local_rank():
+    return int(os.getenv("PADDLE_RANK_IN_NODE", 0))
+
 
 print_rank_0 = print
 
@@ -706,9 +710,9 @@ def get_samples_mapping(indexed_dataset, data_prefix, num_epochs,
     indexmap_filename += '_{}s'.format(seed)
     indexmap_filename += '.npy'
 
-    local_rank = 0 if fleet.local_rank() is None else int(fleet.local_rank())
+    local_rank = get_local_rank()
     if share_folder:
-        local_rank = fleet.worker_index()
+        local_rank = paddle.distributed.get_rank()
     # Build the indexed mapping if not exist.
 
     if local_rank == 0 and \

--- a/examples/language_model/ernie-1.0/README.md
+++ b/examples/language_model/ernie-1.0/README.md
@@ -32,12 +32,7 @@ python -u  -m paddle.distributed.launch \
     --output_dir "output/ernie-1.0-dp8-gb512" \
     --max_seq_len 512 \
     --micro_batch_size 64 \
-    --global_batch_size 512 \
-    --sharding_degree 1\
-    --dp_degree 8 \
-    --use_sharding false \
     --use_amp true \
-    --use_recompute false \
     --max_lr 0.0001 \
     --min_lr 0.00001 \
     --max_steps 1000000 \
@@ -58,29 +53,23 @@ python -u  -m paddle.distributed.launch \
 - `input_dir` 指定输入文件，可以使用目录，指定目录时将包括目录中的所有文件。
 - `output_dir` 指定输出文件。
 - `max_seq_len` 输入文本序列的长度。
-- `micro_batch_size` 单卡单次的 batch size大小。即单张卡运行一次前向网络的 batch size大小。
-- `global_batch_size` 全局的batch size大小，即一次参数更新等效的batch size。
-- `sharding_degree` 切参数切分的分组大小（如 sharding_degree=4 表示参数分为4组，分别到4个设备）。
-- `dp_degree` 数据并行参数。
-- `use_sharding` 开启sharding策略，sharding_degree > 1时，请设置为True。
+- `micro_batch_size` 单卡batch size大小，比如此处单卡bs=64, 采用8卡训练`global_batch_size=64*8=512`。
 - `use_amp` 开启混合精度策略。
-- `use_recompute` 开启重计算策略。暂时未支持，后续将支持。
 - `max_lr` 训练学习率。
 - `min_lr` 学习率衰减的最小值。
 - `max_steps` 最大训练步数。
-- `save_steps` 保存模型间隔。
-- `checkpoint_steps` 模型checkpoint间隔，用于模型断点重启训练。
+- `save_steps` 保存模型间隔。默认保存地址格式为`output_dir/model_50000`(5w 步时的权重)。
+- `checkpoint_steps` 模型checkpoint间隔，用于模型断点重启训练。默认地址为`output_dir/model_last`.
 - `weight_decay` 权重衰减参数。
 - `warmup_rate` 学习率warmup参数。
 - `grad_clip` 梯度裁剪范围。
 - `logging_freq` 日志输出间隔。
+- `num_workers` DataLoader采样进程，当数据输入为瓶颈时，可尝试提高采样进程数目。
 - `eval_freq` 模型评估间隔。
 - `device` 训练设备。
 
 注：
-- 一般而言，需要设置 `mp_degree * sharding_degree` = 训练机器的总卡数。
-- 一般而言， `global_batch_size = micro_batch_size * sharding_degree * dp_degree`。可以使用梯度累积的方式增大`global_batch_size`。设置`global_batch_size`为理论值的整数倍是，默认启用梯度累积。
-- 训练断点重启，直接启动即可，程序会找到最新的checkpoint，开始重启训练。
+- 训练支持断点重启，直接启动即可，程序会找到最新的checkpoint，开始重启训练。请确保重启的训练配置与之前相同。
 
 
 ### CLUECorpusSmall 数据集训练结果
@@ -109,15 +98,6 @@ CMRC2018 | 72.05/85.67 | - |
 
 
 ### 其他
-#### 模型参数转换
-本示例提供了静态图训练脚本`run_pretrain_static.py`，启动参数与动态图一致。Paddle目前主要的使用方式是动态图，本示例提供了静态图参数到动态图参数的转换脚本：
-
-```python
-python converter/params_static_to_dygraph.py --model ernie-1.0 --path ./output/task_name/model_100000/static_vars
-# or
-python converter/params_static_to_dygraph.py --model ernie-1.0 --path ./output/task_name/model_last/static_vars.pdparams
-```
-在当前目录下，可以看到转换后的参数`ernie-1.0_converted.pdparams`, 也可以设置脚本中`--output_path`参数，指定输出路径。
 
 #### 为PaddleNLP贡献预训练参数
 PaddleNLP为开发者支持了[community](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/community)模块，用户可以上传自己训练的模型，开源给其他用户使用。

--- a/examples/language_model/ernie-1.0/README.md
+++ b/examples/language_model/ernie-1.0/README.md
@@ -25,7 +25,7 @@ ERNIE在情感分析、文本匹配、自然语言推理、词法分析、阅读
 python -u  -m paddle.distributed.launch \
     --gpus "0,1,2,3,4,5,6,7" \
     --log_dir "output/ernie-1.0-dp8-gb512/log" \
-    run_pretrain_static.py \
+    run_pretrain.py \
     --model_type "ernie" \
     --model_name_or_path "ernie-1.0" \
     --input_dir "./data" \
@@ -110,7 +110,7 @@ CMRC2018 | 72.05/85.67 | - |
 
 ### 其他
 #### 模型参数转换
-本示例提供了静态图训练脚本，但Paddle目前主要的使用方式是动态图。因此，本示例提供了静态图参数到动态图参数的转换脚本：
+本示例提供了静态图训练脚本`run_pretrain_static.py`，启动参数与动态图一致。Paddle目前主要的使用方式是动态图，本示例提供了静态图参数到动态图参数的转换脚本：
 
 ```python
 python converter/params_static_to_dygraph.py --model ernie-1.0 --path ./output/task_name/model_100000/static_vars

--- a/examples/language_model/ernie-1.0/args.py
+++ b/examples/language_model/ernie-1.0/args.py
@@ -77,7 +77,7 @@ def parse_args(MODEL_CLASSES):
     # AMP config
     parser.add_argument("--use_amp", type=str2bool, nargs='?', const=False, help="Enable mixed precision training.")
     parser.add_argument("--enable_addto", type=str2bool, nargs='?', const=True, default=True, help="Whether to enable the addto strategy for gradient accumulation or not. This is only used for AMP training.")
-    parser.add_argument("--scale_loss", type=float, default=128, help="The value of scale_loss for fp16. This is only used for AMP training.")
+    parser.add_argument("--scale_loss", type=float, default=32768, help="The value of scale_loss for fp16. This is only used for AMP training.")
     parser.add_argument("--hidden_dropout_prob", type=float, default=0.1, help="The hidden dropout prob.")
     parser.add_argument("--attention_probs_dropout_prob", type=float, default=0.1, help="The attention probs dropout prob.")
 

--- a/examples/language_model/ernie-1.0/args.py
+++ b/examples/language_model/ernie-1.0/args.py
@@ -108,8 +108,4 @@ def parse_args(MODEL_CLASSES):
                 "The attention_probs_dropout_prob should set to 0 for accuracy checking."
             )
 
-    logger.info('{:20}:{}'.format("paddle commit id", paddle.version.commit))
-    for arg in vars(args):
-        logger.info('{:20}:{}'.format(arg, getattr(args, arg)))
-
     return args

--- a/examples/language_model/ernie-1.0/run_gb512_s100w.sh
+++ b/examples/language_model/ernie-1.0/run_gb512_s100w.sh
@@ -1,27 +1,23 @@
 set -x
 export PADDLE_WITH_GLOO=0
-export FLAGS_call_stack_level=2
 unset CUDA_VISIBLE_DEVICES
 
-rm -rf *.prototxt
 rm -rf core.*
-rm -rf start_sharding*
-rm -rf main_sharding*
 
-task_name="ernie-1.0-dp8-gb1024"
+task_name="ernie-1.0-dp8-gb512"
 rm -rf output/$task_name/log
 
 PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --gpus "0,1,2,3,4,5,6,7" \
     --log_dir "output/$task_name/log" \
-    run_pretrain_static.py \
+    run_pretrain.py \
     --model_type "ernie" \
     --model_name_or_path "ernie-1.0" \
     --input_dir "./data" \
     --output_dir "output/$task_name" \
     --max_seq_len 512 \
     --micro_batch_size 64 \
-    --global_batch_size 1024 \
+    --global_batch_size 512 \
     --sharding_degree 1\
     --dp_degree 8 \
     --use_sharding false \
@@ -29,16 +25,18 @@ PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --use_recompute false \
     --max_lr 0.0001 \
     --min_lr 0.00001 \
-    --max_steps 2000000 \
-    --save_steps 100000 \
+    --max_steps 1000000 \
+    --save_steps 50000 \
     --checkpoint_steps 5000 \
-    --decay_steps 1980000 \
-    --weight_decay 0.01\
+    --decay_steps 990000 \
+    --weight_decay 0.01 \
     --warmup_rate 0.01 \
     --grad_clip 1.0 \
-    --num_workers 2 \
     --logging_freq 20\
+    --num_workers 2 \
     --eval_freq 1000 \
-    --device "gpu"
+    --device "gpu"\
+
+# --check_accuracy true\
 
 # NOTE: please set use_sharding=True for sharding_degree > 1

--- a/examples/language_model/ernie-1.0/run_gb512_s100w.sh
+++ b/examples/language_model/ernie-1.0/run_gb512_s100w.sh
@@ -17,10 +17,6 @@ PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --output_dir "output/$task_name" \
     --max_seq_len 512 \
     --micro_batch_size 64 \
-    --global_batch_size 512 \
-    --sharding_degree 1\
-    --dp_degree 8 \
-    --use_sharding false \
     --use_amp true \
     --use_recompute false \
     --max_lr 0.0001 \
@@ -37,6 +33,3 @@ PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --eval_freq 1000 \
     --device "gpu"\
 
-# --check_accuracy true\
-
-# NOTE: please set use_sharding=True for sharding_degree > 1

--- a/examples/language_model/ernie-1.0/run_gb512_s100w_static.sh
+++ b/examples/language_model/ernie-1.0/run_gb512_s100w_static.sh
@@ -11,7 +11,6 @@ rm -rf main_sharding*
 task_name="ernie-1.0-dp8-gb512"
 rm -rf output/$task_name/log
 
-
 PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --gpus "0,1,2,3,4,5,6,7" \
     --log_dir "output/$task_name/log" \
@@ -30,18 +29,16 @@ PYTHONPATH=../../../  python -u  -m paddle.distributed.launch \
     --use_recompute false \
     --max_lr 0.0001 \
     --min_lr 0.00001 \
-    --max_steps 2000000 \
+    --max_steps 1000000 \
     --save_steps 50000 \
     --checkpoint_steps 5000 \
-    --decay_steps 1980000 \
-    --weight_decay 0.01 \
-    --warmup_rate 0.005 \
+    --decay_steps 990000 \
+    --weight_decay 0.01\
+    --warmup_rate 0.01 \
     --grad_clip 1.0 \
-    --logging_freq 20\
     --num_workers 2 \
+    --logging_freq 20\
     --eval_freq 1000 \
-    --device "gpu"\
-
-# --check_accuracy true\
+    --device "gpu"
 
 # NOTE: please set use_sharding=True for sharding_degree > 1

--- a/examples/language_model/ernie-1.0/run_pretrain.py
+++ b/examples/language_model/ernie-1.0/run_pretrain.py
@@ -57,9 +57,10 @@ def create_pretrained_dataset(
         current_step=0, ):
 
     train_valid_test_num_samples = [
-        args.global_batch_size * args.max_steps, args.micro_batch_size *
-        (args.max_steps // args.eval_freq + 1) * args.eval_iters *
-        data_world_size, args.micro_batch_size * args.test_iters
+        args.global_batch_size * args.max_steps,
+        args.micro_batch_size * (args.max_steps // args.eval_freq + 1) *
+        args.eval_iters * data_world_size,
+        args.micro_batch_size * args.test_iters * data_world_size
     ]
     train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
         data_prefix=data_file,

--- a/examples/language_model/ernie-1.0/run_pretrain.py
+++ b/examples/language_model/ernie-1.0/run_pretrain.py
@@ -1,0 +1,547 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pretrain  ERNIE in dygraph mode.
+"""
+import argparse
+import os
+import sys
+import random
+import time
+import yaml
+import shutil
+
+import numpy as np
+import paddle
+import paddle.distributed.fleet as fleet
+from paddle.io import DataLoader, Dataset
+from visualdl import LogWriter
+
+from paddlenlp.transformers import ErnieModel, ErnieForPretraining, ErniePretrainingCriterion, ErnieTokenizer
+from paddlenlp.transformers import CosineAnnealingWithWarmupDecay, LinearDecayWithWarmup
+from paddlenlp.utils.batch_sampler import DistributedBatchSampler
+from paddlenlp.data import Stack, Tuple, Pad
+from paddlenlp.ops import Topology
+from paddlenlp.utils.log import logger
+
+from args import parse_args
+sys.path.insert(0, os.path.abspath("../"))
+from data_tools.dataset_utils import build_train_valid_test_datasets
+
+MODEL_CLASSES = {
+    "ernie": (ErnieModel, ErnieForPretraining, ErniePretrainingCriterion,
+              ErnieTokenizer),
+}
+
+
+def create_pretrained_dataset(
+        args,
+        data_file,
+        tokenizer,
+        data_world_size,
+        data_world_rank,
+        max_seq_len,
+        places=None,
+        data_holders=None,
+        current_step=0, ):
+
+    train_valid_test_num_samples = [
+        args.global_batch_size * args.max_steps, args.micro_batch_size *
+        (args.max_steps // args.eval_freq + 1) * args.eval_iters *
+        data_world_size, args.micro_batch_size * args.test_iters
+    ]
+    train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
+        data_prefix=data_file,
+        args=args,
+        tokenizer=tokenizer,
+        splits_string=args.split,
+        train_valid_test_num_samples=train_valid_test_num_samples,
+        max_seq_length=args.max_seq_len,
+        masked_lm_prob=args.masked_lm_prob,
+        short_seq_prob=args.short_seq_prob,
+        seed=args.seed,
+        skip_warmup=True,
+        binary_head=True,
+        max_seq_length_dec=None,
+        dataset_type='ernie')
+
+    def _collate_data(data, stack_fn=Stack()):
+        num_fields = len(data[0])
+        out = [None] * num_fields
+        # 0. input_ids,
+        # 1. segment_ids,
+        # 2. input_mask,
+        # 3. masked_lm_positions,
+        # 4. masked_lm_labels,
+        # 5. next_sentence_labels
+        for i in (0, 1, 2, 5):
+            out[i] = stack_fn([x[i] for x in data])
+        out[5] = out[5].reshape([-1, 1])
+        batch_size, seq_length = out[0].shape
+        size = num_mask = sum(len(x[3]) for x in data)
+        # masked_lm_positions
+        # Organize as a 1D tensor for gather or use gather_nd
+        if size % 8 != 0:
+            size += 8 - (size % 8)
+        out[3] = np.full(size, 0, dtype=np.int32)
+        # masked_lm_labels
+        out[4] = np.full([size, 1], -1, dtype=np.int64)
+        mask_token_num = 0
+        for i, x in enumerate(data):
+            for j, pos in enumerate(x[3]):
+                out[3][mask_token_num] = i * seq_length + pos
+                out[4][mask_token_num] = x[4][j]
+                mask_token_num += 1
+
+        return out
+
+    def loader(dataset, consumed_samples=0):
+        batch_sampler = DistributedBatchSampler(
+            dataset,
+            batch_size=args.micro_batch_size,
+            num_replicas=data_world_size,
+            rank=data_world_rank,
+            shuffle=False,
+            drop_last=True,
+            consumed_samples=consumed_samples)
+        data_loader = paddle.io.DataLoader(
+            dataset=dataset,
+            batch_sampler=batch_sampler,
+            num_workers=args.num_workers,
+            worker_init_fn=None,
+            collate_fn=_collate_data,
+            return_list=False)
+        return data_loader
+
+    train_dl = loader(train_ds, args.global_batch_size * current_step)
+    valid_dl = loader(valid_ds, args.micro_batch_size * (
+        (current_step + 1) // args.eval_freq) * args.eval_iters *
+                      data_world_size)
+    test_dl = loader(test_ds, 0)
+
+    return train_dl, valid_dl, test_dl
+
+
+def get_train_data_file(args):
+    files = [
+        os.path.join(args.input_dir, f) for f in os.listdir(args.input_dir)
+        if (os.path.isfile(os.path.join(args.input_dir, f)) and "_idx.npz" in
+            str(f))
+    ]
+    files = [x.replace("_idx.npz", "") for x in files]
+    return files
+
+
+@paddle.no_grad()
+def run_evaluate(data_loader,
+                 model,
+                 criterion,
+                 iter_steps,
+                 log_writer,
+                 global_step,
+                 args,
+                 is_last,
+                 eval_fetch,
+                 task_name="valid"):
+    model.eval()
+    all_loss, all_lm_loss, all_sop_loss = [], [], []
+    local_time = time.time()
+
+    for eval_step, batch in enumerate(data_loader):
+        input_ids, segment_ids, input_mask, masked_lm_positions, \
+        masked_lm_labels, next_sentence_labels = batch
+
+        # Create the model for the gpt pretrain
+        prediction_scores, seq_relationship_score = model(
+            input_ids=input_ids,
+            token_type_ids=segment_ids,
+            position_ids=None,
+            attention_mask=input_mask,
+            masked_positions=masked_lm_positions)
+
+        lm_loss, sop_loss = criterion(prediction_scores, seq_relationship_score,
+                                      masked_lm_labels, next_sentence_labels)
+        loss = lm_loss + sop_loss
+
+        if is_last:
+            all_loss.append(float(loss.item()))
+            all_lm_loss.append(float(lm_loss.item()))
+            all_sop_loss.append(float(sop_loss.item()))
+
+        if eval_step >= iter_steps - 1:
+            if not is_last:
+                break
+            average_loss = sum(all_loss) / len(all_loss)
+            average_lm_loss = sum(all_lm_loss) / len(all_lm_loss)
+            average_sop_loss = sum(all_sop_loss) / len(all_sop_loss)
+            logger.info(
+                "%s step %d, batch: %d, loss: %f, lm_loss: %.6f, sop_loss: %.6f, speed: %.0f tokens/s"
+                % (task_name, global_step, eval_step, average_loss,
+                   average_lm_loss, average_sop_loss,
+                   iter_steps * args.micro_batch_size * args.max_seq_len /
+                   (time.time() - local_time)))
+
+            log_writer.add_scalar(task_name + "_loss", average_loss,
+                                  global_step)
+            log_writer.add_scalar(task_name + "_lm_loss", average_lm_loss,
+                                  global_step)
+            log_writer.add_scalar(task_name + "_sop_loss", average_sop_loss,
+                                  global_step)
+
+            break
+
+    model.train()
+
+
+def set_seed(args):
+    if args.device == "cpu":
+        idx = 0
+    else:
+        idx = paddle.distributed.get_rank()
+    random.seed(args.seed + idx)
+    np.random.seed(args.seed + idx)
+    paddle.seed(args.seed + idx)
+
+
+def args_post_process(args, topo):
+    default_global_batch_size = topo.data_info.size * args.micro_batch_size
+    if args.global_batch_size is None:
+        args.global_batch_size = default_global_batch_size
+
+    bsz_per_dp = args.global_batch_size // topo.data_info.size
+    micro_batch_size = args.micro_batch_size
+    assert args.global_batch_size % micro_batch_size == 0, \
+        "cannot do gradient accumulate, global_batch_size: {} micro_batch_size: {}".format(
+        args.global_batch_size, micro_batch_size)
+    accumulate_steps = bsz_per_dp // micro_batch_size
+
+    args.eval_iters *= accumulate_steps
+    args.test_iters *= accumulate_steps
+
+    args.accumulate_steps = accumulate_steps
+
+
+def do_train(args):
+    assert args.device in [
+        "cpu", "gpu", "xpu"
+    ], "Invalid device! Available device should be cpu, gpu, or xpu."
+    paddle.set_device(args.device)
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": args.dp_degree,
+        "mp_degree": args.mp_degree,
+        "pp_degree": args.pp_degree,
+        "sharding_degree": args.sharding_degree
+    }
+
+    if paddle.distributed.get_world_size() > 1:
+        paddle.distributed.init_parallel_env()
+
+    fleet.init(is_collective=True, strategy=strategy)
+    hcg = fleet.get_hybrid_communicate_group()
+
+    worker_index = paddle.distributed.get_rank()
+    worker_num = paddle.distributed.get_world_size()
+    local_rank = int(os.getenv("PADDLE_RANK_IN_NODE", 0))
+
+    # Create the random seed for the worker
+    set_seed(args)
+
+    assert args.dp_degree * args.sharding_degree * args.mp_degree * args.pp_degree == worker_num, \
+        "The product of degree num should be equal to worker_num."
+
+    topo = Topology(
+        device_rank=worker_index,
+        world_size=worker_num,
+        dp_degree=args.dp_degree,
+        pp_degree=args.pp_degree,
+        sharding_degree=args.sharding_degree,
+        mp_degree=args.mp_degree)
+
+    args_post_process(args, topo)
+
+    logger.info("The topo of hybrid parallelism:\n{}".format(topo))
+
+    # Create log write, train results show on last card of pipeline.
+    if topo.is_last:
+        log_writer_path = os.path.join(
+            args.output_dir, "train_log",
+            "{}_globalbsz_{}_amp_{}_recompute_{}_card_{}".format(
+                args.model_name_or_path, args.global_batch_size, args.use_amp,
+                args.use_recompute, worker_index).lower())
+        log_writer = LogWriter(log_writer_path)
+
+    # Define the input data in the static mode
+    base_class, model_class, criterion_class, tokenizer_class = MODEL_CLASSES[
+        args.model_type]
+    pretrained_models_list = list(
+        model_class.pretrained_init_configuration.keys())
+
+    # load config in checkpoint
+    global_step = 0
+    consumed_samples = 0
+    checkpoint_dir = os.path.join(args.output_dir, "model_last")
+    if os.path.exists(checkpoint_dir):
+        if os.path.isfile(os.path.join(checkpoint_dir, "./config.yml")):
+            with open(os.path.join(checkpoint_dir, "./config.yml"), "r") as f:
+                step_config = yaml.load(f, Loader=yaml.FullLoader)
+                assert step_config[
+                    "global_batch_size"] == args.global_batch_size, "Please ensure checkpoint global batch size is the same. Folder: {}".format(
+                        checkpoint_dir)
+                consumed_samples = step_config["consumed_samples"]
+                global_step = step_config["global_step"]
+
+    if args.model_name_or_path in pretrained_models_list:
+        model_config = model_class.pretrained_init_configuration[
+            args.model_name_or_path]
+        if model_config["vocab_size"] % 8 != 0:
+            model_config["vocab_size"] += 8 - (model_config["vocab_size"] % 8)
+        model_config["hidden_dropout_prob"] = args.hidden_dropout_prob
+        model_config[
+            "attention_probs_dropout_prob"] = args.attention_probs_dropout_prob
+        model = model_class(base_class(**model_config))
+    else:
+        model = model_class.from_pretrained(
+            args.model_name_or_path,
+            hidden_dropout_prob=args.hidden_dropout_prob,
+            attention_probs_dropout_prob=args.attention_probs_dropout_prob)
+
+    criterion = criterion_class()
+
+    # Create the learning_rate sheduler and optimizer
+    if args.decay_steps is None:
+        args.decay_steps = args.max_steps
+
+    lr_scheduler = LinearDecayWithWarmup(
+        args.max_lr, args.max_steps, args.warmup_rate, last_epoch=global_step)
+
+    clip = None
+    if args.grad_clip > 0:
+        clip = paddle.fluid.clip.GradientClipByGlobalNorm(
+            clip_norm=args.grad_clip)
+
+    decay_param = [
+        p.name for n, p in model.named_parameters()
+        if not any(nd in n for nd in ["bias", "norm"])
+    ]
+    logger.info("Using paddle.optimizer.AdamW.")
+    optimizer = paddle.optimizer.AdamW(
+        learning_rate=lr_scheduler if lr_scheduler is not None else args.max_lr,
+        beta1=args.adam_beta1,
+        beta2=args.adam_beta2,
+        epsilon=args.adam_epsilon,
+        parameters=model.parameters(),
+        weight_decay=args.weight_decay,
+        grad_clip=clip,
+        apply_decay_param_fun=lambda x: x in decay_param,
+        multi_precision=args.use_amp)
+
+    if args.use_amp:
+        scaler = paddle.amp.GradScaler(init_loss_scaling=args.scale_loss)
+        scaler = fleet.distributed_scaler(scaler)
+        model = paddle.amp.decorate(
+            models=model, level='O2', save_dtype='float32')
+
+    if paddle.distributed.get_world_size() > 1:
+        model = fleet.distributed_model(model)
+        optimizer = fleet.distributed_optimizer(optimizer)
+
+    tokenizer = tokenizer_class.from_pretrained(args.model_name_or_path)
+
+    data_file = get_train_data_file(args)
+
+    train_data_loader, valid_data_loader, test_data_loader = create_pretrained_dataset(
+        args,
+        data_file,
+        tokenizer,
+        data_world_size=topo.data_info.size,
+        data_world_rank=topo.data_info.rank,
+        max_seq_len=args.max_seq_len,
+        current_step=global_step)
+
+    # load checkpoint vars 
+    if os.path.exists(checkpoint_dir):
+        if os.path.isfile(os.path.join(checkpoint_dir, "./config.yml")):
+            logger.info("Try to load checkpoint from %s " % checkpoint_dir)
+            opt_path = os.path.join(checkpoint_dir, "model_state.pdopt")
+            params_path = os.path.join(checkpoint_dir, "model_state.pdparams")
+
+            if os.path.exists(opt_path):
+                opt_dict = paddle.load(opt_path)
+                optimizer.set_state_dict(opt_dict)
+                model_dict = paddle.load(params_path)
+                model.set_state_dict(model_dict)
+            else:
+                logger.warning("No optimizer checkpoint file found in %s." %
+                               opt_path)
+            logger.info("Checkpoint loaded from global step: {}".format(
+                global_step))
+
+    tic_train = time.time()
+    while True:
+        # If not call valid_data_loader, the enumerate will call valid_data_loader
+        # many times. and start a new random dataloader.
+        valid_data_loader = valid_data_loader()
+        test_data_loader = test_data_loader()
+
+        # time count
+        train_reader_cost = 0.0
+        train_run_cost = 0.0
+        reader_start = time.time()
+
+        for step, batch in enumerate(train_data_loader()):
+            train_reader_cost += time.time() - reader_start
+            train_start = time.time()
+
+            # 0. input_ids,
+            # 1. segment_ids,
+            # 2. input_mask,
+            # 3. masked_lm_positions,
+            # 4. masked_lm_labels,
+            # 5. next_sentence_labels
+
+            input_ids, segment_ids, input_mask, masked_lm_positions, \
+            masked_lm_labels, next_sentence_labels = batch
+
+            with paddle.amp.auto_cast(
+                    args.use_amp,
+                    custom_black_list=[
+                        "reduce_sum", "c_softmax_with_cross_entropy",
+                        "elementwise_div"
+                    ],
+                    level='O2'):
+
+                # Create the model for the ernie pretrain
+                prediction_scores, seq_relationship_score = model(
+                    input_ids=input_ids,
+                    token_type_ids=segment_ids,
+                    position_ids=None,
+                    attention_mask=input_mask,
+                    masked_positions=masked_lm_positions)
+
+                lm_loss, sop_loss = criterion(
+                    prediction_scores, seq_relationship_score, masked_lm_labels,
+                    next_sentence_labels)
+                loss = lm_loss + sop_loss
+
+            if args.use_amp:
+                scaler.scale(loss).backward()
+                scaler.minimize(optimizer, loss)
+            else:
+                loss.backward()
+                optimizer.step()
+
+            optimizer.clear_grad()
+            train_run_cost += time.time() - train_start
+
+            # Skip for accumulate_steps in global step
+            if (step + 1) % args.accumulate_steps != 0:
+                continue
+
+            global_step += 1
+
+            if global_step % args.logging_freq == 0:
+                if topo.is_last:
+                    speed = args.logging_freq / (time.time() - tic_train)
+                    common_loginfo = "global step %d, loss: %.9f, lm_loss: %.6f, sop_loss: %.6f, speed: %.2f steps/s, ips: %.2f seqs/s, learning rate: %.5e" % (
+                        global_step, loss.item(), lm_loss.item(),
+                        sop_loss.item(), speed, speed * args.global_batch_size,
+                        lr_scheduler.get_lr())
+                    addition_info = ""
+                    if args.use_amp:
+                        addition_info = " loss_scaling: %.1f, incr_count: %d, decr_count: %d" % (
+                            scaler._scale.numpy(), scaler._incr_count,
+                            scaler._decr_count)
+                    logger.info(common_loginfo + addition_info)
+                    log_writer.add_scalar("loss", loss.item(), global_step)
+                    log_writer.add_scalar("lm_loss",
+                                          lm_loss.item(), global_step)
+                    log_writer.add_scalar("sop_loss",
+                                          sop_loss.item(), global_step)
+
+                tic_train = time.time()
+
+            if lr_scheduler is not None:
+                lr_scheduler.step()
+
+            if global_step % args.eval_freq == 0:
+                # TODO, check the input data of validation
+                eval_fetch = []
+                if topo.is_last:
+                    eval_fetch = [loss, lm_loss, sop_loss]
+
+                run_evaluate(valid_data_loader, model, criterion,
+                             args.eval_iters, log_writer, global_step, args,
+                             topo.is_last, eval_fetch, "valid")
+                tic_train = time.time()
+
+            def save_ckpt(output_dir, model, tokenizer, args, global_step):
+                step_config = {
+                    "model_name": args.model_name_or_path,
+                    "global_step": global_step,
+                    "global_batch_size": args.global_batch_size,
+                    "consumed_samples": global_step * args.global_batch_size,
+                }
+
+                logger.debug("saving models to {}".format(output_dir))
+                model_to_save = model._layers if isinstance(
+                    model, paddle.DataParallel) else model
+
+                model_to_save.save_pretrained(output_dir)
+                tokenizer.save_pretrained(output_dir)
+                paddle.save(optimizer.state_dict(),
+                            os.path.join(output_dir, "model_state.pdopt"))
+
+                with open(os.path.join(output_dir, "config.yml"), "w") as f:
+                    yaml.dump(
+                        step_config, f, encoding='utf-8', allow_unicode=True)
+
+            if global_step % args.save_steps == 0 or global_step >= args.max_steps:
+                output_dir = os.path.join(args.output_dir,
+                                          "model_%d" % global_step)
+                if worker_index == 0:
+                    save_ckpt(output_dir, model, tokenizer, args, global_step)
+
+                if worker_num > 1:
+                    paddle.distributed.barrier()
+                tic_train = time.time()
+
+            if global_step % args.checkpoint_steps == 0:
+                output_dir = os.path.join(args.output_dir, "model_last")
+                if worker_index == 0:
+                    if not os.path.exists(output_dir):
+                        os.mkdir(output_dir)
+                    output_dir_bak = os.path.join(args.output_dir,
+                                                  "model_last_bak")
+                    if os.path.exists(output_dir):
+                        if os.path.exists(output_dir_bak):
+                            shutil.rmtree(output_dir_bak)
+                        shutil.move(output_dir, output_dir_bak)
+                        os.mkdir(output_dir)
+                    save_ckpt(output_dir, model, tokenizer, args, global_step)
+
+                if worker_num > 1:
+                    paddle.distributed.barrier()
+
+            if global_step >= args.max_steps:
+                run_evaluate(test_data_loader, model, criterion,
+                             args.test_iters, log_writer, global_step, args,
+                             topo.is_last, eval_fetch, "test")
+                del train_data_loader
+                return
+
+
+if __name__ == "__main__":
+    config = parse_args(MODEL_CLASSES)
+    do_train(config)

--- a/examples/language_model/ernie-1.0/run_pretrain.py
+++ b/examples/language_model/ernie-1.0/run_pretrain.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Pretrain  ERNIE in dygraph mode.
+ERNIE-1.0 pretraining scripts.
 """
 import argparse
 import os

--- a/examples/language_model/ernie-1.0/run_pretrain_static.py
+++ b/examples/language_model/ernie-1.0/run_pretrain_static.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Pretrain  ERNIE in static graph mode.
+ERNIE pretraining scripts for paddlepaddle static graph mode.
 """
 import argparse
 import math
@@ -43,7 +43,7 @@ from visualdl import LogWriter
 
 from args import parse_args
 import sys
-sys.path.insert(0, "../")
+sys.path.insert(0, os.path.abspath("../"))
 from data_tools.dataset_utils import build_train_valid_test_datasets
 
 MODEL_CLASSES = {

--- a/examples/language_model/ernie-1.0/run_pretrain_static.py
+++ b/examples/language_model/ernie-1.0/run_pretrain_static.py
@@ -669,5 +669,9 @@ def do_train(args):
 
 
 if __name__ == "__main__":
-    config = parse_args(MODEL_CLASSES)
-    do_train(config)
+    args = parse_args(MODEL_CLASSES)
+    logger.info('{:20}:{}'.format("paddle commit id", paddle.version.commit))
+    for arg in vars(args):
+        logger.info('{:20}:{}'.format(arg, getattr(args, arg)))
+
+    do_train(args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Add ernie-1.0 dygraph training script.

目前支持了Pure FP16，暂未支持Sharing，后续支持。

#### 速度对比

Paddle版本： Paddle 2.2.2 or develop (pure fp16)
设备：V100 16G
配置:  max_seq_len=128

单位 seq/s | AMP(bs=128) static | AMP(bs=128) dygraph | Pure FP16(bs=128) dygraph | Pure FP16(bs=256) dygraph | FP32(bs=64) static | FP32(bs=64) dygraph
-- | -- | -- | -- | -- | -- | --
ERNIE | 666.11 | 455.23 | 546.16 | 639.26 | 163.68 | 161.49
BERT | 661.30 | 444.20 |   |   | 161.07 | 161.78


结论：
1. AMP情况下 ERNIE 动态训练速度与 BERT 基本一致(符合预期)，但与静态图差距较大。(可能与AMP黑白名单差异有关)
2. Pure FP16 并加大 batch size的情况下，动态图速度基本可以持平静态图。训练脚本默认使用 Pure FP16。


### 训练效果对比
数据集：ClueCorpusSmall 14G
训练配置：batch_size 512, step 100w, lr 1e-4
训练脚本：
```shell
python -u  -m paddle.distributed.launch \
    --gpus "0,1,2,3,4,5,6,7" \
    --log_dir "output/ernie-1.0-dp8-gb512/log" \
    run_pretrain.py \
    --model_type "ernie" \
    --model_name_or_path "ernie-1.0" \
    --input_dir "./data" \
    --output_dir "output/ernie-1.0-dp8-gb512" \
    --max_seq_len 512 \
    --micro_batch_size 64 \
    --global_batch_size 512 \
    --use_amp true \
    --max_lr 0.0001 \
    --min_lr 0.00001 \
    --max_steps 1000000 \
    --save_steps 50000 \
    --checkpoint_steps 5000 \
    --decay_steps 990000 \
    --weight_decay 0.01 \
    --warmup_rate 0.01 \
    --grad_clip 1.0 \
    --logging_freq 20\
    --num_workers 2 \
    --eval_freq 1000 \
    --device "gpu"\
```
CLUE评估结果：

Model | Arch | CLUE 平均值 |  AFQMC | TNEWS | IFLYTEK | CMNLI | OCNLI | CLUEWSC2020 | CSL
-- | -- | -- | -- | -- | -- | -- |  -- | -- | --
Metrics |   |   |   | Acc | Acc | Acc | Acc | Acc | Acc | Acc
ERNIE-1.0 Base | 12L768H | 73.78 |  74.95 | 58.73 | 61.37 | 81.77 | 75.46 | 81.25 | 82.93
ERINE-1.0-cluecorpussmall | 12L768H | 73.24(-0.54) | 74.26 | 57.24 | 60.79 | 81.15 | 76.64 | 81.25 | 81.33
