### PR TITLE
fix output dtype of ddparser

### DIFF
--- a/paddlenlp/taskflow/dependency_parsing.py
+++ b/paddlenlp/taskflow/dependency_parsing.py
@@ -337,7 +337,7 @@ class DDParserTask(Task):
         arcs = inputs['arcs']
         rels = inputs['rels']
         words = inputs['words']
-        arcs = [[s for s in seq] for seq in arcs]
+        arcs = [[s.item() for s in seq] for seq in arcs]
         rels = [self.rel_vocab.to_tokens(seq) for seq in rels]
 
         results = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
fix output dtype of ddparser, the original output dtype `np.int64` is incompatible with json dumps, convert output dtype to `int`