### PR TITLE
Replace the deprecated parameter in NPTag

### DIFF
--- a/examples/text_to_knowledge/nptag/data.py
+++ b/examples/text_to_knowledge/nptag/data.py
@@ -59,7 +59,7 @@ def convert_example(example,
         tokens,
         return_length=True,
         is_split_into_words=True,
-        max_seq_len=max_seq_len)
+        max_length=max_seq_len)
 
     label_indices = list(
         range(inputs["seq_len"] - 1 - max_cls_len, inputs["seq_len"] - 1))

--- a/paddlenlp/taskflow/knowledge_mining.py
+++ b/paddlenlp/taskflow/knowledge_mining.py
@@ -296,7 +296,7 @@ class WordTagTask(Task):
                     list(text),
                     return_length=True,
                     is_split_into_words=True,
-                    max_seq_len=self._max_seq_len)
+                    max_length=self._max_seq_len)
                 yield tokenized_output['input_ids'], tokenized_output[
                     'token_type_ids'], tokenized_output['seq_len']
 
@@ -689,7 +689,7 @@ class NPTagTask(Task):
                     tokens,
                     return_length=True,
                     is_split_into_words=True,
-                    max_seq_len=self._max_seq_len)
+                    max_length=self._max_seq_len)
                 label_indices = list(
                     range(tokenized_output["seq_len"] - 1 - self._max_cls_len,
                           tokenized_output["seq_len"] - 1))

--- a/paddlenlp/utils/downloader.py
+++ b/paddlenlp/utils/downloader.py
@@ -403,7 +403,9 @@ class DownloaderCheck(threading.Thread):
             extra.update({"addition": addition})
         try:
             import paddle
+            import paddlenlp
             payload['hub_version'] = " "
+            payload['ppnlp_version'] = paddlenlp.__version__
             payload['paddle_version'] = paddle.__version__.split('-')[0]
             payload['from'] = 'ppnlp'
             payload['extra'] = json.dumps(extra)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
- Replace the deprecated parameter `max_seq_len` with `max_length` for Tokenizer
- Add paddlenlp version check