### PR TITLE
Fix tokenizer padding in GPT-3 static and generation

### DIFF
--- a/examples/language_model/gpt-3/static/run_generation.py
+++ b/examples/language_model/gpt-3/static/run_generation.py
@@ -200,6 +200,7 @@ def do_generation(args):
                 feeds = create_data_holder(args)
                 tokenizer = tokenizer_class.from_pretrained(
                     args.model_name_or_path)
+                tokenizer.pad_token = tokenizer.eos_to_token
                 eos_id = tokenizer.eos_token_id
 
                 _, _, test_data_loader = create_pretrained_dataset(

--- a/examples/language_model/gpt-3/static/run_pretrain_static.py
+++ b/examples/language_model/gpt-3/static/run_pretrain_static.py
@@ -264,6 +264,7 @@ def do_train(args):
 
                 tokenizer = tokenizer_class.from_pretrained(
                     args.model_name_or_path)
+                tokenizer.pad_token = tokenizer.eos_to_token
                 eos_id = tokenizer.eos_token_id
 
                 train_data_loader, valid_data_loader, test_data_loader = create_pretrained_dataset(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
最近升级tokenizer导致，GPT-3的静态图里生成模型和静态图训练因为没有设置padding字符报错。
![截屏2022-06-23 13 51 42](https://user-images.githubusercontent.com/63526175/175228541-159353b9-6822-4f49-a6b9-05667dc309a9.png)

