### PR TITLE
Fix init_removed of update_range in faster_tokenizer

### DIFF
--- a/faster_tokenizer/faster_tokenizer/src/normalizers/normalizer.cc
+++ b/faster_tokenizer/faster_tokenizer/src/normalizers/normalizer.cc
@@ -113,7 +113,7 @@ void NormalizedString::UpdateNormalizedRange(
   std::vector<core::Range> alignments;
   alignments.reserve(n_range.second - n_range.first);
 
-  int replaced_normalized_idx = 0;
+  int replaced_normalized_idx = initial_removed;
   // Calculate the new alignments
   for (int i = 0; i < new_normalized.u32normalized.length(); ++i) {
     auto idx = offset;

--- a/faster_tokenizer/python/faster_tokenizer/__init__.py
+++ b/faster_tokenizer/python/faster_tokenizer/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from typing import Tuple, Union, Tuple, List
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix the index error when initial_removed does not equals to 0. If the first several characters of sequence need to be removed, the bug will be reproduced. 

The case :

```python
from paddlenlp.transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained('ernie-3.0-medium-zh', use_faster=True)
tokenizer(text="63天2008/03/27出发3402精36樱落武汉3天2010/03/21出发948443印象·武汉2天2012/03/05出发6139492【一个人的精彩】初秋...3天2012/11/02出发384179湖北20125天2012/03/02出发4678295这是最好的城市，也是...12天2012/06/30出发401026水乡绍兴印象。3天2008/07/08出发4728109武汉一日游1天2013/03/31出发112021清明武汉暴走游3天2013/04/04出发2308", max_seq_len=384)
```