### PR TITLE
Use functools to replace importlib_metadata.functools to avoid extra dependency

### DIFF
--- a/paddlenlp/ops/faster_transformer/transformer/decoding.py
+++ b/paddlenlp/ops/faster_transformer/transformer/decoding.py
@@ -14,7 +14,7 @@
 from collections import defaultdict
 from contextlib import contextmanager
 import os
-from importlib_metadata import functools
+import functools
 import numpy as np
 from functools import partial
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Use functools to replace importlib_metadata.functools to avoid extra dependency.  ` importlib_metadata.functools ` is import by IDE automatically..