### PR TITLE
[TIPC] Add scripts for npu and xpu, test=develop

### DIFF
--- a/examples/language_model/gpt-3/dygraph/args.py
+++ b/examples/language_model/gpt-3/dygraph/args.py
@@ -286,7 +286,7 @@ def parse_args(MODEL_CLASSES):
     parser.add_argument("--device",
                         type=str,
                         default="gpu",
-                        choices=["cpu", "gpu", "xpu"],
+                        choices=["cpu", "gpu", "xpu", "npu"],
                         help="select cpu, gpu, xpu devices.")
     parser.add_argument("--lr_decay_style",
                         type=str,

--- a/examples/machine_translation/transformer/deploy/python/inference.py
+++ b/examples/machine_translation/transformer/deploy/python/inference.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 

--- a/examples/machine_translation/transformer/deploy/python/inference.py
+++ b/examples/machine_translation/transformer/deploy/python/inference.py
@@ -28,7 +28,7 @@ def parse_args():
     parser.add_argument("--device",
                         default="gpu",
                         type=str,
-                        choices=["gpu", "xpu", "cpu"],
+                        choices=["gpu", "xpu", "cpu", "npu"],
                         help="Device to use during inference. ")
     parser.add_argument("--use_mkl",
                         default=False,
@@ -131,7 +131,9 @@ class Predictor(object):
             if args.device == "gpu":
                 config.enable_use_gpu(100, 0)
             elif args.device == "xpu":
-                config.enable_xpu(100)
+                config.enable_xpu()
+            elif args.device == "npu":
+                config.enable_npu()
             else:
                 # CPU
                 config.disable_gpu()

--- a/examples/machine_translation/transformer/predict.py
+++ b/examples/machine_translation/transformer/predict.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import yaml
 import logging
@@ -60,12 +74,10 @@ def parse_args():
         type=str,
         help="The eos token. It should be provided when use custom vocab_file. "
     )
-    parser.add_argument(
-        "--device", 
-        default="gpu", 
-        choices=["gpu", "cpu", "xpu", "npu"], 
-        help="Device selected for inference."
-    )
+    parser.add_argument("--device",
+                        default="gpu",
+                        choices=["gpu", "cpu", "xpu", "npu"],
+                        help="Device selected for inference.")
 
     args = parser.parse_args()
     return args

--- a/examples/machine_translation/transformer/predict.py
+++ b/examples/machine_translation/transformer/predict.py
@@ -60,6 +60,13 @@ def parse_args():
         type=str,
         help="The eos token. It should be provided when use custom vocab_file. "
     )
+    parser.add_argument(
+        "--device", 
+        default="gpu", 
+        choices=["gpu", "cpu", "xpu", "npu"], 
+        help="Device selected for inference."
+    )
+
     args = parser.parse_args()
     return args
 
@@ -83,6 +90,10 @@ def post_process_seq(seq, bos_idx, eos_idx, output_bos=False, output_eos=False):
 def do_predict(args):
     if args.device == "gpu":
         place = "gpu"
+    elif args.device == "xpu":
+        place = "xpu"
+    elif args.device == "npu":
+        place = "npu"
     else:
         place = "cpu"
 
@@ -157,6 +168,7 @@ if __name__ == "__main__":
     args.unk_token = ARGS.unk_token
     args.bos_token = ARGS.bos_token
     args.eos_token = ARGS.eos_token
+    args.device = ARGS.device
     pprint(args)
 
     do_predict(args)

--- a/examples/machine_translation/transformer/train.py
+++ b/examples/machine_translation/transformer/train.py
@@ -100,9 +100,9 @@ def parse_args():
                         type=str,
                         choices=['true', 'false', 'True', 'False'],
                         help="Whether to use amp to train Transformer. ")
