### PR TITLE
fix bug of debug mode

### DIFF
--- a/model_zoo/uie/utils.py
+++ b/model_zoo/uie/utils.py
@@ -334,7 +334,8 @@ def get_relation_type_dict(relation_data):
                 added_list.append(relation_data[i][0])
                 suffix = relation_data[i][0].rsplit("的", 1)[1]
                 suffix = unify_prompt_name(suffix)
-                relation_type_dict[suffix] = relation_data[i][1]
+                relation_type_dict.setdefault(suffix,
+                                              []).append(relation_data[i][1])
     return relation_type_dict
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- fix bug of debug mode when there is only one raw data in a class
- Traceback：

```python
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 218, in _thread_loop
    self._thread_done_event)
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/dataloader/fetcher.py", line 121, in fetch
    data.append(self.dataset[idx])
  File "/usr/local/lib/python3.7/dist-packages/paddlenlp/datasets/dataset.py", line 277, in __getitem__
    ) if self._transform_pipline else self.new_data[idx]
KeyError: 0
```