### PR TITLE
[duee] modify the default path to DuEE-fin

### DIFF
--- a/examples/information_extraction/DuEE/README.md
+++ b/examples/information_extraction/DuEE/README.md
@@ -51,8 +51,8 @@ f1_score = (2 * P * R) / (P + R)，其中
 
 ### 快速复现基线Step1：数据预处理并加载
 
-从比赛官网下载数据集，解压存放于data/DuEE-Fin目录下，将原始数据预处理成序列标注格式数据。
-处理之后的数据同样放在data/DuEE-Fin下，触发词识别数据文件存放在data/DuEE-Fin/role下，论元角色识别数据文件存放在data/DuEE-Fin/trigger下。
+从比赛官网下载数据集，逐层解压存放于data/DuEE-fin目录下，运行以下脚本将原始数据预处理成序列标注格式数据。
+处理之后的数据放在data/DuEE-Fin下，触发词识别数据文件存放在data/DuEE-Fin/role下，论元角色识别数据文件存放在data/DuEE-Fin/trigger下。
 枚举分类数据存放在data/DuEE-Fin/enum下。
 
 ```

--- a/examples/information_extraction/DuEE/duee_fin_data_prepare.py
+++ b/examples/information_extraction/DuEE/duee_fin_data_prepare.py
@@ -217,7 +217,9 @@ if __name__ == "__main__":
     # schema process
     print("\n=================DUEE FINANCE DATASET==============")
     conf_dir = "./conf/DuEE-Fin"
-    schema_path = "{}/event_schema.json".format(conf_dir)
+    if not os.path.exists(conf_dir):
+        os.makedirs(conf_dir)
+    schema_path = "./data/DuEE-fin/duee_fin_event_schema.json"
     tags_trigger_path = "{}/trigger_tag.dict".format(conf_dir)
     tags_role_path = "{}/role_tag.dict".format(conf_dir)
     tags_enum_path = "{}/enum_tag.dict".format(conf_dir)
@@ -245,11 +247,14 @@ if __name__ == "__main__":
     print("\n********** start document process **********")
     if not os.path.exists(sentence_dir):
         os.makedirs(sentence_dir)
-    train_sent = docs_data_process("{}/duee_fin_train.json".format(data_dir))
+    train_sent = docs_data_process(
+        "./data/DuEE-fin/duee_fin_train.json/duee_fin_train.json")
     write_by_lines("{}/train.json".format(sentence_dir), train_sent)
-    dev_sent = docs_data_process("{}/duee_fin_dev.json".format(data_dir))
+    dev_sent = docs_data_process(
+        "./data/DuEE-fin/duee_fin_dev.json/duee_fin_dev.json")
     write_by_lines("{}/dev.json".format(sentence_dir), dev_sent)
-    test_sent = docs_data_process("{}/duee_fin_test1.json".format(data_dir))
+    test_sent = docs_data_process(
+        "./data/DuEE-fin/duee_fin_test2.json/duee_fin_test2.json")
     write_by_lines("{}/test.json".format(sentence_dir), test_sent)
     print("train {} dev {} test {}".format(
         len(train_sent), len(dev_sent), len(test_sent)))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- Modify the default path to ``DuEE-fin`` dataset to avoid ``FileNotFoundError``  when the files are not carefully renamed.