### PR TITLE
[MLU] support SQuAD_Bert with mlu device

### DIFF
--- a/examples/machine_reading_comprehension/SQuAD/args.py
+++ b/examples/machine_reading_comprehension/SQuAD/args.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 
 
@@ -78,7 +92,7 @@ def parse_args():
                         help="random seed for initialization")
     parser.add_argument(
         '--device',
-        choices=['cpu', 'gpu'],
+        choices=['cpu', 'gpu', 'mlu'],
         default="gpu",
         help="Select which device to train model, defaults to gpu.")
     parser.add_argument(
@@ -131,5 +145,12 @@ def parse_args():
     parser.add_argument("--do_predict",
                         action='store_true',
                         help="Whether to predict.")
+    parser.add_argument("--use_amp",
+                        action='store_true',
+                        help="Whether to use AMP.")
+    parser.add_argument("--scale_loss",
+                        type=float,
+                        default=2**15,
+                        help="The value of scale_loss for fp16.")
     args = parser.parse_args()
     return args


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
适配 MLU 设备，以运行 SQuAD_Bert example。并且适配了 amp 模式。MLU 和 GPU 均测试通过。

#### MLU
**1、mlu FP32 运行脚本： **
```bash
python -m paddle.distributed.launch --mlus "0,1,2,3,4,5,6,7" run_squad.py \
    --model_type bert \
    --model_name_or_path bert-base-uncased \
    --max_seq_length 384 \
    --batch_size 12 \
    --learning_rate 3e-5 \
    --num_train_epochs 2 \
    --logging_steps 100 \
    --save_steps 1000 \
    --warmup_proportion 0.1 \
    --weight_decay 0.01 \
    --output_dir ./output_bert/8c_fp16 \
    --device mlu \
    --do_train \
    --do_predict
```
精度结果：
![image](https://user-images.githubusercontent.com/25411141/195044588-8fc78241-a349-4f23-9fb3-2d75405f8684.png)


**2、mlu AMP 运行脚本： **
```bash
python -m paddle.distributed.launch --mlus "0,1,2,3,4,5,6,7" run_squad.py \
    --model_type bert \
    --model_name_or_path bert-base-uncased \
    --max_seq_length 384 \
    --batch_size 12 \
    --learning_rate 3e-5 \
    --num_train_epochs 2 \
    --logging_steps 100 \
    --save_steps 1000 \
    --warmup_proportion 0.1 \
    --weight_decay 0.01 \
    --output_dir ./output_bert/8c_fp16 \
    --device mlu \
    --do_train \
    --do_predict \
    --use_amp
```
精度结果：
![image](https://user-images.githubusercontent.com/25411141/195037246-67e01e6a-9dda-499b-a432-2c864196cd4f.png)


#### GPU
**1、gpu FP32 运行脚本： **
```bash
python -m paddle.distributed.launch --gpus "0,1,2,3,4,5,6,7" run_squad.py \
    --model_type bert \
    --model_name_or_path bert-base-uncased \
    --max_seq_length 384 \
    --batch_size 12 \
    --learning_rate 3e-5 \
    --num_train_epochs 2 \
    --logging_steps 100 \
    --save_steps 1000 \
    --warmup_proportion 0.1 \
    --weight_decay 0.01 \
    --output_dir ./output_bert/8c_fp16 \
    --device gpu \
    --do_train \
    --do_predict \
    --use_amp
```
精度结果：
![image](https://user-images.githubusercontent.com/25411141/195044833-32b5e302-e948-4b68-9754-f9fb2ea26087.png)


**2、gpu AMP 运行脚本： **
```bash
python -m paddle.distributed.launch --gpus "0,1,2,3,4,5,6,7" run_squad.py \
    --model_type bert \
    --model_name_or_path bert-base-uncased \
    --max_seq_length 384 \
    --batch_size 12 \
    --learning_rate 3e-5 \
    --num_train_epochs 2 \
    --logging_steps 100 \
    --save_steps 1000 \
    --warmup_proportion 0.1 \
    --weight_decay 0.01 \
    --output_dir ./output_bert/8c_fp16 \
    --device gpu \
    --do_train \
    --do_predict \
    --use_amp
```
精度结果：
![image](https://user-images.githubusercontent.com/25411141/195037609-488d1c6d-4b8b-4b53-8636-c98415cbd946.png)

