### PR TITLE
[Bugfix] update paddle dependency version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Lint:
     name: Install Environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Lint:
     name: Install Environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -19,7 +19,7 @@ jobs:
   ppdiffusers:
     name: Pack
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -19,7 +19,7 @@ jobs:
   ppdiffusers:
     name: Pack
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Test:
     name: Install Environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Test:
     name: Install Environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v1

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ unit-test:
 
 .PHONY: install
 install:
-	pip install -r requirements.txt
 	pip install -r requirements-dev.txt
+	pip install -r requirements.txt
 	pre-commit install
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-paddlepaddle==2.4.0rc0
+paddlepaddle>=2.3.0,<2.4.0
 pre-commit
 pytest
 isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
-paddlepaddle>=2.3.0,<2.4.0
+paddlepaddle==2.4.0rc0
 pre-commit
 pytest
 isort
-GitPython
 pylint
 flake8
 black


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
paddlepaddle==2.3.2在 ubuntu 上面与 gcc 版本不兼容的问题，会导致test workflow 会挂掉

详细可见：
* https://github.com/PaddlePaddle/Paddle/issues/36801
* https://github.com/PaddlePaddle/PaddleNLP/actions/runs/3589093674/jobs/6041170606#logs
