### PR TITLE
Fix UNIMOText eval failed when use_faster=False

### DIFF
--- a/paddlenlp/transformers/model_outputs.py
+++ b/paddlenlp/transformers/model_outputs.py
@@ -91,7 +91,7 @@ def _transformer_encoder_fwd(self,
         if output_attentions:
             all_attentions.append(outputs[-1])
         if cache is not None:
-            new_caches.append(outputs[1])
+            new_caches.append(outputs[0])
 
     if self.norm is not None:
         output = self.norm(output)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
Fix UNIMOText eval failed when use_faster=False. . Fix "Support more model outputs for BERT/ERNIE/RoBERTa" #2876 
 #2665 