### PR TITLE
[BugFix] fix astype error when dynamic-to-static mode

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -576,7 +576,11 @@ class PretrainedModel(Layer, GenerationMixin):
                 dtype = str(v.dtype)[dtype_prefix_len:]
             # TODO(guosheng): add warnings for unmatched dtypes
             if k in state_to_load:
-                state_to_load[k] = paddle.cast(state_to_load[k], dtype)
+                if paddle.in_dynamic_mode():
+                    state_to_load[k] = paddle.cast(state_to_load[k], dtype)
+                else:
+                    state_to_load[k] = np.array(state_to_load[k])
+                    state_to_load[k] = state_to_load[k].astype(dtype)
 
         # For model parallel if FasterGeneration
         # To avoid recursive import temporarily.

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -576,7 +576,7 @@ class PretrainedModel(Layer, GenerationMixin):
                 dtype = str(v.dtype)[dtype_prefix_len:]
             # TODO(guosheng): add warnings for unmatched dtypes
             if k in state_to_load:
-                state_to_load[k] = state_to_load[k].astype(dtype)
+                state_to_load[k] = paddle.cast(state_to_load[k], dtype)
 
         # For model parallel if FasterGeneration
         # To avoid recursive import temporarily.

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -579,6 +579,10 @@ class PretrainedModel(Layer, GenerationMixin):
                 if paddle.in_dynamic_mode():
                     state_to_load[k] = paddle.cast(state_to_load[k], dtype)
                 else:
+                    # there are some latent error when case dtype in static-mode, so let's:
+                    # 1. convert fluid.*.Tensor -> numpy.ndarray
+                    # 2. cast the dtype with numpy tools
+                    # 3. paddle works well with ndarray state-dict
                     state_to_load[k] = np.array(state_to_load[k])
                     state_to_load[k] = state_to_load[k].astype(dtype)
 

--- a/ppdiffusers/Makefile
+++ b/ppdiffusers/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := all
 
 .PHONY: all
-all: build deploy-version deploy
+all: deploy-version build deploy
 
 .PHONY: build
 build:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

when converting dynamic to static model, there is an error in `astype` snippet code. So to fix it .
