### PR TITLE
[prompt] fix bug when no mask token in template

### DIFF
--- a/paddlenlp/prompt/prompt_trainer.py
+++ b/paddlenlp/prompt/prompt_trainer.py
@@ -366,7 +366,8 @@ class PromptModelForSequenceClassification(nn.Layer):
             k: input_dict[k]
             for k in input_dict if k in self.forward_keys
         }
-        model_inputs["masked_positions"] = None
+        if "masked_positions" in model_inputs:
+            model_inputs.pop("masked_positions")
         outputs = self.plm(**model_inputs)
         if self.verbalizer is not None:
             label_outputs = self.verbalizer.process_outputs(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
- Fix KeyError when there is not `{'mask'}` token defined in template