### PR TITLE
Change data dtype from generator to list 

### DIFF
--- a/examples/simultaneous_translation/stacl/reader.py
+++ b/examples/simultaneous_translation/stacl/reader.py
@@ -171,7 +171,7 @@ def prepare_train_input(insts, pad_idx):
     """
     word_pad = Pad(pad_idx)
     src_word = word_pad([inst[0] for inst in insts])
-    trg_word = word_pad(inst[1][:-1] for inst in insts)
+    trg_word = word_pad([inst[1][:-1] for inst in insts])
     lbl_word = word_pad([inst[1][1:] for inst in insts])
     data_inputs = [src_word, trg_word, lbl_word]
 
@@ -183,7 +183,7 @@ def prepare_infer_input(insts, pad_idx):
     Put all padded data needed by beam search decoder into a list.
     """
     word_pad = Pad(pad_idx)
-    src_word = word_pad(inst[0] for inst in insts)
+    src_word = word_pad([inst[0] for inst in insts])
 
     return [src_word, ]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Examples
### Description
<!-- Describe what this PR does -->
PAD要求数据类型为list/numpy，传入generator也可以正常跑通，现在data/collate.py增加了类型判断，导致不过。所以修改数据类型为list