### PR TITLE
fix tokenizer encode bug for layoutxlm

### DIFF
--- a/examples/multimodal/layoutxlm/xfun.py
+++ b/examples/multimodal/layoutxlm/xfun.py
@@ -226,6 +226,7 @@ class XFUN(Dataset):
             text = info["text"]
             encode_res = self.tokenizer.encode(text,
                                                pad_to_max_seq_len=False,
+                                               return_token_type_ids=True,
                                                return_attention_mask=True)
 
             gt_label = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

Fix ``tokenizer.encode()`` calling error for layoutxlm, the default setting of `return_token_type_ids` is None and it will cause the following error:

Traceback:
```text
  File "./run_xfun_ser.py", line 344, in <module>
    train(args)
  File "./run_xfun_ser.py", line 105, in train
    load_mode='all')
  File "/workspace/uie/fix_layout/PaddleNLP/examples/multimodal/layoutxlm/xfun.py", line 79, in __init__
    self.encoded_inputs_all = self._parse_label_file_all()
  File "/workspace/uie/fix_layout/PaddleNLP/examples/multimodal/layoutxlm/xfun.py", line 164, in _parse_label_file_all
    encoded_inputs_all.extend(self._parse_label_file(line))
  File "/workspace/uie/fix_layout/PaddleNLP/examples/multimodal/layoutxlm/xfun.py", line 179, in _parse_label_file
    encoded_inputs = self._read_encoded_inputs_sample(info_str)
  File "/workspace/uie/fix_layout/PaddleNLP/examples/multimodal/layoutxlm/xfun.py", line 235, in _read_encoded_inputs_sample
    encode_res["token_type_ids"] = encode_res["token_type_ids"][
  File "/usr/local/lib/python3.7/dist-packages/paddlenlp/transformers/tokenizer_utils_base.py", line 246, in __getitem__
    return self.data[item]
KeyError: 'token_type_ids'
```