### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/examples/question_generation/unimo-text/requirements.txt
+++ b/examples/question_generation/unimo-text/requirements.txt
@@ -1,3 +1,3 @@
 nltk==3.6.2
-evaluate==0.2.2
+evaluate==0.3.0
 tqdm==4.64.0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.