### PR TITLE
[cblue] fix ValueError brought by the switch of TransformerEncoder in electra

### DIFF
--- a/model_zoo/ernie-health/cblue/model.py
+++ b/model_zoo/ernie-health/cblue/model.py
@@ -120,12 +120,14 @@ class ElectraForSPO(ElectraPretrainedModel):
                 token_type_ids=None,
                 position_ids=None,
                 attention_mask=None):
-        sequence_outputs, _, all_hidden_states = self.electra(
-            input_ids,
-            token_type_ids,
-            position_ids,
-            attention_mask,
-            output_hidden_states=True)
+        outputs = self.electra(input_ids,
+                               token_type_ids,
+                               position_ids,
+                               attention_mask,
+                               output_hidden_states=True,
+                               return_dict=True)
+        sequence_outputs = outputs.last_hidden_state
+        all_hidden_states = outputs.hidden_states
         sequence_outputs = self.dropout(sequence_outputs)
         ent_logits = self.classifier(sequence_outputs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Fix `ValueError: not enough values to unpack` brought by the switch of TransformerEncoder in electra.