### PR TITLE
fix data collator for stsb

### DIFF
--- a/paddlenlp/data/collate.py
+++ b/paddlenlp/data/collate.py
@@ -403,7 +403,9 @@ class DataCollatorWithPadding:
                                    pad_val=self.tokenizer.pad_token_id,
                                    dtype='int64')([d[k] for d in data])
                 else:
-                    batch[k] = Stack()([d[k] for d in data])
+                    dtype = 'int64' if type(v) is int else 'float32'
+                    batch[k] = Stack(dtype=dtype)([d[k] for d in data])
+
         if self.return_tensors:
             for k, v in batch.items():
                 batch[k] = paddle.to_tensor(v)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Stack的默认dtype是float64，传入loss会有问题，导致glue stsb训练报错。于是在DataCollatorWithPadding中指定了dtype
