### PR TITLE
[PPDiffusers] support recompute

### DIFF
--- a/ppdiffusers/examples/text_to_image_laion400m/README.md
+++ b/ppdiffusers/examples/text_to_image_laion400m/README.md
@@ -107,7 +107,7 @@ python -u train_txt2img_laion400m_trainer.py \
 > * `--fp16`: 是否使用 fp16 混合精度训练而不是 fp32 训练。(`bool`, 可选, 默认为 `False`)
 > * `--fp16_opt_level`: 混合精度训练模式，可为``O1``或``O2``模式，默认``O1``模式，默认O1. 只在fp16选项开启时候生效。
 
-#### 1.3.3 单机多卡训练
+#### 1.3.3 单机多卡训练 (多机多卡训练，仅需在 paddle.distributed.launch 后加个 --ips IP1,IP2,IP3,IP4)
 ```bash
 python -u -m paddle.distributed.launch --gpus "0,1,2,3,4,5,6,7" train_txt2img_laion400m_trainer.py \
     --do_train \
@@ -187,6 +187,7 @@ python -u train_txt2img_laion400m_no_trainer.py \
 > * `--tokenizer_name`: 我们需要使用的`tokenizer_name`。
 > * `--use_ema`: 是否对`unet`使用`ema`，默认为`False`。
 > * `--max_grad_norm`: 梯度剪裁的最大norm值，`-1`表示不使用梯度裁剪策略。
+> * `--recompute`: 是否开启重计算，(`bool`, 可选, 默认为 `False`)，在开启后我们可以增大batch_size，注意在小batch_size的条件下，开启recompute后显存变化不明显，只有当开大batch_size后才能明显感受到区别。
 > * `--fp16`: 是否使用 fp16 混合精度训练而不是 fp32 训练。(`bool`, 可选, 默认为 `False`)
 > * `--fp16_opt_level`: 混合精度训练模式，可为``O1``或``O2``模式，默认``O1``模式，默认O1. 只在fp16选项开启时候生效。
 

--- a/ppdiffusers/examples/text_to_image_laion400m/README.md
+++ b/ppdiffusers/examples/text_to_image_laion400m/README.md
@@ -104,6 +104,7 @@ python -u train_txt2img_laion400m_trainer.py \
 > * `--tokenizer_name`: 我们需要使用的`tokenizer_name`，我们可以使用英文的分词器`bert-base-uncased`，也可以使用中文的分词器`ernie-1.0`。
 > * `--use_ema`: 是否对`unet`使用`ema`，默认为`False`。
 > * `--max_grad_norm`: 梯度剪裁的最大norm值，`-1`表示不使用梯度裁剪策略。
+> * `--recompute`: 是否开启重计算，(`bool`, 可选, 默认为 `False`)，在开启后我们可以增大batch_size，注意在小batch_size的条件下，开启recompute后显存变化不明显，只有当开大batch_size后才能明显感受到区别。
 > * `--fp16`: 是否使用 fp16 混合精度训练而不是 fp32 训练。(`bool`, 可选, 默认为 `False`)
 > * `--fp16_opt_level`: 混合精度训练模式，可为``O1``或``O2``模式，默认``O1``模式，默认O1. 只在fp16选项开启时候生效。
 

--- a/ppdiffusers/examples/text_to_image_laion400m/ldm/ldm_args.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/ldm/ldm_args.py
@@ -123,6 +123,13 @@ class NoTrainerTrainingArguments:
     report_to: str = field(
         default="visualdl", metadata={"help": "The list of integrations to report the results and logs to."}
     )
+    recompute: bool = field(
+        default=False,
+        metadata={
+            "help": "Recompute the forward pass to calculate gradients. Used for saving memory. "
+            "Only support for networks with transformer blocks."
+        },
+    )
 
     def __str__(self):
         self_as_dict = asdict(self)

--- a/ppdiffusers/examples/text_to_image_laion400m/ldm/model.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/ldm/model.py
@@ -246,3 +246,16 @@ class LatentDiffusionModel(nn.Layer):
             image = self.vae.decode(latents).sample
             image = (image / 2 + 0.5).clip(0, 1).transpose([0, 2, 3, 1]) * 255.0
         return image.cast("float32").numpy().round()
+
+    def set_recompute(self, value=False):
+        def fn(layer):
+            # ldmbert
+            if hasattr(layer, "enable_recompute"):
+                layer.enable_recompute = value
+                print("Set", layer.__class__, "recompute", layer.enable_recompute)
+            # unet
+            if hasattr(layer, "gradient_checkpointing"):
+                layer.gradient_checkpointing = value
+                print("Set", layer.__class__, "recompute", layer.gradient_checkpointing)
+
+        self.apply(fn)

--- a/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_no_trainer.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_no_trainer.py
@@ -78,7 +78,7 @@ def main():
         os.makedirs(training_args.output_dir, exist_ok=True)
 
     model = LatentDiffusionModel(model_args)
-
+    model.set_recompute(training_args.recompute)
     params_to_train = itertools.chain(model.text_encoder.parameters(), model.unet.parameters())
 
     if num_processes > 1:

--- a/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_trainer.py
+++ b/ppdiffusers/examples/text_to_image_laion400m/train_txt2img_laion400m_trainer.py
@@ -71,6 +71,8 @@ def main():
     trainer = LatentDiffusionTrainer(
         model=model, args=training_args, train_dataset=train_dataset, tokenizer=model.tokenizer
     )
+    # must set recompute after trainer init
+    trainer.model.set_recompute(training_args.recompute)
     params_to_train = itertools.chain(trainer.model.text_encoder.parameters(), trainer.model.unet.parameters())
     trainer.set_optimizer_grouped_parameters(params_to_train)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- 给ldm训练添加recompute支持。
- 注意：开启recompute后，默认会将ldmbert和unet部分都开启recompute计算，原版代码只会开启unet的recompute计算。
- 当batch size很小的时候，recompute表现出来的显存占用并未减小，因此需要使用大的batch size！