### PR TITLE
Add ernie-3.0 mkldnn fp32 and int8 support

### DIFF
--- a/model_zoo/ernie-3.0/infer.py
+++ b/model_zoo/ernie-3.0/infer.py
@@ -121,14 +121,17 @@ def parse_args():
     parser.add_argument(
         "--enable_quantize",
         action='store_true',
-        help="Whether to enable quantization for acceleration. Valid for both onnx and dnnl", )
+        help="Whether to enable quantization for acceleration. Valid for both onnx and dnnl",
+    )
     parser.add_argument(
         "--use_onnxruntime",
         type=distutils.util.strtobool,
         default=False,
         help="Use onnxruntime to infer or not.")
     parser.add_argument(
-        "--debug", action='store_true', help="With debug it will save graph and model after each pass.")
+        "--debug",
+        action='store_true',
+        help="With debug it will save graph and model after each pass.")
     parser.add_argument(
         "--provider",
         default='CPUExecutionProvider',
@@ -223,7 +226,8 @@ class Predictor(object):
             sess_options = ort.SessionOptions()
             sess_options.intra_op_num_threads = args.num_threads
             sess_options.inter_op_num_threads = args.num_threads
-            executionprovider=args.provider
+            executionprovider = args.provider
+            print("ExecutionProvider is: ", executionprovider)
             predictor = ort.InferenceSession(
                 dynamic_quantize_model,
                 sess_options=sess_options,

--- a/model_zoo/ernie-3.0/infer.py
+++ b/model_zoo/ernie-3.0/infer.py
@@ -107,6 +107,7 @@ def parse_args():
         "--collect_shape",
         action='store_true',
         help="Whether to collect shape info.")
+
     parser.add_argument(
         "--precision",
         default="fp32",
@@ -127,9 +128,7 @@ def parse_args():
         default=False,
         help="Use onnxruntime to infer or not.")
     parser.add_argument(
-        "--debug",
-        action='store_true',
-        help="Use onnxruntime to infer or not.")
+        "--debug", action='store_true', help="Use onnxruntime to infer or not.")
     parser.add_argument(
         "--provider",
         default='CPUExecutionProvider',
@@ -245,7 +244,7 @@ class Predictor(object):
             config.disable_gpu()
             config.switch_ir_optim(True)
             config.enable_mkldnn()
-            if args.enable_quantize: 
+            if args.enable_quantize:
                 config.enable_mkldnn_int8()
             if args.debug:
                 config.switch_ir_debug(True)

--- a/model_zoo/ernie-3.0/infer.py
+++ b/model_zoo/ernie-3.0/infer.py
@@ -121,20 +121,20 @@ def parse_args():
     parser.add_argument(
         "--enable_quantize",
         action='store_true',
-        help="Whether to enable quantization for acceleration.", )
+        help="Whether to enable quantization for acceleration. Valid for both onnx and dnnl", )
     parser.add_argument(
         "--use_onnxruntime",
         type=distutils.util.strtobool,
         default=False,
         help="Use onnxruntime to infer or not.")
     parser.add_argument(
-        "--debug", action='store_true', help="Use onnxruntime to infer or not.")
+        "--debug", action='store_true', help="With debug it will save graph and model after each pass.")
     parser.add_argument(
         "--provider",
         default='CPUExecutionProvider',
         choices=['CPUExecutionProvider', 'DnnlExecutionProvider'],
         type=str,
-        help="Onnx with DNNL or without DNNL")
+        help="Onnx ExecutionProvider with DNNL or without DNNL")
 
     args = parser.parse_args()
     return args
@@ -223,6 +223,7 @@ class Predictor(object):
             sess_options = ort.SessionOptions()
             sess_options.intra_op_num_threads = args.num_threads
             sess_options.inter_op_num_threads = args.num_threads
+            executionprovider=args.provider
             predictor = ort.InferenceSession(
                 dynamic_quantize_model,
                 sess_options=sess_options,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Performance optimization

### PR changes
Others

### Description
Add ernie-3.0 fp32 and int8 mkldnn support. The Paddle need to be after Ernie-3.0 int8 fix [#43297 [Bug fix] Do not quantize weights Y when matmul X and Y both other ops outputs](https://github.com/PaddlePaddle/Paddle/pull/43297). 

