### PR TITLE
update moe recompute.

### DIFF
--- a/examples/language_model/moe/dygraph/modeling.py
+++ b/examples/language_model/moe/dygraph/modeling.py
@@ -408,7 +408,9 @@ class TransformerDecoderLayer(nn.Layer):
                  top_k=2,
                  hcg=None,
                  gate=None,
-                 recompute_interval=0):
+                 recompute_interval=0,
+                 recompute_partition=False,
+                 recompute_offload=False):
         self._config = locals()
         self._config.pop("self")
         self._config.pop("__class__", None)  # py3
@@ -452,12 +454,19 @@ class TransformerDecoderLayer(nn.Layer):
                 "type": "gshard",
                 "top_k": top_k,
             }
+
+            recompute_ctx = {
+                "mp_group": mp_group,
+                "offload": recompute_offload,
+                "partition": recompute_partition
+            }
             self.moe_mlp = MoeLayer(d_model=d_model,
                                     experts=experts_list,
                                     gate=gate_config,
                                     moe_group=moe_group,
                                     mp_group=mp_group,
-                                    recompute_interval=self.recompute_interval)
+                                    recompute_interval=self.recompute_interval,
+                                    recompute_ctx=recompute_ctx)
         else:
             self.linear1 = fleet.meta_parallel.ColumnParallelLinear(
                 d_model,
@@ -793,7 +802,9 @@ class GPTModel(GPTPretrainedModel):
                     top_k=top_k,
                     hcg=hcg,
                     gate=gate,
-                    recompute_interval=recompute_interval))
+                    recompute_interval=recompute_interval,
+                    recompute_partition=recompute_partition,
+                    recompute_offload=recompute_offload))
 
         self.decoder = TransformerDecoder(decoder_layers,
                                           num_hidden_layers,

--- a/examples/language_model/moe/dygraph/modeling.py
+++ b/examples/language_model/moe/dygraph/modeling.py
@@ -35,8 +35,6 @@ from paddle.incubate.distributed.models import moe
 MoeLayer = moe.MoELayer
 from utils import get_timers
 
-from paddle.distributed.fleet.meta_parallel.pp_utils.utils import _initialize_recompute_setting, _initialize_recompute_hcg
-
 __all__ = [
     'GPTModel',
     "GPTPretrainedModel",
@@ -768,11 +766,6 @@ class GPTModel(GPTPretrainedModel):
         self.initializer_range = initializer_range
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
-
-        if recompute_interval > 0:
-            _initialize_recompute_hcg(hcg)
-            _initialize_recompute_setting(recompute_offload,
-                                          recompute_partition)
 
         self.embeddings = GPTEmbeddings(vocab_size, hidden_size,
                                         hidden_dropout_prob,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
this PR fix a recompute bug for moe. for recompute in hybrid parallel, recommand to use this API:
```
paddle.incubate.distributed.fleet.recompute_hybrid()
```