### PR TITLE
fix bigru crf offset index error

### DIFF
--- a/tests/test_tipc/bigru_crf/data.py
+++ b/tests/test_tipc/bigru_crf/data.py
@@ -141,7 +141,7 @@ def parse_result(words, preds, lengths, word_vocab, label_vocab):
             for index in words[sent_index][:lengths[sent_index]]
         ]
         tags = [
-            id2label_dict[index]
+            id2label_dict.get(index, 'O')
             for index in preds[sent_index][:lengths[sent_index]]
         ]
 

--- a/tests/test_tipc/bigru_crf/deploy/predict.py
+++ b/tests/test_tipc/bigru_crf/deploy/predict.py
@@ -108,7 +108,7 @@ def parse_result(words, preds, lengths, word_vocab, label_vocab):
             for index in words[sent_index][:lengths[sent_index]]
         ]
         tags = [
-            id2label_dict[index]
+            id2label_dict.get(index, 'O')
             for index in preds[sent_index][:lengths[sent_index]]
         ]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
PaddleNLP bigru_crf 推理随机hang
- 由于训练epoch数量过小，导致模型在预测的时候，可能会预测书start和stop标记，而这些标记是不应该被预测的，因此将这些标记index值设置为『O』。
- 如图所示 0-66表示实际标签，67，68分别表示start和stop标记。
![image](https://user-images.githubusercontent.com/50394665/194742606-6952a3fc-a796-4006-93fe-63bf789481c9.png)
