### PR TITLE
fix logits calculation error in albert/fnet QA models

### DIFF
--- a/paddlenlp/transformers/albert/modeling.py
+++ b/paddlenlp/transformers/albert/modeling.py
@@ -1875,7 +1875,7 @@ class AlbertForQuestionAnswering(AlbertPretrainedModel):
                                                 num_or_sections=2,
                                                 axis=-1)
         start_logits = start_logits.squeeze(axis=-1)
-        end_logits = start_logits.squeeze(axis=-1)
+        end_logits = end_logits.squeeze(axis=-1)
 
         total_loss = None
         if start_positions is not None and end_positions is not None:

--- a/paddlenlp/transformers/fnet/modeling.py
+++ b/paddlenlp/transformers/fnet/modeling.py
@@ -1145,7 +1145,7 @@ class FNetForQuestionAnswering(FNetPretrainedModel):
                                                 num_or_sections=1,
                                                 axis=-1)
         start_logits = start_logits.squeeze(axis=-1)
-        end_logits = start_logits.squeeze(axis=-1)
+        end_logits = end_logits.squeeze(axis=-1)
         if return_dict:
             return {
                 "start_logits": start_logits,

--- a/paddlenlp/transformers/fnet/modeling.py
+++ b/paddlenlp/transformers/fnet/modeling.py
@@ -1111,7 +1111,7 @@ class FNetForQuestionAnswering(FNetPretrainedModel):
 
     """
 
-    def __init__(self, fnet, num_labels):
+    def __init__(self, fnet, num_labels=2):
         super(FNetForQuestionAnswering, self).__init__()
         self.num_labels = num_labels
         self.fnet = fnet
@@ -1142,7 +1142,7 @@ class FNetForQuestionAnswering(FNetPretrainedModel):
             "last_hidden_state"]
         logits = self.qa_outputs(sequence_output)
         start_logits, end_logits = paddle.split(logits,
-                                                num_or_sections=1,
+                                                num_or_sections=2,
                                                 axis=-1)
         start_logits = start_logits.squeeze(axis=-1)
         end_logits = end_logits.squeeze(axis=-1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Models

### Description
1. 修改 `FNetForQuestionAnswering` 及 `AlbertForQuestionAnswering` 计算 `end_logits` 时候出现的变量引用错误。
原始代码中，针对 question answering 任务计算的 `start_logits` 与 `end_logits` 相同：
```python
import paddle
from paddlenlp.transformers import  AlbertForQuestionAnswering, AlbertTokenizer

tokenizer = AlbertTokenizer.from_pretrained('albert-base-v1')
model =  AlbertForQuestionAnswering.from_pretrained('albert-base-v1')

inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
start_logits, end_logits  = model(**inputs)

print(start_logits == end_logits)
# Tensor(shape=[1, 13], dtype=bool, place=Place(gpu:0), stop_gradient=True,
#        [[True, True, True, True, True, True, True, True, True, True, True, True,
#          True]])
```

2. 修改 `FNetForQuestionAnswering` 中 `forward` 函数bug。