### PR TITLE
disable use_pos for segmented inputs

### DIFF
--- a/paddlenlp/taskflow/dependency_parsing.py
+++ b/paddlenlp/taskflow/dependency_parsing.py
@@ -192,6 +192,8 @@ class DDParserTask(Task):
         return inputs
 
     def from_segments(self, segmented_words):
+        # pos tag is not available for segmented inputs
+        self.use_pos = False
         segmented_words = self._check_segmented_words(segmented_words)
         inputs = {}
         inputs['words'] = segmented_words

--- a/paddlenlp/taskflow/utils.py
+++ b/paddlenlp/taskflow/utils.py
@@ -105,10 +105,10 @@ def cut_chinese_sent(para):
     """
     Cut the Chinese sentences more precisely, reference to "https://blog.csdn.net/blmoistawinde/article/details/82379256".
     """
-    para = re.sub('([。！？\?])([^”’])', r"\1\n\2", para)
-    para = re.sub('(\.{6})([^”’])', r"\1\n\2", para)
-    para = re.sub('(\…{2})([^”’])', r"\1\n\2", para)
-    para = re.sub('([。！？\?][”’])([^，。！？\?])', r'\1\n\2', para)
+    para = re.sub(r'([。！？\?])([^”’])', r'\1\n\2', para)
+    para = re.sub(r'(\.{6})([^”’])', r'\1\n\2', para)
+    para = re.sub(r'(\…{2})([^”’])', r'\1\n\2', para)
+    para = re.sub(r'([。！？\?][”’])([^，。！？\?])', r'\1\n\2', para)
     para = para.rstrip()
     return para.split("\n")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
1.句法分析任务使用已分词模式进行输入时use_pos参数无效，不返回词性标签
2.去除正则表达式引入的DeprecationWarning