### PR TITLE
[ppdiffusers] support EulerAncestralDiscreteScheduler

### DIFF
--- a/ppdiffusers/README.md
+++ b/ppdiffusers/README.md
@@ -133,7 +133,7 @@ import PIL
 import requests
 from io import BytesIO
 
-from ppdiffusers import StableDiffusionInpaintPipeline
+from ppdiffusers import StableDiffusionInpaintPipeline, EulerAncestralDiscreteScheduler
 
 def download_image(url):
     response = requests.get(url)
@@ -145,8 +145,8 @@ mask_url = "https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diff
 
 init_image = download_image(img_url).resize((512, 512))
 mask_image = download_image(mask_url).resize((512, 512))
-
-pipe = StableDiffusionInpaintPipeline.from_pretrained("runwayml/stable-diffusion-inpainting")
+scheduler = EulerAncestralDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
+pipe = StableDiffusionInpaintPipeline.from_pretrained("runwayml/stable-diffusion-inpainting", scheduler=scheduler)
 
 prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
 image = pipe(prompt=prompt, image=init_image, mask_image=mask_image).images[0]

--- a/ppdiffusers/ppdiffusers/__init__.py
+++ b/ppdiffusers/ppdiffusers/__init__.py
@@ -46,6 +46,7 @@ if is_paddle_available():
     from .pipeline_utils import DiffusionPipeline
     from .pipelines import DDIMPipeline, DDPMPipeline, KarrasVePipeline, LDMPipeline, PNDMPipeline, ScoreSdeVePipeline
     from .schedulers import (
+        EulerAncestralDiscreteScheduler,
         DDIMScheduler,
         DDPMScheduler,
         KarrasVeScheduler,

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -23,7 +23,7 @@ from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPToke
 from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
-from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, EulerAncestralDiscreteScheduler
 from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
@@ -65,7 +65,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
+        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler,
+                         EulerAncestralDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_all_in_one.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_all_in_one.py
@@ -30,7 +30,7 @@ from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPToke
 from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
-from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, EulerAncestralDiscreteScheduler
 from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
@@ -490,7 +490,8 @@ class StableDiffusionPipelineAllinOne(DiffusionPipeline):
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
+        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler,
+                         EulerAncestralDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -31,7 +31,7 @@ from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPToke
 from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
-from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, EulerAncestralDiscreteScheduler
 from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
@@ -83,7 +83,8 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
+        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler,
+                         EulerAncestralDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -30,7 +30,7 @@ from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPToke
 from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
-from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, EulerAncestralDiscreteScheduler
 from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
@@ -87,7 +87,8 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
+        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler,
+                         EulerAncestralDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
@@ -31,7 +31,7 @@ from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPToke
 from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
-from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, EulerAncestralDiscreteScheduler
 from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
@@ -94,7 +94,8 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
+        scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler,
+                         EulerAncestralDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):

--- a/ppdiffusers/ppdiffusers/schedulers/__init__.py
+++ b/ppdiffusers/ppdiffusers/schedulers/__init__.py
@@ -16,6 +16,7 @@
 from ..utils import is_scipy_available, is_paddle_available
 
 if is_paddle_available():
+    from .scheduling_euler_ancestral_discrete import EulerAncestralDiscreteScheduler
     from .scheduling_ddim import DDIMScheduler
     from .scheduling_ddpm import DDPMScheduler
     from .scheduling_karras_ve import KarrasVeScheduler

