### PR TITLE
修改组网代码中涉及numpy操作的部分，改为 paddle 的 API 重新实现

### DIFF
--- a/examples/few_shot/p-tuning/model.py
+++ b/examples/few_shot/p-tuning/model.py
@@ -46,8 +46,7 @@ class ErnieForPretraining(ErniePretrainedModel):
             sequence_output, pooled_output = outputs[:2]
 
             max_len = input_ids.shape[1]
-            new_masked_positions = paddle.fluid.layers.create_array(
-                dtype='int32')
+            new_masked_positions = paddle.tensor.create_array(dtype='int32')
             # masked_positions: [bs, label_length]
             for bs_index, mask_pos in enumerate(masked_positions):
                 for pos in mask_pos:

--- a/examples/few_shot/p-tuning/model.py
+++ b/examples/few_shot/p-tuning/model.py
@@ -49,7 +49,7 @@ class ErnieForPretraining(ErniePretrainedModel):
             new_masked_positions = paddle.fluid.layers.create_array(
                 dtype='int32')
             # masked_positions: [bs, label_length]
-            for bs_index, mask_pos in enumerate(masked_positions.numpy()):
+            for bs_index, mask_pos in enumerate(masked_positions):
                 for pos in mask_pos:
                     new_masked_positions.append(bs_index * max_len + pos)
 

--- a/examples/few_shot/p-tuning/model.py
+++ b/examples/few_shot/p-tuning/model.py
@@ -46,16 +46,16 @@ class ErnieForPretraining(ErniePretrainedModel):
             sequence_output, pooled_output = outputs[:2]
 
             max_len = input_ids.shape[1]
-            new_masked_positions = []
+            new_masked_positions = paddle.fluid.layers.create_array(
+                dtype='int32')
             # masked_positions: [bs, label_length]
             for bs_index, mask_pos in enumerate(masked_positions.numpy()):
                 for pos in mask_pos:
                     new_masked_positions.append(bs_index * max_len + pos)
 
             # new_masked_positions: [bs * label_length, 1]
-            new_masked_positions = np.array(new_masked_positions).astype(
-                'int32')
-            new_masked_positions = paddle.to_tensor(new_masked_positions)
+            new_masked_positions = paddle.to_tensor(new_masked_positions,
+                                                    'int32')
 
             prediction_scores, seq_relationship_score = self.cls(
                 sequence_output, pooled_output, new_masked_positions)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
 Others 

### PR changes
 Models

### Description
修改组网代码中new_masked_positions中涉及numpy操作的部分，改为 paddle 的 API 重新实现，防止转换为静态图时报错

根据API文档中如下部分进行修改
三、内嵌 Numpy 操作？
动态图模型代码中的 numpy 相关的操作可以转为静态图么？

答：不能。所有与组网相关的 numpy 操作都必须用 paddle 的 API 重新实现。即不支持 Layer → numpy operations → Layer 的组网方式。