### PR TITLE
[few-shot] fix typo and failed links

### DIFF
--- a/applications/text_classification/hierarchical/few-shot/README.md
+++ b/applications/text_classification/hierarchical/few-shot/README.md
@@ -2,17 +2,18 @@
 
 ## 目录
 
-  * [1. 项目说明](1.项目说明)
-  * [2. 效果展示](2.效果展示)
-  * [3. 定制训练](3.定制训练)
-    * [3.1 运行环境](3.1运行环境)
-    * [3.2 代码结构](3.2代码结构)
-    * [3.3 数据标注](3.3数据标注)
-    * [3.4 模型训练](3.4模型训练)
-    * [3.5 模型评估](3.5模型评估)
-    * [3.6 模型部署](3.6模型部署)
-  * [4. References](4.References)
+- [1. 项目说明](#项目说明)
+- [2. 效果展示](#效果展示)
+- [3. 定制训练](#定制训练)
+  - [3.1 运行环境](#运行环境)
+  - [3.2 代码结构](#代码结构)
+  - [3.3 数据标注](#数据标注)
+  - [3.4 模型训练](#模型训练)
+  - [3.5 模型评估](#模型评估)
+  - [3.6 模型部署](#模型部署)
+- [4. References](#References)
 
+<a name="项目说明"></a>
 ## 1. 项目说明
 
 本项目提供了小样本场景下文本多标签层次分类的解决方案，在 ERNIE3.0 的基础上利用提示学习取得比微调更好的分类效果，充分利用标注信息。
@@ -40,6 +41,8 @@
 - **标注成本低**：以往的微调方式需要大量的数据标注才能保证模型分类效果。提示学习可以降低数据标注依赖，在小样本（few-shot）的场景下取得比微调更好的分类效果。
 - **全流程打通**：提供了从训练到部署的完整解决方案，可以低成本迁移至实际应用场景。
 
+
+<a name="效果展示"></a>
 ## 2.效果展示
 
 本项目中使用了 ERNIE3.0 模型，对于中文训练任务可以根据需求选择不同的预训练模型参数进行训练，我们测评了 Base 模型在事件类型分类任务上的表现。测试配置如下：
@@ -91,17 +94,20 @@
    | ernie-3.0-base-zh | 提示学习 | 0.8855 | 0.8443 |
 
 
+<a name="定制训练"></a>
 ## 3.定制训练
 
 下边通过事件抽取任务的例子展示如何使用小样本学习来进行文本分类。
 
+<a name="运行环境"></a>
 ### 3.1 运行环境
 
 - python >= 3.6
-- paddlepaddle >= 2.3
+- paddlepaddle > 2.3（2.4版本发布前推荐安装[develop版本](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html)）
 - paddlenlp >= 2.3.5
 - paddle2onnx >= 1.0.0rc3
 
+<a name="代码结构"></a>
 ### 3.2 代码结构
 
 ```text
@@ -112,6 +118,7 @@
 └── README.md
 ```
 
+<a name="数据标注"></a>
 ### 3.3 数据标注
 
 我们推荐使用数据标注平台[doccano](https://github.com/doccano/doccano)进行自定义数据标注，本项目也打通了从标注到训练的通道，即doccano导出数据后可通过[doccano.py](../../doccano.py)脚本轻松将数据转换为输入模型时需要的形式，实现无缝衔接。标注方法的详细介绍请参考[doccano数据标注指南](../../doccano.md)。
@@ -195,6 +202,7 @@ data/
 
 **Note**: 这里的标签映射词定义遵循的规则是，不同映射词尽可能长度一致，映射词和提示需要尽可能构成通顺的语句。越接近自然语句，小样本下模型训练效果越好。如果原标签名已经可以构成通顺语句，也可以不构造映射词，每行一个标签即可。
 
+<a name="模型训练"></a>
 ### 3.4 模型训练
 
 **单卡训练**
@@ -276,6 +284,8 @@ python -u -m paddle.distributed.launch --gpus 0,1,2,3 train.py \
 
 更多参数介绍可参考[配置文件](../../../../paddlenlp/trainer/trainer_args.py)。
 
+
+<a name="模型评估"></a>
 ### 3.5 模型评估
 
 在模型训练时开启`--do_predict`，训练结束后直接在测试集上`test.txt`进行评估，也可以在训练结束后，通过运行以下命令加载模型参数进行评估：
@@ -291,6 +301,7 @@ python train.py --do_predict --data_dir ./data --output_dir ./predict_checkpoint
 - `do_predict`: 是否进行测试集评估。
 - `max_seq_length`: 最大句子长度，超过该长度的文本将被截断，不足的以Pad补全。提示文本不会被截断。
 
+<a name="模型部署"></a>
 ### 3.6 模型部署
 
 #### 模型导出
@@ -352,6 +363,7 @@ python infer.py --model_path_prefix checkpoints/export/model --data_dir ./data -
 
 **Note**: 在GPU设备的CUDA计算能力 (CUDA Compute Capability) 大于7.0，在包括V100、T4、A10、A100、GTX 20系列和30系列显卡等设备上可以开启FP16进行加速，在CPU或者CUDA计算能力 (CUDA Compute Capability) 小于7.0时开启不会带来加速效果。
 
+<a name="References"></a>
 ## 4. References
 
 - Liu, Xiao, et al. "GPT understands, too." arXiv preprint arXiv:2103.10385 (2021). [[PDF]](https://arxiv.org/abs/2103.10385)

--- a/applications/text_classification/hierarchical/few-shot/train.py
+++ b/applications/text_classification/hierarchical/few-shot/train.py
@@ -146,7 +146,7 @@ def main():
         ]
         export_path = os.path.join(training_args.output_dir, 'export')
         trainer.export_model(export_path,
-                             input_spec=input_sepc,
+                             input_spec=input_spec,
                              export_type=model_args.export_type)
 
 

--- a/applications/text_classification/multi_class/few-shot/README.md
+++ b/applications/text_classification/multi_class/few-shot/README.md
@@ -2,17 +2,18 @@
 
 ## 目录
 
-  * [1. 项目说明](1.项目说明)
-  * [2. 效果展示](2.效果展示)
-  * [3. 定制训练](3.定制训练)
-    * [3.1 运行环境](3.1运行环境)
-    * [3.2 代码结构](3.2代码结构)
-    * [3.3 数据标注](3.3数据标注)
-    * [3.4 模型训练](3.4模型训练)
-    * [3.5 模型评估](3.5模型评估)
-    * [3.6 模型部署](3.6模型部署)
-  * [4. References](4.References)
+- [1. 项目说明](#项目说明)
+- [2. 效果展示](#效果展示)
+- [3. 定制训练](#定制训练)
+  - [3.1 运行环境](#运行环境)
+  - [3.2 代码结构](#代码结构)
+  - [3.3 数据标注](#数据标注)
+  - [3.4 模型训练](#模型训练)
+  - [3.5 模型评估](#模型评估)
+  - [3.6 模型部署](#模型部署)
+- [4. References](#References)
 
+<a name="项目说明"></a>
 ## 1. 项目说明
 
 本项目提供了小样本场景下文本二/多分类的解决方案，在 ERNIE3.0 的基础上利用提示学习取得比微调更好的分类效果，充分利用标注信息。
@@ -41,6 +42,7 @@
 - **标注成本低**：以往的微调方式需要大量的数据标注才能保证模型分类效果。提示学习可以降低数据标注依赖，在少样本（few-shot）的场景下取得比微调更好的分类效果。
 - **全流程打通**：提供了从训练到部署的完整解决方案，可以低成本迁移至实际应用场景。
 
+<a name="效果展示"></a>
 ## 2.效果展示
 
 本项目中使用了 ERNIE3.0 模型，对于中文训练任务可以根据需求选择不同的预训练模型参数进行训练，我们测评了 Base 模型在新闻分类任务上的表现。测试配置如下：
@@ -92,17 +94,20 @@ python train.py --data_dir ./data/ --output_dir ./checkpoints/ --prompt "这条�
 | ernie-3.0-base-zh | 提示学习 | 0.5521 |
 
 
+<a name="定制训练"></a>
 ## 3.定制训练
 
 下边通过**新闻分类**的例子展示如何使用小样本学习来进行文本分类。
 
+<a name="运行环境"></a>
 ### 3.1 运行环境
 
 - python >= 3.6
-- paddlepaddle >= 2.3
+- paddlepaddle > 2.3 （2.4版本发布前推荐安装[develop版本](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html)）
 - paddlenlp >= 2.3.5
 - paddle2onnx >= 1.0.0rc3
 
+<a name="代码结构"></a>
 ### 3.2 代码结构
 
 ```text
@@ -113,6 +118,7 @@ python train.py --data_dir ./data/ --output_dir ./checkpoints/ --prompt "这条�
 └── README.md
 ```
 
+<a name="数据标注"></a>
 ### 3.3 数据标注
 
 我们推荐使用数据标注平台[doccano](https://github.com/doccano/doccano)进行自定义数据标注，本项目也打通了从标注到训练的通道，即doccano导出数据后可通过[doccano.py](../../doccano.py)脚本轻松将数据转换为输入模型时需要的形式，实现无缝衔接。标注方法的详细介绍请参考[doccano数据标注指南](../../doccano.md)。
@@ -186,6 +192,7 @@ news_culture==文化
 ```
 **Note**: 这里的标签映射词定义遵循的规则是，不同映射词尽可能长度一致，映射词和提示需要尽可能构成通顺的语句。越接近自然语句，小样本下模型训练效果越好。如果原标签名已经可以构成通顺语句，也可以不构造映射词，每行一个标签即可。
 
+<a name="模型训练"></a>
 ### 3.4 模型训练
 
 **单卡训练**
@@ -259,6 +266,7 @@ python -u -m paddle.distributed.launch --gpus 0,1,2,3 train.py \
 
 更多参数介绍可参考[配置文件](../../../../paddlenlp/trainer/trainer_args.py)。
 
+<a name="模型评估"></a>
 ### 3.5 模型评估
 
 在模型训练时开启`--do_predict`，训练结束后直接在测试集上`test.txt`进行评估，也可以在训练结束后，通过运行以下命令加载模型参数进行评估：
@@ -274,6 +282,7 @@ python train.py --do_predict --data_dir ./data --output_dir ./predict_checkpoint
 - `do_predict`: 是否进行预测。
 - `max_seq_length`: 最大句子长度，超过该长度的文本将被截断，不足的以Pad补全。提示文本不会被截断。
 
+<a name="模型部署"></a>
 ### 3.6 模型部署
 
 #### 模型导出
@@ -335,6 +344,7 @@ python infer.py --model_path_prefix checkpoints/export/model --data_dir ./data -
 
 **Note**: 在GPU设备的CUDA计算能力 (CUDA Compute Capability) 大于7.0，在包括V100、T4、A10、A100、GTX 20系列和30系列显卡等设备上可以开启FP16进行加速，在CPU或者CUDA计算能力 (CUDA Compute Capability) 小于7.0时开启不会带来加速效果。
 
+<a name="References"></a>
 ## 4. References
 
 - Liu, Xiao, et al. "GPT understands, too." arXiv preprint arXiv:2103.10385 (2021). [[PDF]](https://arxiv.org/abs/2103.10385)

--- a/applications/text_classification/multi_label/few-shot/README.md
+++ b/applications/text_classification/multi_label/few-shot/README.md
@@ -2,17 +2,18 @@
 
 ## 目录
 
-  * [1. 项目说明](1.项目说明)
-  * [2. 效果展示](2.效果展示)
-  * [3. 定制训练](3.定制训练)
-    * [3.1 运行环境](3.1运行环境)
-    * [3.2 代码结构](3.2代码结构)
-    * [3.3 数据标注](3.3数据标注)
-    * [3.4 模型训练](3.4模型训练)
-    * [3.5 模型评估](3.5模型评估)
-    * [3.6 模型部署](3.6模型部署)
-  * [4. References](4.References)
+- [1. 项目说明](#项目说明)
+- [2. 效果展示](#效果展示)
+- [3. 定制训练](#定制训练)
+  - [3.1 运行环境](#运行环境)
+  - [3.2 代码结构](#代码结构)
+  - [3.3 数据标注](#数据标注)
+  - [3.4 模型训练](#模型训练)
+  - [3.5 模型评估](#模型评估)
+  - [3.6 模型部署](#模型部署)
+- [4. References](#References)
 
+<a name="项目说明"></a>
 ## 1. 项目说明
 
 本项目提供了小样本场景下文本多标签分类的解决方案，在 ERNIE3.0 的基础上利用提示学习取得比微调更好的分类效果，充分利用标注信息。
@@ -46,6 +47,7 @@
 - **标注成本低**：以往的微调方式需要大量的数据标注才能保证模型分类效果。提示学习可以降低数据标注依赖，在小样本（few-shot）的场景下取得比微调更好的分类效果。
 - **全流程打通**：提供了从训练到部署的完整解决方案，可以低成本迁移至实际应用场景。
 
+<a name="效果展示"></a>
 ## 2.效果展示
 
 本项目中使用了 ERNIE3.0 模型，对于中文训练任务可以根据需求选择不同的预训练模型参数进行训练，我们测评了 Base 模型在婚姻家庭要素提取任务上的表现。测试配置如下：
@@ -96,18 +98,20 @@
    | ernie-3.0-base-zh | 微调学习 | 0.7419 | 0.5105 |
    | ernie-3.0-base-zh | 提示学习 | 0.7838 | 0.6985 |
 
-
+<a name="定制训练"></a>
 ## 3.定制训练
 
 下边通过婚姻家庭要素提取的例子展示如何使用小样本学习来进行文本分类。
 
+<a name="运行环境"></a>
 ### 3.1 运行环境
 
 - python >= 3.6
-- paddlepaddle >= 2.3
+- paddlepaddle > 2.3（2.4版本发布前推荐安装[develop版本](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/develop/install/pip/linux-pip.html)）
 - paddlenlp >= 2.3.5
 - paddle2onnx >= 1.0.0rc3
 
+<a name="代码结构"></a>
 ### 3.2 代码结构
 
 ```text
@@ -118,6 +122,7 @@
 └── README.md
 ```
 
+<a name="数据标注"></a>
 ### 3.3 数据标注
 
 我们推荐使用数据标注平台[doccano](https://github.com/doccano/doccano)进行自定义数据标注，本项目也打通了从标注到训练的通道，即doccano导出数据后可通过[doccano.py](../../doccano.py)脚本轻松将数据转换为输入模型时需要的形式，实现无缝衔接。标注方法的详细介绍请参考[doccano数据标注指南](../../doccano.md)。
@@ -198,6 +203,7 @@ data/
 ...
 ```
 
+<a name="模型训练"></a>
 ### 3.4 模型训练
 
 **单卡训练**
@@ -279,6 +285,7 @@ python -u -m paddle.distributed.launch --gpus 0,1,2,3 train.py \
 
 更多参数介绍可参考[配置文件](../../../../paddlenlp/trainer/trainer_args.py)。
 
+<a name="模型评估"></a>
 ### 3.5 模型评估
 
 在模型训练时开启`--do_predict`，训练结束后直接在测试集上`test.txt`进行评估，也可以在训练结束后，通过运行以下命令加载模型参数进行评估：
@@ -294,6 +301,7 @@ python train.py --do_predict --data_dir ./data --output_dir ./predict_checkpoint
 - `do_predict`: 是否进行测试集评估。
 - `max_seq_length`: 最大句子长度，超过该长度的文本将被截断，不足的以Pad补全。提示文本不会被截断。
 
+<a name="模型部署"></a>
 ### 3.6 模型部署
 
 #### 模型导出
@@ -355,6 +363,7 @@ python infer.py --model_path_prefix checkpoints/export/model --data_dir ./data -
 
 **Note**: 在GPU设备的CUDA计算能力 (CUDA Compute Capability) 大于7.0，在包括V100、T4、A10、A100、GTX 20系列和30系列显卡等设备上可以开启FP16进行加速，在CPU或者CUDA计算能力 (CUDA Compute Capability) 小于7.0时开启不会带来加速效果。
 
+<a name="References"></a>
 ## 4. References
 
 - Liu, Xiao, et al. "GPT understands, too." arXiv preprint arXiv:2103.10385 (2021). [[PDF]](https://arxiv.org/abs/2103.10385)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- Fix  typo `input_sepc` in `applications/text_classification/hierarchical/few-shot/train.py`
- Fix failed links in READMEs 
- Update the `paddlepaddle` requirement as develop version to solve the problem during inference that 
```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Mul node. Name:'p2o.Mul.118' Status Message: p2o.Mul.118: right operand cannot broadcast on dim 1 
```


- 修改了`applications/text_classification/hierarchical/few-shot/train.py`文件中的错误 `input_sepc`
- 修复了 README 文档中目录链接无法正常跳转的问题
- 将 paddlepaddle 版本要求改为 develop 版本，以解决模型导出错误引起的 `ONNXRuntimeError`，详细报错如下
```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Mul node. Name:'p2o.Mul.118' Status Message: p2o.Mul.118: right operand cannot broadcast on dim 1 
```