### PR TITLE
[FastTokenizer] Fix fast_tokenizer import

### DIFF
--- a/paddlenlp/transformers/auto/tokenizer.py
+++ b/paddlenlp/transformers/auto/tokenizer.py
@@ -23,7 +23,7 @@ from huggingface_hub import hf_hub_download
 from paddlenlp import __version__
 from paddlenlp.utils.downloader import COMMUNITY_MODEL_PREFIX, get_path_from_url
 from paddlenlp.utils.env import HF_CACHE_HOME, MODEL_HOME
-from paddlenlp.utils.import_utils import is_fast_tokenizer_available
+from paddlenlp.utils.import_utils import import_module, is_fast_tokenizer_available
 from paddlenlp.utils.log import logger
 
 __all__ = [
@@ -154,22 +154,22 @@ class AutoTokenizer:
 
         if init_class:
             class_name = cls._name_mapping[init_class]
-            import_class = importlib.import_module(f"paddlenlp.transformers.{class_name}.tokenizer")
+            import_class = import_module(f"paddlenlp.transformers.{class_name}.tokenizer")
             tokenizer_class = getattr(import_class, init_class)
             if use_fast:
                 if is_fast_tokenizer_available():
                     is_support_fast_tokenizer = False
-                    for faster_tokenizer_class, name in cls._faster_name_mapping.items():
-                        if name == class_name:
+                    init_class_prefix = init_class[:-9]
+                    for fast_tokenizer_class, name in cls._fast_name_mapping.items():
+                        fast_tokenizer_class_prefix = fast_tokenizer_class[:-9]
+                        if name == class_name and fast_tokenizer_class_prefix.startswith(init_class_prefix):
                             is_support_fast_tokenizer = True
-                            import_class = importlib.import_module(
-                                f"paddlenlp.transformers.{class_name}.faster_tokenizer"
-                            )
-                            tokenizer_class = getattr(import_class, faster_tokenizer_class)
+                            import_class = import_module(f"paddlenlp.transformers.{class_name}.fast_tokenizer")
+                            tokenizer_class = getattr(import_class, fast_tokenizer_class)
                             break
                     if not is_support_fast_tokenizer:
                         logger.warning(
-                            f"The tokenizer {tokenizer_class} doesn't have the faster version."
+                            f"The tokenizer {tokenizer_class} doesn't have the fast version."
                             " Please check the map `paddlenlp.transformers.auto.tokenizer.FAST_TOKENIZER_MAPPING_NAMES`"
                             " to see which fast tokenizers are currently supported."
                         )
@@ -188,7 +188,7 @@ class AutoTokenizer:
                 if pattern in pretrained_model_name_or_path.lower():
                     init_class = key
                     class_name = cls._name_mapping[init_class]
-                    import_class = importlib.import_module(f"paddlenlp.transformers.{class_name}.tokenizer")
+                    import_class = import_module(f"paddlenlp.transformers.{class_name}.tokenizer")
                     tokenizer_class = getattr(import_class, init_class)
             return tokenizer_class
 

--- a/paddlenlp/transformers/auto/tokenizer.py
+++ b/paddlenlp/transformers/auto/tokenizer.py
@@ -157,10 +157,28 @@ class AutoTokenizer:
             import_class = importlib.import_module(f"paddlenlp.transformers.{class_name}.tokenizer")
             tokenizer_class = getattr(import_class, init_class)
             if use_fast:
-                for fast_tokenizer_class, name in cls._fast_name_mapping.items():
-                    if name == class_name:
-                        import_class = importlib.import_module(f"paddlenlp.transformers.{class_name}.fast_tokenizer")
-                        tokenizer_class = getattr(import_class, fast_tokenizer_class)
+                if is_fast_tokenizer_available():
+                    is_support_fast_tokenizer = False
+                    for faster_tokenizer_class, name in cls._faster_name_mapping.items():
+                        if name == class_name:
+                            is_support_fast_tokenizer = True
+                            import_class = importlib.import_module(
+                                f"paddlenlp.transformers.{class_name}.faster_tokenizer"
+                            )
+                            tokenizer_class = getattr(import_class, faster_tokenizer_class)
+                            break
+                    if not is_support_fast_tokenizer:
+                        logger.warning(
+                            f"The tokenizer {tokenizer_class} doesn't have the faster version."
+                            " Please check the map `paddlenlp.transformers.auto.tokenizer.FAST_TOKENIZER_MAPPING_NAMES`"
+                            " to see which fast tokenizers are currently supported."
+                        )
+                else:
+                    logger.warning(
+                        "Can't find the fast_tokenizer package, "
+                        "please ensure install fast_tokenizer correctly. "
+                        "You can install fast_tokenizer by `pip install fast-tokenizer-python`."
+                    )
             return tokenizer_class
         # If no `init_class`, we use pattern recognition to recognize the tokenizer class.
         else:

--- a/tests/transformers/auto/__init__.py
+++ b/tests/transformers/auto/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/auto/test_tokenizer.py
+++ b/tests/transformers/auto/test_tokenizer.py
@@ -21,14 +21,10 @@ from paddlenlp.transformers import AutoTokenizer, is_fast_tokenizer_available
 
 class AutoTokenizerTest(unittest.TestCase):
     def test_fast_tokenizer_import(self):
-        tokenizer1 = AutoTokenizer.from_pretrained(
-            "hf-internal-testing/tiny-random-BertModel", from_hf_hub=True, use_fast=False
-        )
+        tokenizer1 = AutoTokenizer.from_pretrained("__internal_testing__/bert", use_fast=False)
         self.assertIsInstance(tokenizer1, paddlenlp.transformers.BertTokenizer)
 
-        tokenizer2 = AutoTokenizer.from_pretrained(
-            "hf-internal-testing/tiny-random-BertModel", from_hf_hub=True, use_fast=True
-        )
+        tokenizer2 = AutoTokenizer.from_pretrained("__internal_testing__/bert", use_fast=True)
         if is_fast_tokenizer_available():
             self.assertIsInstance(tokenizer2, paddlenlp.transformers.BertFastTokenizer)
         else:

--- a/tests/transformers/auto/test_tokenizer.py
+++ b/tests/transformers/auto/test_tokenizer.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright 2019 Hugging Face inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddlenlp
+from paddlenlp.transformers import AutoTokenizer, is_fast_tokenizer_available
+
+
+class AutoTokenizerTest(unittest.TestCase):
+    def test_fast_tokenizer_import(self):
+        tokenizer1 = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-BertModel", from_hf_hub=True, use_fast=False
+        )
+        self.assertIsInstance(tokenizer1, paddlenlp.transformers.BertTokenizer)
+
+        tokenizer2 = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-BertModel", from_hf_hub=True, use_fast=True
+        )
+        if is_fast_tokenizer_available():
+            self.assertIsInstance(tokenizer2, paddlenlp.transformers.BertFastTokenizer)
+        else:
+            self.assertIsInstance(tokenizer2, paddlenlp.transformers.BertTokenizer)

--- a/tests/transformers/auto/test_tokenizer.py
+++ b/tests/transformers/auto/test_tokenizer.py
@@ -29,3 +29,8 @@ class AutoTokenizerTest(unittest.TestCase):
             self.assertIsInstance(tokenizer2, paddlenlp.transformers.BertFastTokenizer)
         else:
             self.assertIsInstance(tokenizer2, paddlenlp.transformers.BertTokenizer)
+
+    def test_fast_tokenizer_non_exist(self):
+        tokenizer1 = AutoTokenizer.from_pretrained("t5-small", use_fast=True)
+        # T5 FastTokenizer doesn't exist yet, so from_pretrained will return the normal tokenizer.
+        self.assertIsInstance(tokenizer1, paddlenlp.transformers.T5Tokenizer)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Fix the error raised by AutoTokenizer when fast_tokenizer  hasn't been installed
```python
from paddlenlp import Taskflow
schema = ['时间']
# Oops, raise error when fast_tokenizer hasn't been installed
ie = Taskflow('information_extraction', use_fast=True)
```