### PR TITLE
Change ernie-3.0-xbase-zh dropout to 0.1

### DIFF
--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -318,9 +318,9 @@ class ErniePretrainedModel(PretrainedModel):
             "pad_token_id": 0,
         },
         "ernie-3.0-xbase-zh": {
-            "attention_probs_dropout_prob": 0.0,
+            "attention_probs_dropout_prob": 0.1,
             "hidden_act": "gelu",
-            "hidden_dropout_prob": 0.0,
+            "hidden_dropout_prob": 0.1,
             "intermediate_size": 4096,  # special for large model
             "hidden_size": 1024,
             "initializer_range": 0.02,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Change ernie-3.0-xbase-zh dropout to 0.1

 NAME | AVG_CLS | AFQMC | TNEWS | IFLYTEK | CMNLI | OCNLI | CLUEWSC2020 | CSL
-- | -- | -- | -- | -- | -- | -- | -- | --
ERNIE-3.0-xbase-NLP | 77.42 | 76.95 | 60.34 | 62.22 | 84.98 | 82.07 | 91.12 | 84.27
ERNIE-3.0-xbase-Paddle-Dropout | 77.24 | 76.85 | 59.89 | 62.41 | 84.76 | 82.51 | 89.80 | 84.47
ERNIE-3.0-xbase-Paddle | 76.96 | 76.88 | 60.48 | 61.60 | 84.87 | 81.97 | 88.49 | 84.43

第一行为ERNIE report结果，第二行为Paddle复现`dropout=0.1`结果，第三行为Paddle复现`dropout=0.0`结果
与ERNIE report结果主要差异在`CLUEWSC2020`数据集。

`IFLYTEK`，`CLUEWSC2020` 数据集在开启dropout时候效果会更好。此PR更改默认设置`dropout=0.1`。