### PR TITLE
fix(sec): upgrade streamlit to 1.11.1

### DIFF
--- a/pipelines/requirements.txt
+++ b/pipelines/requirements.txt
@@ -17,7 +17,7 @@ opencv-contrib-python-headless
 python-multipart
 st-annotated-text
 click==8.0
-streamlit==1.9.0
+streamlit==1.11.1
 fastapi
 uvicorn
 markdown


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in streamlit 1.9.0
- [CVE-2022-35918](https://www.oscs1024.com/hd/CVE-2022-35918)


### What did I do？
Upgrade streamlit from 1.9.0 to 1.11.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS