### PR TITLE
Fix os.makedirs error when running distributed training

### DIFF
--- a/paddlenlp/utils/env.py
+++ b/paddlenlp/utils/env.py
@@ -43,7 +43,7 @@ def _get_ppnlp_home():
 def _get_sub_home(directory, parent_home=_get_ppnlp_home()):
     home = os.path.join(parent_home, directory)
     if not os.path.exists(home):
-        os.makedirs(home)
+        os.makedirs(home, exist_ok=True)
     return home
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
The `os.makedirs` would raise error when running distributed training. This PR fixes this issue.