### PR TITLE
Update roformerv2 tokenizer's token_type_ids

### DIFF
--- a/paddlenlp/transformers/roformerv2/tokenizer.py
+++ b/paddlenlp/transformers/roformerv2/tokenizer.py
@@ -254,7 +254,7 @@ class RoFormerv2Tokenizer(PretrainedTokenizer):
         A RoFormerv2 sequence pair mask has the following format:
         ::
 
-            0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+            0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1
             | first sequence    | second sequence |
 
         If `token_ids_1` is `None`, this method only returns the first portion of the mask (0s).
@@ -273,7 +273,7 @@ class RoFormerv2Tokenizer(PretrainedTokenizer):
         if token_ids_1 is None:
             return len(_cls + token_ids_0 + _sep) * [0]
         return len(_cls + token_ids_0 + _sep) * [0] + len(token_ids_1 +
-                                                          _sep) * [0]
+                                                          _sep) * [1]
 
     def get_special_tokens_mask(self,
                                 token_ids_0,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs 
### Description
<!-- Describe what this PR does -->
修改roformerv2的tokenizer中的token_type_ids。
当输入text和text pair时，返回如下形式。
```text
0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1
| first sequence    | second sequence |
```