### PR TITLE
Support HUGGINGFACE_HUB_CACHE in HF hub download through os env

### DIFF
--- a/paddlenlp/transformers/auto/tokenizer.py
+++ b/paddlenlp/transformers/auto/tokenizer.py
@@ -23,7 +23,7 @@ from huggingface_hub import hf_hub_download
 from paddlenlp.transformers import *
 from paddlenlp.utils.downloader import (COMMUNITY_MODEL_PREFIX,
                                         get_path_from_url)
-from paddlenlp.utils.env import MODEL_HOME
+from paddlenlp.utils.env import HF_CACHE_HOME
 from paddlenlp.utils.import_utils import is_fast_tokenizer_available
 from paddlenlp.utils.log import logger
 
@@ -242,7 +242,7 @@ class AutoTokenizer():
         if from_hf_hub:
             config_file = hf_hub_download(repo_id=pretrained_model_name_or_path,
                                           filename=cls.tokenizer_config_file,
-                                          cache_dir=MODEL_HOME)
+                                          cache_dir=HF_CACHE_HOME)
             if os.path.exists(config_file):
                 tokenizer_class = cls._get_tokenizer_class_from_config(
                     pretrained_model_name_or_path, config_file, use_fast)

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -31,7 +31,7 @@ from huggingface_hub import hf_hub_download
 
 from paddlenlp import __version__
 from paddlenlp.transformers.utils import resolve_cache_dir
-from paddlenlp.utils.env import MODEL_HOME
+from paddlenlp.utils.env import HF_CACHE_HOME
 from paddlenlp.utils.log import logger
 
 from ..utils import CONFIG_NAME
@@ -748,7 +748,7 @@ class PretrainedConfig:
             resolved_config_file = hf_hub_download(
                 repo_id=pretrained_model_name_or_path,
                 filename=CONFIG_NAME,
-                cache_dir=MODEL_HOME)
+                cache_dir=HF_CACHE_HOME)
 
         # 3. get the configuration file from url, eg: https://ip/path/to/model_config.jsons
         elif is_url(pretrained_model_name_or_path):

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -33,7 +33,7 @@ from paddle.nn import Embedding, Layer
 from paddle.utils.download import is_url
 from paddlenlp.utils.downloader import (download_check, COMMUNITY_MODEL_PREFIX)
 from paddlenlp.utils.downloader import get_path_from_url_with_filelock
-from paddlenlp.utils.env import MODEL_HOME, LOCK_FILE_HOME
+from paddlenlp.utils.env import HF_CACHE_HOME, MODEL_HOME, LOCK_FILE_HOME
 
 from paddlenlp.utils.log import logger
 from paddlenlp.utils.file_lock import FileLock
@@ -439,7 +439,7 @@ class PretrainedModel(Layer, GenerationMixin):
                 resolved_resource_files[file_id] = hf_hub_download(
                     repo_id=pretrained_model_name_or_path,
                     filename=file_path,
-                    cache_dir=MODEL_HOME)
+                    cache_dir=HF_CACHE_HOME)
             else:
                 path = os.path.join(default_root, file_path.split('/')[-1])
                 if os.path.exists(path):
@@ -848,7 +848,7 @@ class PretrainedModel(Layer, GenerationMixin):
             return hf_hub_download(
                 repo_id=pretrained_model_name_or_path,
                 filename=cls.resource_files_names['model_state'],
-                cache_dir=MODEL_HOME)
+                cache_dir=HF_CACHE_HOME)
 
         # 2. when it is model-name
         if pretrained_model_name_or_path in cls.pretrained_init_configuration:

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -31,17 +31,11 @@ from paddle import Tensor
 from paddle.nn import Embedding, Layer
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.utils.download import is_url
-<<<<<<< HEAD
-from paddlenlp.utils.downloader import (download_check, COMMUNITY_MODEL_PREFIX)
-from paddlenlp.utils.downloader import get_path_from_url_with_filelock
-from paddlenlp.utils.env import HF_CACHE_HOME, MODEL_HOME, LOCK_FILE_HOME
-=======
->>>>>>> origin/develop
 
 from paddlenlp import __version__
 from paddlenlp.utils.downloader import (COMMUNITY_MODEL_PREFIX, download_check,
                                         get_path_from_url_with_filelock)
-from paddlenlp.utils.env import LOCK_FILE_HOME, MODEL_HOME
+from paddlenlp.utils.env import HF_CACHE_HOME, LOCK_FILE_HOME, MODEL_HOME
 from paddlenlp.utils.file_lock import FileLock
 from paddlenlp.utils.log import logger
 

--- a/paddlenlp/utils/env.py
+++ b/paddlenlp/utils/env.py
@@ -50,6 +50,7 @@ def _get_sub_home(directory, parent_home=_get_ppnlp_home()):
 USER_HOME = _get_user_home()
 PPNLP_HOME = _get_ppnlp_home()
 MODEL_HOME = _get_sub_home('models')
+HF_CACHE_HOME = os.environ.get('HUGGINGFACE_HUB_CACHE', MODEL_HOME)
 DATA_HOME = _get_sub_home('datasets')
 LOCK_FILE_HOME = _get_sub_home(".lock")
 DOWNLOAD_SERVER = "http://paddlepaddle.org.cn/paddlehub"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Function optimization
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
Allows the use of HUGGINGFACE_HUB_CACHE through OS env variable when available, which can be used to speed up model loading in HF Inference API due to their use of NFS
<!-- Describe what this PR does -->