--- a/ppdiffusers/ppdiffusers/schedulers/scheduling_euler_ancestral_discrete.py
+++ b/ppdiffusers/ppdiffusers/schedulers/scheduling_euler_ancestral_discrete.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright 2022 Katherine Crowson and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import paddle
+
+from ..configuration_utils import ConfigMixin, register_to_config
+from ..utils import BaseOutput, logging
+from .scheduling_utils import SchedulerMixin
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+@dataclass
+class EulerAncestralDiscreteSchedulerOutput(BaseOutput):
+    """
+    Output class for the scheduler's step function output.
+
+    Args:
+        prev_sample (`paddle.Tensor` of shape `(batch_size, num_channels, height, width)` for images):
+            Computed sample (x_{t-1}) of previous timestep. `prev_sample` should be used as next model input in the
+            denoising loop.
+        pred_original_sample (`paddle.Tensor` of shape `(batch_size, num_channels, height, width)` for images):
+            The predicted denoised sample (x_{0}) based on the model output from the current timestep.
+            `pred_original_sample` can be used to preview progress or for guidance.
+    """
+
+    prev_sample: paddle.Tensor
+    pred_original_sample: Optional[paddle.Tensor] = None
+
+
+class EulerAncestralDiscreteScheduler(SchedulerMixin, ConfigMixin):
+    """
+    Ancestral sampling with Euler method steps. Based on the original k-diffusion implementation by Katherine Crowson:
+    https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L72
+
+    [`~ConfigMixin`] takes care of storing all config attributes that are passed in the scheduler's `__init__`
+    function, such as `num_train_timesteps`. They can be accessed via `scheduler.config.num_train_timesteps`.
+    [`~ConfigMixin`] also provides general loading and saving functionality via the [`~ConfigMixin.save_config`] and
+    [`~ConfigMixin.from_config`] functions.
+
+    Args:
+        num_train_timesteps (`int`): number of diffusion steps used to train the model.
+        beta_start (`float`): the starting `beta` value of inference.
+        beta_end (`float`): the final `beta` value.
+        beta_schedule (`str`):
+            the beta schedule, a mapping from a beta range to a sequence of betas for stepping the model. Choose from
+            `linear` or `scaled_linear`.
+        trained_betas (`np.ndarray`, optional):
+            option to pass an array of betas directly to the constructor to bypass `beta_start`, `beta_end` etc.
+
+    """
+
+    _compatible_classes = [
+        "DDIMScheduler",
+        "DDPMScheduler",
+        "LMSDiscreteScheduler",
+        "PNDMScheduler",
+        "EulerDiscreteScheduler",
+        "DPMSolverMultistepScheduler",
+    ]
+
+    @register_to_config
+    def __init__(
+        self,
+        num_train_timesteps: int = 1000,
+        beta_start: float = 0.0001,
+        beta_end: float = 0.02,
+        beta_schedule: str = "linear",
+        trained_betas: Optional[np.ndarray] = None,
+    ):
+        if trained_betas is not None:
+            self.betas = paddle.to_tensor(trained_betas)
+        elif beta_schedule == "linear":
+            self.betas = paddle.linspace(beta_start,
+                                         beta_end,
+                                         num_train_timesteps,
+                                         dtype="float32")
+        elif beta_schedule == "scaled_linear":
+            # this schedule is very specific to the latent diffusion model.
+            self.betas = (paddle.linspace(beta_start**0.5,
+                                          beta_end**0.5,
+                                          num_train_timesteps,
+                                          dtype="float32")**2)
+        else:
+            raise NotImplementedError(
+                f"{beta_schedule} does is not implemented for {self.__class__}")
+
+        self.alphas = 1.0 - self.betas
+        self.alphas_cumprod = paddle.cumprod(self.alphas, 0)
+
+        sigmas = np.array(
+            ((1 - self.alphas_cumprod) / self.alphas_cumprod)**0.5)
+        sigmas = np.concatenate([sigmas[::-1], [0.0]]).astype(np.float32)
+        self.sigmas = paddle.to_tensor(sigmas)
+
+        # standard deviation of the initial noise distribution
+        self.init_noise_sigma = self.sigmas.max()
+
+        # setable values
+        self.num_inference_steps = None
+        timesteps = np.linspace(0,
+                                num_train_timesteps - 1,
+                                num_train_timesteps,
+                                dtype=float)[::-1].copy()
+        self.timesteps = paddle.to_tensor(timesteps)
+        self.is_scale_input_called = False
+
+    def scale_model_input(
+            self, sample: paddle.Tensor,
+            timestep: Union[float, paddle.Tensor]) -> paddle.Tensor:
+        """
+        Scales the denoising model input by `(sigma**2 + 1) ** 0.5` to match the Euler algorithm.
+
+        Args:
+            sample (`paddle.Tensor`): input sample
+            timestep (`float` or `paddle.Tensor`): the current timestep in the diffusion chain
+
+        Returns:
+            `paddle.Tensor`: scaled input sample
+        """
+        step_index = (self.timesteps == timestep).nonzero().item()
+        sigma = self.sigmas[step_index]
+        sample = sample / ((sigma**2 + 1)**0.5)
+        self.is_scale_input_called = True
+        return sample
+
+    def set_timesteps(self, num_inference_steps: int):
+        """
+        Sets the timesteps used for the diffusion chain. Supporting function to be run before inference.
+
+        Args:
+            num_inference_steps (`int`):
+                the number of diffusion steps used when generating samples with a pre-trained model.
+        """
+        self.num_inference_steps = num_inference_steps
+
+        timesteps = np.linspace(0,
+                                self.config.num_train_timesteps - 1,
+                                num_inference_steps,
+                                dtype=float)[::-1].copy()
+        sigmas = np.array(
+            ((1 - self.alphas_cumprod) / self.alphas_cumprod)**0.5)
+        sigmas = np.interp(timesteps, np.arange(0, len(sigmas)), sigmas)
+        sigmas = np.concatenate([sigmas, [0.0]]).astype(np.float32)
+        self.sigmas = paddle.to_tensor(sigmas)
+        self.timesteps = paddle.to_tensor(timesteps)
+
+    def step(
+        self,
+        model_output: paddle.Tensor,
+        timestep: Union[float, paddle.Tensor],
+        sample: paddle.Tensor,
+        return_dict: bool = True,
+    ) -> Union[EulerAncestralDiscreteSchedulerOutput, Tuple]:
+        """
+        Predict the sample at the previous timestep by reversing the SDE. Core function to propagate the diffusion
+        process from the learned model outputs (most often the predicted noise).
+
+        Args:
+            model_output (`paddle.Tensor`): direct output from learned diffusion model.
+            timestep (`float`): current timestep in the diffusion chain.
+            sample (`paddle.Tensor`):
+                current instance of sample being created by diffusion process.
+            return_dict (`bool`): option for returning tuple rather than EulerAncestralDiscreteSchedulerOutput class
+
+        Returns:
+            [`~schedulers.scheduling_utils.EulerAncestralDiscreteSchedulerOutput`] or `tuple`:
+            [`~schedulers.scheduling_utils.EulerAncestralDiscreteSchedulerOutput`] if `return_dict` is True, otherwise
+            a `tuple`. When returning a tuple, the first element is the sample tensor.
+
+        """
+        if not self.is_scale_input_called:
+            logger.warn(
+                "The `scale_model_input` function should be called before `step` to ensure correct denoising. "
+                "See `StableDiffusionPipeline` for a usage example.")
+        step_index = (self.timesteps == timestep).nonzero().item()
+        sigma = self.sigmas[step_index]
+
+        # 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
+        pred_original_sample = sample - sigma * model_output
+        sigma_from = self.sigmas[step_index]
+        sigma_to = self.sigmas[step_index + 1]
+        sigma_up = (sigma_to**2 * (sigma_from**2 - sigma_to**2) /
+                    sigma_from**2)**0.5
+        sigma_down = (sigma_to**2 - sigma_up**2)**0.5
+
+        # 2. Convert to an ODE derivative
+        derivative = (sample - pred_original_sample) / sigma
+
+        dt = sigma_down - sigma
+
+        prev_sample = sample + derivative * dt
+
+        noise = paddle.randn(model_output.shape, dtype=model_output.dtype)
+
+        prev_sample = prev_sample + noise * sigma_up
+
+        if not return_dict:
+            return (prev_sample, )
+
+        return EulerAncestralDiscreteSchedulerOutput(
+            prev_sample=prev_sample, pred_original_sample=pred_original_sample)
+
+    def add_noise(
+        self,
+        original_samples: paddle.Tensor,
+        noise: paddle.Tensor,
+        timesteps: paddle.Tensor,
+    ) -> paddle.Tensor:
+        # Make sure sigmas and timesteps have the same device and dtype as original_samples
+        self.sigmas = self.sigmas.astype(original_samples.dtype)
+
+        schedule_timesteps = self.timesteps
+        step_indices = [(schedule_timesteps == t).nonzero().item()
+                        for t in timesteps]
+
+        sigma = self.sigmas[step_indices].flatten()
+        while len(sigma.shape) < len(original_samples.shape):
+            sigma = sigma.unsqueeze(-1)
+
+        noisy_samples = original_samples + noise * sigma
+        return noisy_samples
+
+    def __len__(self):
+        return self.config.num_train_timesteps