-    parser.add_argument("--device", 
-                        default="gpu", 
-                        choices=["gpu", "cpu", "xpu", "npu"], 
+    parser.add_argument("--device",
+                        default="gpu",
+                        choices=["gpu", "cpu", "xpu", "npu"],
                         help="Device selected for inference.")
     parser.add_argument(
         "--amp_level",

--- a/examples/machine_translation/transformer/train.py
+++ b/examples/machine_translation/transformer/train.py
@@ -130,15 +130,18 @@ def do_train(args):
     if args.device == "gpu":
         rank = dist.get_rank()
         trainer_count = dist.get_world_size()
+    elif args.device == "npu":
+        rank = dist.get_rank()
+        trainer_count = dist.get_world_size()
+        paddle.set_device("npu")
+    elif args.device == "xpu":
+        rank = dist.get_rank()
+        trainer_count = dist.get_world_size()
+        paddle.set_device("xpu")
     else:
         rank = 0
         trainer_count = 1
-        if args.device == "npu":
-            paddle.set_device("npu")
-        elif args.device == "xpu":
-            paddle.set_device("xpu")
-        else:
-            paddle.set_device("cpu")
+        paddle.set_device("cpu")
 
     if trainer_count > 1:
         dist.init_parallel_env()

--- a/examples/machine_translation/transformer/train.py
+++ b/examples/machine_translation/transformer/train.py
@@ -100,6 +100,10 @@ def parse_args():
                         type=str,
                         choices=['true', 'false', 'True', 'False'],
                         help="Whether to use amp to train Transformer. ")
+    parser.add_argument("--device", 
+                        default="gpu", 
+                        choices=["gpu", "cpu", "xpu", "npu"], 
+                        help="Device selected for inference.")
     parser.add_argument(
         "--amp_level",
         default=None,
@@ -129,7 +133,12 @@ def do_train(args):
     else:
         rank = 0
         trainer_count = 1
-        paddle.set_device("cpu")
+        if args.device == "npu":
+            paddle.set_device("npu")
+        elif args.device == "xpu":
+            paddle.set_device("xpu")
+        else:
+            paddle.set_device("cpu")
 
     if trainer_count > 1:
         dist.init_parallel_env()
@@ -401,6 +410,7 @@ if __name__ == "__main__":
     args.bos_token = ARGS.bos_token
     args.eos_token = ARGS.eos_token
     args.to_static = ARGS.to_static
+    args.device = ARGS.device
     pprint(args)
 
     args.profiler_options = ARGS.profiler_options

--- a/model_zoo/bert/run_pretrain.py
+++ b/model_zoo/bert/run_pretrain.py
@@ -150,7 +150,7 @@ def parse_args():
     parser.add_argument("--device",
                         type=str,
                         default="gpu",
-                        choices=["cpu", "gpu", "xpu"],
+                        choices=["cpu", "gpu", "xpu", "npu"],
                         help="Device for selecting for the training.")
     parser.add_argument("--use_amp",
                         type=distutils.util.strtobool,

--- a/model_zoo/gpt/args.py
+++ b/model_zoo/gpt/args.py
@@ -241,7 +241,7 @@ def parse_args(MODEL_CLASSES):
     parser.add_argument("--device",
                         type=str,
                         default="gpu",
-                        choices=["cpu", "gpu", "xpu"],
+                        choices=["cpu", "gpu", "xpu", "npu"],
                         help="select cpu, gpu, xpu devices.")
     parser.add_argument("--lr_decay_style",
                         type=str,

--- a/tests/test_tipc/bigru_crf/deploy/predict.py
+++ b/tests/test_tipc/bigru_crf/deploy/predict.py
@@ -28,7 +28,7 @@ parser.add_argument("--model_dir", type=str, default='./output', help="The path 
 parser.add_argument("--data_dir", type=str, default=None, help="The folder where the dataset is located.")
 parser.add_argument("--batch_size", type=int, default=2, help="The number of sequences contained in a mini-batch.")
 parser.add_argument("--max_seq_len", type=int, default=128, help="Number of words of the longest seqence.")
-parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
+parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu", "npu", "xpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
 parser.add_argument("--benchmark", type=eval, default=False, help="To log some information about environment and running.")
 parser.add_argument("--save_log_path", type=str, default="./log_output/", help="The file path to save log.")
 parser.add_argument('--use_tensorrt', default=False, type=eval, choices=[True, False], help='Enable to use tensorrt to speed up.')
@@ -202,7 +202,10 @@ class Predictor(object):
             config.set_cpu_math_library_num_threads(args.cpu_threads)
         elif device == "xpu":
             # set XPU configs accordingly
-            config.enable_xpu(100)
+            config.enable_xpu()
+        elif device == "npu":
+            # set NPU configs accordingly
+            config.enable_npu()
         config.switch_use_feed_fetch_ops(False)
         self.predictor = paddle.inference.create_predictor(config)
 

--- a/tests/test_tipc/ernie_information_extraction/predict.py
+++ b/tests/test_tipc/ernie_information_extraction/predict.py
@@ -166,7 +166,10 @@ class Predictor(object):
             config.set_cpu_math_library_num_threads(cpu_threads)
         elif device == "xpu":
             # set XPU configs accordingly
-            config.enable_xpu(100)
+            config.enable_xpu()
+        elif device == "npu":
+            # set NPU configs accordingly
+            config.enable_npu()
 
         config.switch_use_feed_fetch_ops(False)
         self.predictor = paddle.inference.create_predictor(config)
@@ -250,7 +253,7 @@ if __name__ == '__main__':
     parser.add_argument("--model_dir", type=str, default='./output', help="The path to parameters in static graph.")
     parser.add_argument("--data_dir", type=str, default="./waybill_ie/data", help="The folder where the dataset is located.")
     parser.add_argument("--batch_size", type=int, default=32, help="The number of sequences contained in a mini-batch.")
-    parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
+    parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu", "npu", "xpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
     parser.add_argument('--use_tensorrt', default=False, type=eval, choices=[True, False], help='Enable to use tensorrt to speed up.')
     parser.add_argument("--precision", default="fp32", type=str, choices=["fp32", "fp16", "int8"], help='The tensorrt precision.')
     parser.add_argument('--cpu_threads', default=10, type=int, help='Number of threads to predict when using cpu.')

--- a/tests/test_tipc/ernie_information_extraction/train.py
+++ b/tests/test_tipc/ernie_information_extraction/train.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
     parser.add_argument("--save_dir", default='./checkpoint', type=str, help="The output directory where the model checkpoints will be written.")
     parser.add_argument("--epochs", default=10, type=int, help="Total number of training epochs to perform.")
     parser.add_argument("--batch_size", default=200, type=int, help="Batch size per GPU/CPU for training.")
-    parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
+    parser.add_argument("--device", default="gpu", type=str, choices=["cpu", "gpu", "npu", "xpu"] ,help="The device to select to train the model, is must be cpu/gpu.")
     parser.add_argument("--seed", type=int, default=1000, help="Random seed for initialization.")
     parser.add_argument("--max_steps", default=-1, type=int, help="If > 0: set total number of training steps to perform.")
     parser.add_argument("--data_dir", default='./waybill_ie/data', type=str, help="The folder where the dataset is located.")

--- a/tests/test_tipc/ernie_text_cls/predict.py
+++ b/tests/test_tipc/ernie_text_cls/predict.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
     parser.add_argument("--model_dir", type=str, required=True, help="The directory to static model.")
     parser.add_argument("--max_seq_length", default=128, type=int, help="The maximum total input sequence length after tokenization. Sequences longer than this will be truncated, sequences shorter will be padded.")
     parser.add_argument("--batch_size", default=2, type=int, help="Batch size per GPU/CPU for training.")
-    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
+    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu', 'npu'], default="gpu", help="Select which device to train model, defaults to gpu.")
     parser.add_argument('--use_tensorrt', default=False, type=eval, choices=[True, False], help='Enable to use tensorrt to speed up.')
     parser.add_argument("--precision", default="fp32", type=str, choices=["fp32", "fp16", "int8"], help='The tensorrt precision.')
     parser.add_argument('--cpu_threads', default=10, type=int, help='Number of threads to predict when using cpu.')

--- a/tests/test_tipc/ernie_text_cls/train.py
+++ b/tests/test_tipc/ernie_text_cls/train.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
     parser.add_argument("--init_from_ckpt", type=str, default=None, help="The path of checkpoint to be loaded.")
     parser.add_argument("--seed", type=int, default=1000, help="random seed for initialization")
     parser.add_argument("--max_steps", default=-1, type=int, help="If > 0: set total number of training steps to perform.")
-    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
+    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu', 'npu'], default="gpu", help="Select which device to train model, defaults to gpu.")
     args = parser.parse_args()
     # yapf: enable
 

--- a/tests/test_tipc/ernie_text_matching/predict.py
+++ b/tests/test_tipc/ernie_text_matching/predict.py
@@ -94,7 +94,10 @@ class Predictor(object):
             config.set_cpu_math_library_num_threads(cpu_threads)
         elif device == "xpu":
             # set XPU configs accordingly
-            config.enable_xpu(100)
+            config.enable_xpu()
+        elif device == "npu":
+            # set NPU configs accordingly
+            config.enable_npu()
 
         config.switch_use_feed_fetch_ops(False)
         self.predictor = paddle.inference.create_predictor(config)

--- a/tests/test_tipc/ernie_text_matching/predict.py
+++ b/tests/test_tipc/ernie_text_matching/predict.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
     parser.add_argument("--model_dir", type=str, required=True, help="The directory to static model.")
     parser.add_argument("--max_seq_length", default=128, type=int, help="The maximum total input sequence length after tokenization. Sequences longer than this will be truncated, sequences shorter will be padded.")
     parser.add_argument("--batch_size", default=32, type=int, help="Batch size per GPU/CPU for training.")
-    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
+    parser.add_argument('--device', choices=['cpu', 'gpu', 'xpu', 'npu'], default="gpu", help="Select which device to train model, defaults to gpu.")
     parser.add_argument('--use_tensorrt', default=False, type=eval, choices=[True, False], help='Enable to use tensorrt to speed up.')
     parser.add_argument("--precision", default="fp32", type=str, choices=["fp32", "fp16", "int8"], help='The tensorrt precision.')
     parser.add_argument('--cpu_threads', default=10, type=int, help='Number of threads to predict when using cpu.')

--- a/tests/test_tipc/ernie_text_matching/train.py
+++ b/tests/test_tipc/ernie_text_matching/train.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     parser.add_argument("--init_from_ckpt", type=str, default=None, help="The path of checkpoint to be loaded.")
     parser.add_argument("--seed", type=int, default=1000, help="Random seed for initialization.")
     parser.add_argument("--max_steps", default=-1, type=int, help="If > 0: set total number of training steps to perform.")
-    parser.add_argument('--device', choices=['cpu', 'gpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
+    parser.add_argument('--device', choices=['cpu', 'gpu', 'npu', 'xpu'], default="gpu", help="Select which device to train model, defaults to gpu.")
     args = parser.parse_args()
     # yapf: enable
     do_train(args)

--- a/tests/test_tipc/test_train_inference_python_npu.sh
+++ b/tests/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+function func_parser_dir() {
+    strs=$1
+    IFS="/"
+    array=(${strs})
+    len=${#array[*]}
+    dir=""
+    count=1
+    for arr in ${array[*]}; do 
+        if [ ${len} = "${count}" ]; then
+            continue;
+        else
+            dir="${dir}/${arr}"
+            count=$((${count} + 1))
+        fi
+    done
+    echo "${dir}"
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/--device:gpu/--device:npu/g" $FILENAME
+sed -i "s/gpu_list:0|0,1/gpu_list:1/g" $FILENAME
+sed -i "s/state=GPU/state=NPU|cpu/g" $FILENAME
+sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
+sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
+sed -i "s/--device:cpu|gpu/--device:cpu|npu/g" $FILENAME
+sed -i "s/--device:gpu|cpu/--device:cpu|npu/g" $FILENAME
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+sed -i "s/--use_tensorrt:False|True/--use_tensorrt:False/g" $FILENAME
+sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh
+
+# parser params
+dataline=`cat $FILENAME`
+IFS=$'\n'
+lines=(${dataline})
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd
+
+

--- a/tests/test_tipc/test_train_inference_python_npu.sh
+++ b/tests/test_tipc/test_train_inference_python_npu.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 source test_tipc/common_func.sh
 
 function readlinkf() {

--- a/tests/test_tipc/test_train_inference_python_npu.sh
+++ b/tests/test_tipc/test_train_inference_python_npu.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 source test_tipc/common_func.sh
 
 function readlinkf() {

--- a/tests/test_tipc/test_train_inference_python_xpu.sh
+++ b/tests/test_tipc/test_train_inference_python_xpu.sh
@@ -19,12 +19,12 @@ REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
 FILENAME=$1
 
 # change gpu to npu in tipc txt configs
-sed -i "s/--device:gpu/--device:npu/g" $FILENAME
-sed -i "s/state=GPU/state=NPU/g" $FILENAME
+sed -i "s/--device:gpu/--device:xpu/g" $FILENAME
+sed -i "s/state=GPU/state=XPU/g" $FILENAME
 sed -i "s/trainer:pact_train/trainer:norm_train/g" $FILENAME
 sed -i "s/trainer:fpgm_train/trainer:norm_train/g" $FILENAME
-sed -i "s/--device:cpu|gpu/--device:cpu|npu/g" $FILENAME
-sed -i "s/--device:gpu|cpu/--device:cpu|npu/g" $FILENAME
+sed -i "s/--device:cpu|gpu/--device:cpu|xpu/g" $FILENAME
+sed -i "s/--device:gpu|cpu/--device:cpu|xpu/g" $FILENAME
 sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
 sed -i "s/--use_tensorrt:False|True/--use_tensorrt:False/g" $FILENAME
 sed -i 's/\"gpu\"/\"npu\"/g' test_tipc/test_train_inference_python.sh

--- a/tests/test_tipc/test_train_inference_python_xpu.sh
+++ b/tests/test_tipc/test_train_inference_python_xpu.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 source test_tipc/common_func.sh
 
 function readlinkf() {

--- a/tests/test_tipc/test_train_inference_python_xpu.sh
+++ b/tests/test_tipc/test_train_inference_python_xpu.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 source test_tipc/common_func.sh
 
 function readlinkf() {

--- a/tests/transformer/train.py
+++ b/tests/transformer/train.py
@@ -81,10 +81,12 @@ def parse_args():
         type=str,
         help="The eos token. It should be provided when use custom vocab_file. "
     )
-    parser.add_argument("--device", 
-                        default="gpu", 
-                        choices=["gpu", "cpu", "xpu", "npu"], 
-                        help="Device selected for inference.")
+    parser.add_argument(
+        "--device", 
+        default="gpu", 
+        choices=["gpu", "cpu", "xpu", "npu"], 
+        help="Device selected for inference.")
+
     args = parser.parse_args()
     return args
 
@@ -99,15 +101,18 @@ def do_train(args):
     if args.device == "gpu":
         rank = dist.get_rank()
         trainer_count = dist.get_world_size()
+    elif args.device == "npu":
+        rank = dist.get_rank()
+        trainer_count = dist.get_world_size()
+        paddle.set_device("npu")
+    elif args.device == "xpu":
+        rank = dist.get_rank()
+        trainer_count = dist.get_world_size()
+        paddle.set_device("xpu")
     else:
         rank = 0
         trainer_count = 1
-        if args.device == "npu":
-            paddle.set_device("npu")
-        elif args.device == "xpu":
-            paddle.set_device("xpu")
-        else:
-            paddle.set_device("cpu")
+        paddle.set_device("cpu")
 
     if trainer_count > 1:
         dist.init_parallel_env()

--- a/tests/transformer/train.py
+++ b/tests/transformer/train.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import time
@@ -81,11 +95,10 @@ def parse_args():
         type=str,
         help="The eos token. It should be provided when use custom vocab_file. "
     )
-    parser.add_argument(
-        "--device", 
-        default="gpu", 
-        choices=["gpu", "cpu", "xpu", "npu"], 
-        help="Device selected for inference.")
+    parser.add_argument("--device",
+                        default="gpu",
+                        choices=["gpu", "cpu", "xpu", "npu"],
+                        help="Device selected for inference.")
 
     args = parser.parse_args()
     return args

--- a/tests/transformer/train.py
+++ b/tests/transformer/train.py
@@ -81,6 +81,10 @@ def parse_args():
         type=str,
         help="The eos token. It should be provided when use custom vocab_file. "
     )
+    parser.add_argument("--device", 
+                        default="gpu", 
+                        choices=["gpu", "cpu", "xpu", "npu"], 
+                        help="Device selected for inference.")
     args = parser.parse_args()
     return args
 
@@ -98,7 +102,12 @@ def do_train(args):
     else:
         rank = 0
         trainer_count = 1
-        paddle.set_device("cpu")
+        if args.device == "npu":
+            paddle.set_device("npu")
+        elif args.device == "xpu":
+            paddle.set_device("xpu")
+        else:
+            paddle.set_device("cpu")
 
     if trainer_count > 1:
         dist.init_parallel_env()
@@ -317,6 +326,7 @@ if __name__ == "__main__":
     args.unk_token = ARGS.unk_token
     args.bos_token = ARGS.bos_token
     args.eos_token = ARGS.eos_token
+    args.device = ARGS.device
     pprint(args)
 
     do_train(args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
New features

### PR changes
Others 

### Description

为昇腾和昆仑设备添加 TIPC 脚本:

#### 准备小数据集
`bash test_tipc/prepare.sh ./test_tipc/configs/bigru_crf/train_infer_python.txt 'lite_train_lite_infer'
`
#### NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
```
bash test_tipc/test_train_inference_python_npu.sh \
         ./test_tipc/configs/bigru_crf/train_infer_python.txt 'lite_train_lite_infer'

```
#### XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
```
bash test_tipc/test_train_inference_python_xpu.sh \
         ./test_tipc/configs/bigru_crf/train_infer_python.txt 'lite_train_lite_infer'

```