### PR TITLE
Fix the readthedocs display error

### DIFF
--- a/docs/model_zoo/taskflow.md
+++ b/docs/model_zoo/taskflow.md
@@ -1,9 +1,7 @@
-<div align="center">  
-  <h1> PaddleNLP 一键预测功能 </h1>
-</div>
+# PaddleNLP一键预测功能：Taskflow API
 
 
-<p align="center">
+<p align="left">
     <a href="https://pypi.org/project/paddlenlp/"><img src="https://img.shields.io/pypi/v/paddlenlp.svg?label=pip&logo=PyPI&logoColor=white"></a>
     <a href="https://github.com/PaddlePaddle/PaddleNLP/releases"><img src="https://img.shields.io/github/v/release/PaddlePaddle/PaddleNLP?color=ffa"></a>
     <a href="https://pypi.org/project/paddlenlp/"><img src="https://img.shields.io/pypi/pyversions/paddlenlp"></a>
@@ -12,7 +10,7 @@
 </p>
 
 
-<h4 align="center">
+<h4 align="left">
   <a href=#QuickStart> QuickStart </a> |
   <a href=#社区交流> 社区交流 </a> |
   <a href=#详细使用> 一键预测&定制训练 </a> |


### PR DESCRIPTION
Fix the readthedocs display error caused by lacking of main heading H1.

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
