### PR TITLE
Improve the encode_batch performance in faster tokenizers

### DIFF
--- a/faster_tokenizers/faster_tokenizers/src/core/tokenizer.cc
+++ b/faster_tokenizers/faster_tokenizers/src/core/tokenizer.cc
@@ -242,9 +242,9 @@ void Tokenizer::EncodeBatchStrings(
     bool add_special_tokens,
     std::vector<Encoding>* encodings) const {
   encodings->resize(batch_encode_input.size());
-#ifdef WITH_OMP
-#pragma omp parallel for
-#endif
+  // #ifdef WITH_OMP
+  // #pragma omp parallel for
+  // #endif
   for (int i = 0; i < batch_encode_input.size(); ++i) {
     EncodePairStrings(
         batch_encode_input[i], add_special_tokens, &(*encodings)[i]);
@@ -278,9 +278,9 @@ void Tokenizer::EncodeBatchStringsCharOffsets(
     bool add_special_tokens,
     std::vector<Encoding>* encodings) const {
   encodings->resize(batch_encode_input.size());
-#ifdef WITH_OMP
-#pragma omp parallel for
-#endif
+  // #ifdef WITH_OMP
+  // #pragma omp parallel for
+  // #endif
   for (int i = 0; i < batch_encode_input.size(); ++i) {
     Encoding encoding;
     EncodePairStringsCharOffsets(

--- a/faster_tokenizers/faster_tokenizers/src/pybind/tokenizers.cc
+++ b/faster_tokenizers/faster_tokenizers/src/pybind/tokenizers.cc
@@ -541,7 +541,7 @@ static PyObject* EnableTruncation(TokenizerObject* self,
   std::string strategy = "longest_first";
   std::string direction = "right";
 
-  if (args_num >= (Py_ssize_t)1 && args_num <= (Py_ssize_t)4) {
+  if (args_num >= (Py_ssize_t)0 && args_num <= (Py_ssize_t)4) {
     max_length = CastPyArg2AttrSize_t(kw_max_length, 0);
     if ((args_num <= 1 && flag_kwargs && kw_stride) || (args_num >= 2)) {
       stride = CastPyArg2AttrSize_t(kw_stride, 1);

--- a/faster_tokenizers/faster_tokenizers/src/pybind/tokenizers.cc
+++ b/faster_tokenizers/faster_tokenizers/src/pybind/tokenizers.cc
@@ -793,14 +793,16 @@ static PyObject* EncodeBatch(TokenizerObject* self,
   bool add_special_tokens = true;
   bool is_pretokenized = false;
   Py_ssize_t args_num = PyTuple_Size(args);
+  VLOG(6) << " args_num: " << args_num << ", flag_kwargs: " << flag_kwargs
+          << ", flag_: " << flag_;
   std::vector<core::EncodeInput> batch_encode_input;
   if (args_num >= (Py_ssize_t)1 && args_num <= (Py_ssize_t)3) {
     if ((args_num <= 1 && flag_kwargs && kw_special_tokens) ||
         (args_num >= 2)) {
       add_special_tokens = CastPyArg2AttrBoolean(kw_special_tokens, 1);
     }
-    if (args_num == 2 || (kw_is_pretokenized && flag_kwargs)) {
-      is_pretokenized = CastPyArg2AttrBoolean(kw_is_pretokenized, 1);
+    if ((args_num <= 2 && kw_is_pretokenized && flag_kwargs) || args_num == 3) {
+      is_pretokenized = CastPyArg2AttrBoolean(kw_is_pretokenized, 2);
     }
     if (PyList_Check(kw_input)) {
       Py_ssize_t list_size = PyList_Size(kw_input);
@@ -847,7 +849,7 @@ static PyObject* EncodeBatch(TokenizerObject* self,
       }
     } else {
       std::ostringstream oss;
-      oss << "Expected the input argument, but not pass.";
+      oss << "Expected the type of input argument is list";
       throw std::runtime_error(oss.str());
     }
     std::vector<core::Encoding> result_encodings;

--- a/faster_tokenizers/python/faster_tokenizers/tokenizers_impl/base_tokenizer.py
+++ b/faster_tokenizers/python/faster_tokenizers/tokenizers_impl/base_tokenizer.py
@@ -91,13 +91,14 @@ class BaseFasterTokenizer:
         return self._tokenizer.encode(sequence, pair, is_pretokenized,
                                       add_special_tokens)
 
-    def encode_batch(
-            self,
-            inputs,
-            add_special_tokens=True, ):
+    def encode_batch(self,
+                     inputs,
+                     add_special_tokens=True,
+                     is_pretokenized=False):
         if inputs is None:
             raise ValueError("encode_batch: `inputs` can't be `None`")
-        return self._tokenizer.encode_batch(inputs, add_special_tokens)
+        return self._tokenizer.encode_batch(inputs, add_special_tokens,
+                                            is_pretokenized)
 
     def token_to_id(self, token):
         return self._tokenizer.token_to_id(token)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
1. Remove OMP **temporarily** because it has huge cost in gomp_thread_start, especially when batch size of strings is small.
![image](https://user-images.githubusercontent.com/10826371/167538114-4d83395b-0789-46f0-a26d-dad69a3c79b8.png)
2.  Add is_pretokenized args in encode_batch of faster_tokenizer.