### PR TITLE
Fix bert offset mapping issues

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -1331,8 +1331,8 @@ class PretrainedTokenizer(PretrainedTokenizerBase):
         for i, ch in enumerate(text):
             if hasattr(self, "do_lower_case") and self.do_lower_case:
                 ch = ch.lower()
-                ch = unicodedata.normalize('NFD', ch)
-                ch = ''.join([c for c in ch if unicodedata.category(c) != 'Mn'])
+            ch = unicodedata.normalize('NFD', ch)
+            ch = ''.join([c for c in ch if unicodedata.category(c) != 'Mn'])
 
             ch = ''.join([
                 c for c in ch


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
### Bug 出现原因：
1. Python版本OffsetMapping功能原理：
1.1  使用bert tokenizer 将raw_text切成若干个token（保存在`split_tokens`中，切词中也使用了去除标点等clean_text操作）
1.2  将raw_text遍历每个字符并转换为normalized_text，记录raw_text 中每个char与normalized_text的每个char的映射关系（保存在`char_mapping`中，转换中使用了去除标点等clean_text操作，该clean_text操作必须与1.1的clean_text保持一致）
1.3  遍历`split_tokens`中的每个token，根据`char_mapping` 构造 offset_mapping。
2. Bert等Wordpiece类Tokenizer在切词时**必然**会做去除标点等clean_text，并且会使用`do_lower_case`判断是否进行大小写转换操作；
3. 原offset mapping实现中（1.2步所示），在clean_text中去除标点的操作是经过`do_lower_case`这一flag控制的，这使得在`do_lower_case`为False时，1.1与1.2步的操作有diff，导致get_offset_mapping运行失败。ERNIE中文模型的Tokenizer的`do_lower_case`均为True，而Bert中文模型Tokenizer的`do_lower_case`均为False。所以在ERNIE模型中运行正常，而在BERT模型中运行失败。