### PR TITLE
Update trans_to_json.py

### DIFF
--- a/applications/neural_search/recall/domain_adaptive_pretraining/data_tools/trans_to_json.py
+++ b/applications/neural_search/recall/domain_adaptive_pretraining/data_tools/trans_to_json.py
@@ -78,7 +78,7 @@ def raw_text_to_json(path, doc_spliter="", json_key="text", min_doc_length=10):
     out_filepath = path + ".jsonl"
     fout = open(out_filepath, "w", encoding="utf-8")
     len_files = 0
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         doc = ""
         line = f.readline()
         while line:


### PR DESCRIPTION
Bug fix：如果不加，win报如下错误，加进去就好了。
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 45: illegal multibyte sequence

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
