### PR TITLE
代码示例有问题

### DIFF
--- a/docs/data_prepare/data_preprocess.rst
+++ b/docs/data_prepare/data_preprocess.rst
@@ -75,7 +75,7 @@ paddlenlp内置的 :class:`paddlenlp.datasets.MapDataset` 的 :func:`map` 方法
     def convert_examples(examples, tokenizer):
         querys = [example['query'] for example in examples]
         titles = [example['title'] for example in examples]
-        tokenized_examples = tokenizer(text=querys, text_pair=titles)
+        tokenized_examples = tokenizer(text=querys, text_pair=titles,return_dict=False)
 
         # 加上label用于训练
         for idx in range(len(tokenized_examples)):


### PR DESCRIPTION
在map()中batched=true时，使用tokenizer进行分词若不设置return_dict=False会生成dict类型，此时在下方for循环中无法使用[idx]来定位，会运行报错，需要设置return_dict=False后才能使用[idx]进行定位。

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
