### PR TITLE
[Bugfix] fix readthedocs website building error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,9 +17,21 @@ sphinx:
 #formats:
 #   - pdf
 
+# custome building process,
+# get more details: https://docs.readthedocs.io/en/stable/build-customization.html
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
+  jobs:
+    pre_install:
+      # fix the installation issue: 
+      # get more details: https://github.com/PaddlePaddle/Paddle/issues/45146
+      - apt install libgomp1
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,21 +17,21 @@ sphinx:
 #formats:
 #   - pdf
 
-# custome building process,
-# get more details: https://docs.readthedocs.io/en/stable/build-customization.html
-build:
-  os: "ubuntu-20.04"
-  tools:
-    python: "3.8"
-  jobs:
-    pre_install:
-      # fix the installation issue: 
-      # get more details: https://github.com/PaddlePaddle/Paddle/issues/45146
-      - apt install libgomp1
+# # custome building process,
+# # get more details: https://docs.readthedocs.io/en/stable/build-customization.html
+# build:
+#   os: "ubuntu-20.04"
+#   languages:
+#     python: "3.9"
+#   jobs:
+#     pre_install:
+#       # fix the installation issue: 
+#       # get more details: https://github.com/PaddlePaddle/Paddle/issues/45146
+#       - apt install libgomp1
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 2
+version: 3
 
 submodules:
   include: all
@@ -31,7 +31,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,7 +31,7 @@ build:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 3
+version: 2
 
 submodules:
   include: all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,7 +31,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,7 +31,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,21 +17,9 @@ sphinx:
 #formats:
 #   - pdf
 
-# # custome building process,
-# # get more details: https://docs.readthedocs.io/en/stable/build-customization.html
-# build:
-#   os: "ubuntu-20.04"
-#   languages:
-#     python: "3.9"
-#   jobs:
-#     pre_install:
-#       # fix the installation issue: 
-#       # get more details: https://github.com/PaddlePaddle/Paddle/issues/45146
-#       - apt install libgomp1
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,4 +9,5 @@ Markdown < 3.4
 sphinx-copybutton==0.3.1
 sphinx-markdown-tables==0.0.15
 
-paddlepaddle>=2.2.2
+# use paddlepaddle == 2.3.* according to: https://github.com/PaddlePaddle/Paddle/issues/48243
+paddlepaddle>=2.2.2,<2.4.0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Docs

### Description
<!-- Describe what this PR does -->

在最新版本的paddlepaddle（2.4.0） 当中出现：

```shell
Can not import paddle core while this file exists: /home/docs/checkouts/readthedocs.org/user_builds/paddlenlp/envs/3856/lib/python3.8/site-packages/paddle/fluid/libpaddle.so
```

这个问题，而这个问题很早就出现过，详细可见：https://github.com/PaddlePaddle/Paddle/issues/45146

为了兼容最新版本的 paddlepaddle，添加了对应的脚本：

```shell
apt install libgomp1
```