### PR TITLE
[nptag] disable ir optimization for nptag

### DIFF
--- a/examples/text_to_knowledge/nptag/deploy/python/predict.py
+++ b/examples/text_to_knowledge/nptag/deploy/python/predict.py
@@ -49,11 +49,12 @@ class Predictor(object):
         if not os.path.exists(params_file):
             raise ValueError("not find params file path {}".format(params_file))
         config = paddle.inference.Config(model_file, params_file)
+        # Disable IR optimization for NPTag
+        config.switch_ir_optim(False)
 
         if device == "gpu":
             # set GPU configs accordingly
             config.enable_use_gpu(100, 0)
-            config.delete_pass("embedding_eltwise_layernorm_fuse_pass")
         elif device == "cpu":
             # set CPU configs accordingly,
             # such as enable_mkldnn, set_cpu_math_library_num_threads

--- a/paddlenlp/taskflow/knowledge_mining.py
+++ b/paddlenlp/taskflow/knowledge_mining.py
@@ -580,26 +580,8 @@ class NPTagTask(Task):
         self._construct_dict_map()
 
         self._get_inference_model()
-        if paddle.get_device().startswith("gpu"):
-            inference_model_path = os.path.join(self._task_path, "static",
-                                                "inference")
-            model_file = inference_model_path + ".pdmodel"
-            params_file = inference_model_path + ".pdiparams"
-            self._config = paddle.inference.Config(model_file, params_file)
-            self._config.enable_use_gpu(100, 0)
-            self._config.switch_use_feed_fetch_ops(False)
-            self._config.disable_glog_info()
-            # TODO(linjieccc): enable embedding_eltwise_layernorm_fuse_pass after fixed
-            self._config.delete_pass("embedding_eltwise_layernorm_fuse_pass")
-            self.predictor = paddle.inference.create_predictor(self._config)
-            self.input_handles = [
-                self.predictor.get_input_handle(name)
-                for name in self.predictor.get_input_names()
-            ]
-            self.output_handle = [
-                self.predictor.get_output_handle(name)
-                for name in self.predictor.get_output_names()
-            ]
+        # Disable IR optimization for NPTag
+        self._config.switch_ir_optim(False)
 
     @property
     def summary_num(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
- disable ir optim for nptag, since ``embedding_eltwise_layernorm_fuse_pass`` is not support for nptag and it will cause wrong predict output for batch prediction.