### PR TITLE
add _entity_file field to LukeTokenizer

### DIFF
--- a/paddlenlp/transformers/ctrl/tokenizer.py
+++ b/paddlenlp/transformers/ctrl/tokenizer.py
@@ -367,9 +367,6 @@ class CTRLTokenizer(PretrainedTokenizer):
         """
         for name, file_name in self.resource_files_names.items():
             source_path = getattr(self, "_%s" % name)
-            if not os.path.exists(source_path):
-                continue
-
             save_path = os.path.join(save_directory, file_name)
             if os.path.abspath(source_path) != os.path.abspath(save_path):
                 shutil.copyfile(source_path, save_path)

--- a/paddlenlp/transformers/gpt/tokenizer.py
+++ b/paddlenlp/transformers/gpt/tokenizer.py
@@ -519,9 +519,7 @@ class GPTTokenizer(PretrainedTokenizer):
             save_directory (str): Directory to save files into.
         """
         for name, file_name in self.resource_files_names.items():
-            source_path = getattr(self, "_%s" % name, None)
-            if source_path is None:
-                continue
+            source_path = getattr(self, "_%s" % name)
 
             save_path = os.path.join(save_directory, file_name)
             if os.path.abspath(source_path) != os.path.abspath(save_path):

--- a/paddlenlp/transformers/gpt/tokenizer.py
+++ b/paddlenlp/transformers/gpt/tokenizer.py
@@ -389,7 +389,9 @@ class GPTTokenizer(PretrainedTokenizer):
         self.num_command_tokens = 2
         self.num_type_tokens = 2
 
-        self.encoder = json.load(open(vocab_file))
+        with open(vocab_file, 'r', encoding='utf-8') as f:
+            self.encoder = json.load(f)
+
         self.decoder = {v: k for k, v in self.encoder.items()}
 
         self.num_tokens = len(self.encoder)
@@ -397,7 +399,10 @@ class GPTTokenizer(PretrainedTokenizer):
         self.errors = errors  # how to handle errors in decoding
         self.byte_encoder = bytes_to_unicode()
         self.byte_decoder = {v: k for k, v in self.byte_encoder.items()}
-        bpe_data = open(merges_file, encoding='utf-8').read().split('\n')[1:-1]
+
+        with open(merges_file, encoding='utf-8') as f:
+            bpe_data = f.read().split('\n')[1:-1]
+
         bpe_merges = [tuple(merge.split()) for merge in bpe_data]
         self.bpe_ranks = dict(zip(bpe_merges, range(len(bpe_merges))))
         self.cache = {}

--- a/paddlenlp/transformers/luke/tokenizer.py
+++ b/paddlenlp/transformers/luke/tokenizer.py
@@ -205,6 +205,10 @@ class LukeTokenizer(RobertaBPETokenizer):
         self.pat = re.compile(
             r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
         )
+
+        # RobertaTokenizer don't maintain the entity_file resource file name,
+        # so we should not set it as a param in super.__init__ function
+        self._entity_file = entity_file
         super(LukeTokenizer, self).__init__(vocab_file,
                                             merges_file,
                                             do_lower_case=do_lower_case,

--- a/paddlenlp/transformers/skep/tokenizer.py
+++ b/paddlenlp/transformers/skep/tokenizer.py
@@ -448,5 +448,5 @@ class SkepTokenizer(PretrainedTokenizer):
         for name, file_name in self.resource_files_names.items():
             save_path = os.path.join(save_directory, file_name)
             source_file = getattr(self, name)
-            if source_file is not None:
+            if not os.path.samefile(source_file, save_path):
                 shutil.copyfile(source_file, save_path)

--- a/paddlenlp/transformers/xlm/tokenizer.py
+++ b/paddlenlp/transformers/xlm/tokenizer.py
@@ -980,10 +980,7 @@ class XLMTokenizer(PretrainedTokenizer):
             
         """
         for name, file_name in self.resource_files_names.items():
-            source_path = getattr(self, "_%s" % name, None)
-            if source_path is None:
-                continue
-
+            source_path = getattr(self, "_%s" % name)
             save_path = os.path.join(save_directory, file_name)
             if os.path.abspath(source_path) != os.path.abspath(save_path):
                 shutil.copyfile(source_path, save_path)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description

luketokenizer don't maintain the `_entity_file` to store the entity file info, so that save_resouce can't get the meta info about resouce files.

The simple way is to add the filed into `LukeTokenzier`.
