### PR TITLE
[bugfix] fix tokenizer removing kwargs

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -777,7 +777,7 @@ class PretrainedTokenizer(PretrainedTokenizerBase):
             if token in no_split_token:
                 tokenized_text.append(token)
             else:
-                tokenized_text.extend(self._tokenize(token, **kwargs))
+                tokenized_text.extend(self._tokenize(token))
         # ["This", " is", " something", "<special_token_1>", "else"]
         return tokenized_text
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
- xlm的tokenizer需要[传入`lang`和`bypass_tokenizer`参数](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/paddlenlp/transformers/xlm/tokenizer.py#L783)，所以修改了基类tokenizer_utils的`_tokenize()`方法，但由于其他的模型的`_tokenize()`只接受token这一个参数，导致入参失败。