### PR TITLE
Remove use of fluid API

### DIFF
--- a/examples/model_compression/pp-minilm/pruning/export_model.py
+++ b/examples/model_compression/pp-minilm/pruning/export_model.py
@@ -27,7 +27,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-import paddle.fluid.core as core
+from paddle.common_ops_import import core
 
 from paddlenlp.transformers import PPMiniLMModel
 from paddlenlp.utils.log import logger

--- a/paddlenlp/transformers/distill_utils.py
+++ b/paddlenlp/transformers/distill_utils.py
@@ -18,7 +18,7 @@ import paddle
 from paddle import tensor
 import paddle.nn.functional as F
 from paddle.nn import MultiHeadAttention, TransformerEncoderLayer, TransformerEncoder
-from paddle.fluid.data_feeder import convert_dtype
+from paddle.common_ops_import import convert_dtype
 
 from paddlenlp.utils.log import logger
 from paddlenlp.transformers import PPMiniLMForSequenceClassification

--- a/paddlenlp/transformers/ppminilm/modeling.py
+++ b/paddlenlp/transformers/ppminilm/modeling.py
@@ -14,7 +14,7 @@
 import os
 
 import paddle
-import paddle.fluid.core as core
+from paddle.common_ops_import import core
 import paddle.nn as nn
 import paddle.nn.functional as F
 

--- a/paddlenlp/transformers/semantic_search/modeling.py
+++ b/paddlenlp/transformers/semantic_search/modeling.py
@@ -224,7 +224,7 @@ class ErnieCrossEncoder(nn.Layer):
             inputs = tokenizer("你们好", text_pair="你好")
             inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
 
-            # Get similarity probability of text pair.
+            # Get embedding of text pair.
             embedding = model.matching(**inputs)
 
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
using `paddle.common_ops_import` stead of `paddle.fluid`
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models & APIs
### Description
<!-- Describe what this PR does -->
Remove fluid API usage