### PR TITLE
Fix sampling  decoding when model without parallel

### DIFF
--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_sampling.h
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_sampling.h
@@ -135,8 +135,8 @@ public:
     args_.is_mbart_ = is_mbart;
 
     // For models without parallel
-    if(l_parallel_param_.layers_per_group == 0){
-        l_parallel_param_.layers_per_group=decoder_layers;
+    if (l_parallel_param_.layers_per_group == 0) {
+        l_parallel_param_.layers_per_group = decoder_layers;
     }
 
     if (std::is_same<DataType_, float>::value)

--- a/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_sampling.h
+++ b/paddlenlp/ops/patches/FasterTransformer/fastertransformer/decoding_sampling.h
@@ -134,6 +134,11 @@ public:
     args_.prefix_lm_ = prefix_lm;
     args_.is_mbart_ = is_mbart;
 
+    // For models without parallel
+    if(l_parallel_param_.layers_per_group == 0){
+        l_parallel_param_.layers_per_group=decoder_layers;
+    }
+
     if (std::is_same<DataType_, float>::value)
       args_.vocab_size_padded_ = vocab_size;
     else if (std::is_same<DataType_, half>::value)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- 问题：不支持并行推理的模型 sampling decoding时会报`Segmentation fault (core dumped)`错误
- 解决：不支持并行推理的模型`l_parallel_param_.layers_per_group`(默认值为0)应该等于模型层数。
