### PR TITLE
fix bigru crf offset index error

### DIFF
--- a/tests/test_tipc/bigru_crf/deploy/predict.py
+++ b/tests/test_tipc/bigru_crf/deploy/predict.py
@@ -97,11 +97,17 @@ def load_vocab(dict_path):
     return vocab
 
 
-def parse_result(words, preds, lengths, word_vocab, label_vocab):
+def parse_result(words,
+                 preds,
+                 lengths,
+                 word_vocab,
+                 label_vocab,
+                 with_start_stop_tag=True):
     """ Parse padding result """
     batch_out = []
     id2word_dict = dict(zip(word_vocab.values(), word_vocab.keys()))
     id2label_dict = dict(zip(label_vocab.values(), label_vocab.keys()))
+    offset = 1 if with_start_stop_tag else 0
     for sent_index in range(len(lengths)):
         sent = [
             id2word_dict[index]
@@ -109,7 +115,7 @@ def parse_result(words, preds, lengths, word_vocab, label_vocab):
         ]
         tags = [
             id2label_dict[index]
-            for index in preds[sent_index][:lengths[sent_index]]
+            for index in preds[sent_index][offset:offset + lengths[sent_index]]
         ]
 
         sent_out = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
由于BiGruCrf使用了with_start_stop_tag，因此返回的时候会带上start和stop的标记即，
`[start标记] 预测token标记1，预测token标记2，......[end标记]`。所以解码标签需要从 1开始解码。
【TIPC】PaddleNLP bigru_crf 推理随机hang。
![image](https://user-images.githubusercontent.com/50394665/194739210-9d1b4e75-e55d-4da4-95ef-f167b23ee0b3.png)