--- a/ppdiffusers/ppdiffusers/utils/dummy_paddle_objects.py
+++ b/ppdiffusers/ppdiffusers/utils/dummy_paddle_objects.py
@@ -243,6 +243,21 @@ class DDIMScheduler(metaclass=DummyObject):
         requires_backends(cls, ["paddle"])
 
 
+class EulerAncestralDiscreteScheduler(metaclass=DummyObject):
+    _backends = ["paddle"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["paddle"])
+
+    @classmethod
+    def from_config(cls, *args, **kwargs):
+        requires_backends(cls, ["paddle"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["paddle"])
+
+
 class DDPMScheduler(metaclass=DummyObject):
     _backends = ["paddle"]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->

#### EulerAncestralDiscreteScheduler对齐
```python
from ppdiffusers import EulerAncestralDiscreteScheduler as PPEulerAncestralDiscreteScheduler
from diffusers import EulerAncestralDiscreteScheduler as HFEulerAncestralDiscreteScheduler
import torch
import paddle
import random

init_kwargs = dict(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
timestep = 1000
device = "cuda"
batch_size = 16

ppeuler = PPEulerAncestralDiscreteScheduler(**init_kwargs)
hfeuler = HFEulerAncestralDiscreteScheduler(**init_kwargs)
def compare(a, b):
    dif = a.cpu().numpy() - b.cpu().numpy()
    meandif, maxdif = abs(dif).mean(), abs(dif).max()
    print(meandif, maxdif)

# test set_timesteps
ppeuler.set_timesteps(timestep)
hfeuler.set_timesteps(timestep, device=device)
compare(ppeuler.sigmas, ppeuler.sigmas)
compare(ppeuler.timesteps, hfeuler.timesteps)

# test add_noise
hflatents = torch.randn((batch_size, 4, 64, 64)).to(device)
hfnoise = torch.randn((batch_size, 4, 64, 64)).to(device)
hftimesteps = torch.randint(0, timestep, (batch_size, )).long().to(device)
pplatents = paddle.to_tensor(hflatents.cpu().numpy())
ppnoise = paddle.to_tensor(hfnoise.cpu().numpy())
pptimesteps = paddle.to_tensor(hftimesteps.cpu().numpy())

hfnoisy_latents = hfeuler.add_noise(hflatents, hfnoise, hftimesteps)
ppnoisy_latents = ppeuler.add_noise(pplatents, ppnoise, pptimesteps)

compare(hfnoisy_latents, ppnoisy_latents)

t = random.randint(0, 1000)
hft = torch.tensor(t, device=device)
ppt = paddle.to_tensor(t)
# test scale_model_input
hfscale_model_input = hfeuler.scale_model_input(hflatents, hft)
ppscale_model_input = ppeuler.scale_model_input(pplatents, ppt)

compare(hfscale_model_input, ppscale_model_input)

# test step
seed = random.randint(0, 2**32)
generator = torch.Generator(device).manual_seed(seed)
paddle.seed(seed)
hfstep = hfeuler.step(hfnoise, hft, hflatents, generator=generator)
ppstep = ppeuler.step(ppnoise, ppt, pplatents)
compare(hfstep[0], ppstep[0])

# 0.0 0.0
# 0.0 0.0
# 4.1596826e-07 7.6293945e-06
# 0.0 0.0
# 8.9845884e-08 7.1525574e-07
```

#### runwayml/stable-diffusion-v1-5 及 runwayml/stable-diffusion-inpainting 权重转换及前向对齐 （Done）
```python

import torch
torch.set_grad_enabled(False)
from diffusers import StableDiffusionPipeline as HFStableDiffusionPipeline
import paddle
paddle.set_grad_enabled(False)
from ppdiffusers import StableDiffusionPipeline as PPStableDiffusionPipeline
def compare(a, b):
    dif = a.cpu().numpy() - b.cpu().numpy()
    meandif, maxdif = abs(dif).mean(), abs(dif).max()
    print(meandif, maxdif)
device = "cuda"

hf_pipe = HFStableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5").to(device)
pp_pipe = PPStableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5")

######## 1. vae
batch_size = 1
# encode
seed = 42
generator = torch.Generator(device).manual_seed(seed)
hfpixel_values = torch.randn((batch_size, 3, 224, 224), device=device, generator=generator)
hf_out = hf_pipe.vae.encode(hfpixel_values).latent_dist.sample(generator=generator)
paddle.seed(seed)
pppixel_values = paddle.randn((batch_size, 3, 224, 224))
pp_out = pp_pipe.vae.encode(pppixel_values).latent_dist.sample()
compare(hf_out, pp_out)

# decode
seed = 42
generator = torch.Generator(device).manual_seed(seed)
hfpixel_values = torch.randn((batch_size, 4, 64, 64), device=device, generator=generator)
hf_out = hf_pipe.vae.decode(hfpixel_values).sample
paddle.seed(seed)
pppixel_values = paddle.randn((batch_size, 4, 64, 64))
pp_out = pp_pipe.vae.decode(pppixel_values).sample
compare(hf_out, pp_out)

######## 2. unet
hflatents = torch.randn((batch_size, 4, 64, 64)).to(device)
hftimesteps = torch.randint(0, 1000, (batch_size, )).long().to(device)
hfembeddings = torch.randn((batch_size, 77, 768)).to(device)
pplatents = paddle.to_tensor(hflatents.cpu().numpy())
pptimesteps = paddle.to_tensor(hftimesteps.cpu().numpy())
ppembeddings = paddle.to_tensor(hfembeddings.cpu().numpy())
hf_out = hf_pipe.unet(hflatents, hftimesteps, encoder_hidden_states=hfembeddings)[0]
pp_out = pp_pipe.unet(pplatents, pptimesteps, encoder_hidden_states=ppembeddings)[0]
compare(hf_out, pp_out)


######## 3. text_encoder
hfinput_ids = torch.randint(4, 1000, (batch_size, 77), device=device).long()
ppinput_ids = paddle.to_tensor(hfinput_ids.cpu().numpy())
hf_out = hf_pipe.text_encoder(hfinput_ids)[0]
pp_out = pp_pipe.text_encoder(ppinput_ids)[0]
compare(hf_out, pp_out)
# runwayml/stable-diffusion-v1-5
# 2.0066313e-06 2.9563904e-05
# 1.4244446e-07 8.6426735e-06
# 1.533682e-07 1.0430813e-06
# 1.2732149e-06 1.1920929e-05

# runwayml/stable-diffusion-inpainting
# 2.0066313e-06 2.9563904e-05
# 1.4244446e-07 8.6426735e-06
# 4.6644558e-07 6.6310167e-06
# 1.3243238e-06 1.2397766e-05
```

#### runwayml/stable-diffusion-inpainting Inpaint 任务对齐 （Done）
```python
from io import BytesIO
import torch
import requests
import PIL
from diffusers import StableDiffusionInpaintPipeline, EulerAncestralDiscreteScheduler

def download_image(url):
    response = requests.get(url)
    return PIL.Image.open(BytesIO(response.content)).convert("RGB")

device = "cuda"
img_url = "https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/overture-creations.png"
mask_url = "https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/overture-creations-mask.png"
init_image = download_image(img_url).resize((512, 512))
mask_image = download_image(mask_url).resize((512, 512))

scheduler = EulerAncestralDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
pipe = StableDiffusionInpaintPipeline.from_pretrained("runwayml/stable-diffusion-inpainting", scheduler=scheduler).to(device)

seed = 2022
generator = torch.Generator(device).manual_seed(seed)
prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
hfimage = pipe(prompt=prompt, image=init_image, mask_image=mask_image, generator=generator).images[0]
hfimage.save("hf.jpg")
```
```python
import paddle
import PIL
import requests
from io import BytesIO

from ppdiffusers import StableDiffusionInpaintPipeline, EulerAncestralDiscreteScheduler

def download_image(url):
    response = requests.get(url)
    return PIL.Image.open(BytesIO(response.content)).convert("RGB")

img_url = "https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/overture-creations.png"
mask_url = "https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/overture-creations-mask.png"
init_image = download_image(img_url).resize((512, 512))
mask_image = download_image(mask_url).resize((512, 512))

scheduler = EulerAncestralDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
pipe = StableDiffusionInpaintPipeline.from_pretrained("runwayml/stable-diffusion-inpainting", scheduler=scheduler)

seed = 2022
prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
ppimage = pipe(prompt=prompt, image=init_image, mask_image=mask_image, seed=seed).images[0]
ppimage.save("pp.jpg")
```
![hf](https://user-images.githubusercontent.com/50394665/200562304-1d3e3bba-772a-4aa9-9dee-bc452c96aba1.jpg)


![pp](https://user-images.githubusercontent.com/50394665/200562347-e9a0bc8a-3bde-4583-b819-b39c693868a3.jpg)
