### PR TITLE
improve setup.py for easier dev environment setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def get_package_data_files(package, data, package_dir=None):
 
 setuptools.setup(
     name="paddlenlp",
-    version="2.4.0.dev",  # modify this for each release
+    version="2.4.1.dev",  # modify this for each release
     author="PaddleNLP Team",
     author_email="paddlenlp@baidu.com",
     description=

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 import os
 import setuptools
-import sys
 import io
-import paddlenlp
 
-with open("requirements.txt") as fin:
-    REQUIRED_PACKAGES = fin.read()
+def read_requirements_file(filepath):
+    with open(filepath) as fin:
+        requirements = fin.read()
+    return requirements
 
+extras = {}
+REQUIRED_PACKAGES = read_requirements_file("requirements.txt")
+extras["tests"] = read_requirements_file("tests/requirements.txt")
+extras["docs"] = read_requirements_file("docs/requirements.txt")
+extras["dev"] = extras["tests"] + extras["docs"]
 
 def read(*names, **kwargs):
     with io.open(os.path.join(os.path.dirname(__file__), *names),
@@ -51,7 +56,7 @@ def get_package_data_files(package, data, package_dir=None):
 
 setuptools.setup(
     name="paddlenlp",
-    version=paddlenlp.__version__,
+    version="2.4.0.dev",  # modify this for each release
     author="PaddleNLP Team",
     author_email="paddlenlp@baidu.com",
     description=
@@ -75,6 +80,7 @@ setuptools.setup(
     },
     setup_requires=['cython', 'numpy'],
     install_requires=REQUIRED_PACKAGES,
+    extras_require=extras,
     python_requires='>=3.6',
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Function optimization

### PR changes
Others

### Description
Currently, the `setup.py` has a bug when running `pip3 install -e .` due to a circular dependency issue (calling [`import paddlenlp`](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/setup.py#L18) in a file that is supposed to install `paddlenlp ` itself...). 

This PR improves the current `setup.py` for easier dev environment setup, especially for power users and potential open source contributors.

1. Want to install the newest nightly build that has the latest features? `pip3 install -e .`
2. New open source contributor who wants to setup the dev environment with a single line?  `pip3 install -e ".[dev]"`


