### PR TITLE
Fix special token settings in PretrainiedTokenizer

### DIFF
--- a/paddlenlp/transformers/ernie_gen/modeling.py
+++ b/paddlenlp/transformers/ernie_gen/modeling.py
@@ -421,7 +421,7 @@ class ErnieGenPretrainedModel(object):
                                  list(self.resource_files_names.values())[0])
         paddle.save(self.state_dict(), file_name)
 
-    def _wrap_init(self, original_init, *args, **kwargs):
+    def _post_init(self, original_init, *args, **kwargs):
         """
         It would be hooked after `__init__` to add a dict including arguments of
         `__init__` as a attribute named `config` of the prtrained model instance.

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -120,7 +120,7 @@ class PretrainedModel(Layer, GenerationMixin):
     pretrained_resource_files_map = {}
     base_model_prefix = ""
 
-    def _wrap_init(self, original_init, *args, **kwargs):
+    def _post_init(self, original_init, *args, **kwargs):
         """
         It would be hooked after `__init__` to add a dict including arguments of
         `__init__` as a attribute named `config` of the pretrained model instance.

--- a/paddlenlp/transformers/tokenizer_utils_base.py
+++ b/paddlenlp/transformers/tokenizer_utils_base.py
@@ -778,23 +778,20 @@ class SpecialTokensMixin:
     ]
 
     def __init__(self, verbose=True, **kwargs):
-        # TODO(guosheng): `SpecialTokensMixin.__init__` would be called by
-        # `PretrainedTokenizer._wrap_init` using args which might be str rather
-        # than instances of `AddedToken`, and this causes `AddedToken` settings
-        # made by `_build_special_tokens_map_extended` overwrited.
-        # Maybe `PretrainedTokenizer._wrap_init` should be called before init
-        # later.
-        if getattr(self, "_has_built_special_tokens", None):
-            return
-        self._bos_token = None
-        self._eos_token = None
-        self._unk_token = None
-        self._sep_token = None
-        self._pad_token = None
-        self._cls_token = None
-        self._mask_token = None
-        self._pad_token_type_id = 0
-        self._additional_special_tokens = []
+        # note(guosheng): Since `__init__` might be called multiple times which
+        # is hooked before `PretrainedTokenizer` init, we do not set to None as
+        # HF to avoid unintentional overriding.
+        self._bos_token = getattr(self, "_bos_token", None)
+        self._eos_token = getattr(self, "_eos_token", None)
+        self._unk_token = getattr(self, "_unk_token", None)
+        self._sep_token = getattr(self, "_sep_token", None)
+        self._pad_token = getattr(self, "_pad_token", None)
+        self._cls_token = getattr(self, "_cls_token", None)
+        self._mask_token = getattr(self, "_mask_token", None)
+        self._pad_token_type_id = getattr(self, "_pad_token_type_id", 0)
+        self._additional_special_tokens = getattr(self,
+                                                  "_additional_special_tokens",
+                                                  [])
         self.verbose = verbose
 
         # We directly set the hidden value to allow initialization with special tokens


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix special token settings in PretrainiedTokenizer.

Resolve #2630 

Additionally,  by using `_post_init` to replace `_wrap_init` and add `_pre_init`, we can add `Configuration` and parse `Configuration` in `_pre_init` as arguments of `PretrainedModel.__init__` to create models later.