### PR TITLE
fix bug: add parameter encoding='utf-8'  while opening vocab.bpe

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -1645,7 +1645,7 @@ class BPETokenizer(PretrainedTokenizer):
     def _get_encoder(self, encoder_json_path, vocab_bpe_path):
         with open(encoder_json_path, 'r') as f:
             encoder = json.load(f)
-        with open(vocab_bpe_path, 'r') as f:
+        with open(vocab_bpe_path, 'r', encoding='utf-8') as f:
             bpe_data = f.read()
         bpe_merges = [
             tuple(merge_str.split()) for merge_str in bpe_data.split('\n')[1:-1]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
APIs 

### Description
Though python3 set default IO encoding to utf-8,  some windows users still have other default IO encoding setting (e.g.  cp1252),  which causes problem when open 'vocab.bpe' file. It's better to call open() with an explicit parameter, encoding='utf-8'.
