### PR TITLE
[PreTraining] Add ernie-1.0-large-zh pretrained weight

### DIFF
--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -146,6 +146,20 @@ class ErniePretrainedModel(PretrainedModel):
             "vocab_size": 18000,
             "pad_token_id": 0,
         },
+        "ernie-1.0-large-zh": {
+            "attention_probs_dropout_prob": 0.1,
+            "hidden_act": "relu",
+            "hidden_dropout_prob": 0.1,
+            "hidden_size": 1024,
+            "initializer_range": 0.02,
+            "intermediate_size": 3072,  # it is 3072 instead of 4096
+            "max_position_embeddings": 512,
+            "num_attention_heads": 16,
+            "num_hidden_layers": 24,
+            "type_vocab_size": 2,
+            "vocab_size": 18000,
+            "pad_token_id": 0,
+        },
         "ernie-tiny": {
             "attention_probs_dropout_prob": 0.1,
             "hidden_act": "relu",
@@ -401,6 +415,8 @@ class ErniePretrainedModel(PretrainedModel):
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/ernie_v1_chn_base.pdparams",
             "ernie-1.0-base-zh":
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/ernie_v1_chn_base.pdparams",
+            "ernie-1.0-large-zh":
+            "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/ernie_1.0_large_zh.pdparams",
             "ernie-tiny":
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie_tiny/ernie_tiny.pdparams",
             "ernie-2.0-base-zh":

--- a/paddlenlp/transformers/ernie/tokenizer.py
+++ b/paddlenlp/transformers/ernie/tokenizer.py
@@ -83,6 +83,8 @@ class ErnieTokenizer(PretrainedTokenizer):
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/vocab.txt",
             "ernie-1.0-base-zh":
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/vocab.txt",
+            "ernie-1.0-large-zh":
+            "https://bj.bcebos.com/paddlenlp/models/transformers/ernie/vocab.txt",
             "ernie-tiny":
             "https://bj.bcebos.com/paddlenlp/models/transformers/ernie_tiny/vocab.txt",
             "ernie-2.0-base-zh":
@@ -132,6 +134,9 @@ class ErnieTokenizer(PretrainedTokenizer):
             "do_lower_case": True
         },
         "ernie-1.0-base-zh": {
+            "do_lower_case": True
+        },
+        "ernie-1.0-large-zh": {
             "do_lower_case": True
         },
         "ernie-tiny": {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
Add `ernie-1.0-large-zh` model pretrained weight.

#### 使用grid_search 的最优结果
 NAME | AVG_CLS | AFQMC | TNEWS | IFLYTEK | CMNLI | OCNLI | CLUEWSC2020 | CSL  | CMRC2018 | CHID | C3 | ALL_AVG
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- 
`ernie-1.0-large-zh` | 77.94 | 76.74 | 59.71 | 62.87 | 85.18 | 82.27 | 93.75 | 85.07 | 73.13 /91.78 | 88.37 | 84.51 | 79.16

#### 对应最优参数
NAME | AFQMC | TNEWS | IFLYTEK | CMNLI | OCNLI | CLUEWSC2020 | CSL  | CMRC2018 | CHID | C3
-- | --  | -- | -- | -- | -- | -- | -- | -- | -- | -- 
最优参数 |  2e-05_64 | 3e-05_32 | 5e-05_16 | 2e-05_16 | 2e-05_32 | 1e-05_32 | 1e-05_16 |  2e-05_24 |  1e-05_24 | 2e-05_32

#### 使用最优参数复测效果
 NAME | AVG_CLS | AFQMC | TNEWS | IFLYTEK | CMNLI | OCNLI | CLUEWSC2020 | CSL  | CMRC2018 | CHID | C3 | ALL_AVG
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- 
`ernie-1.0-large-zh` | 77.57 | 75.97 | 59.65 | 62.91 | 85.09 | 81.73 | 93.09 | 84.53 |  74.22/91.88 | 88.57 | 84.54 | 79.03
`RoBERTa-wwm-ext-large` | 76.36 | 76.00 | 59.33 | 62.02 | 83.88 | 78.81 | 90.79 | 83.67 | 70.58/89.82 | 85.72 | 75.26 | 76.61

 对比`RoBERTa-wwm-ext-large`：
1. `ernie-1.0-large-zh`分类任务平均高**1.21**个百分点。
2. `ernie-1.0-large-zh`分类+阅读理解任务，平均高**2.42**个百分点。