### PR TITLE
Fix bug in ocr_process.py

### DIFF
--- a/applications/doc_vqa/OCR_process/ocr_process.py
+++ b/applications/doc_vqa/OCR_process/ocr_process.py
@@ -271,7 +271,7 @@ def ocr_preprocess(img_dir):
                        key=lambda x: int(x.split("_")[1].split(".")[0]))
     for img_name in img_names:
         img_path = os.path.join(img_dir, img_name)
-        parsing_res = ocr.ocr(img_path, cls=True)
+        parsing_res = ocr.ocr(img_path, cls=True)[0]
         ocr_res = []
         for para in parsing_res:
             ocr_res.append({"text": para[1][0], "bbox": para[0]})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
`PaddleOCR.ocr` accept a list or single filepath, but although single file is passed, it will return a list with only result.

```python
# code in https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.6/paddleocr.py
# line 532
            if not isinstance(img, list):
                img = [img]
            if self.use_angle_cls and cls:
                img, cls_res, elapse = self.text_classifier(img)
                if not rec:
                    return cls_res
            rec_res, elapse = self.text_recognizer(img)
            return rec_res
```

so need get first element from the result list.