### PR TITLE
fix bert unittest bug

### DIFF
--- a/tests/transformers/bert/test_modeling.py
+++ b/tests/transformers/bert/test_modeling.py
@@ -312,12 +312,10 @@ class BertModelTester:
                        return_dict=self.return_dict)
         if token_labels is not None:
             result = result[1:]
-        elif paddle.is_tensor(result):
-            result = [result]
 
-        self.parent.assertEqual(result[1].shape,
+        self.parent.assertEqual(result[0].shape,
                                 [self.batch_size, self.seq_length])
-        self.parent.assertEqual(result[2].shape,
+        self.parent.assertEqual(result[1].shape,
                                 [self.batch_size, self.seq_length])
 
     def create_and_check_for_sequence_classification(

--- a/tests/transformers/bert/test_modeling.py
+++ b/tests/transformers/bert/test_modeling.py
@@ -310,7 +310,7 @@ class BertModelTester:
                        start_positions=sequence_labels,
                        end_positions=sequence_labels,
                        return_dict=self.return_dict)
-        if token_labels is not None:
+        if sequence_labels is not None:
             result = result[1:]
 
         self.parent.assertEqual(result[0].shape,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description

在 https://github.com/PaddlePaddle/PaddleNLP/pull/3130 中Bert的单测通过了（本不该过），导致这里的一个潜在bug。

我本地针对于`bert`, `ernie`, `roberta`, `roformer`做了测试，是通过的。