### PR TITLE
[Bug fixes] fix load-torch with different prefix key

### DIFF
--- a/paddlenlp/utils/serialization.py
+++ b/paddlenlp/utils/serialization.py
@@ -40,6 +40,12 @@ class TensorMeta:
         return f"size: {self.size} key: {self.key}, nbytes: {self.nbytes}, dtype: {self.dtype}"
 
 
+class SerializationError(Exception):
+    """Exception for serialization"""
+
+    pass
+
+
 @lru_cache(maxsize=None)
 def _storage_type_to_dtype_to_map():
     """convert storage type to numpy dtype"""
@@ -150,6 +156,8 @@ def seek_by_string(file_handler: BufferedReader, string: str, file_size: int) ->
         else:
             word_index = 0
 
+    if file_handler.tell() >= file_size - 1:
+        raise SerializationError(f"can't find the find the target string<{string}> in the file")
     return file_handler.tell()
 
 

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -21,7 +21,7 @@ from huggingface_hub import hf_hub_download
 from parameterized import parameterized
 
 from paddlenlp.utils import load_torch
-from tests.testing_utils import require_package, slow
+from tests.testing_utils import require_package
 
 
 class SerializationTest(TestCase):
@@ -54,14 +54,20 @@ class SerializationTest(TestCase):
                     torch_data[key].numpy(),
                 )
 
-    @slow
     @require_package("torch")
-    def test_load_bert_model(self):
+    @parameterized.expand(
+        [
+            "hf-internal-testing/tiny-random-codegen",
+            "hf-internal-testing/tiny-random-Data2VecTextModel",
+            "hf-internal-testing/tiny-random-SwinModel",
+        ]
+    )
+    def test_load_bert_model(self, repo_id):
         import torch
 
         with tempfile.TemporaryDirectory() as tempdir:
             weight_file = hf_hub_download(
-                repo_id="hf-internal-testing/tiny-random-codegen",
+                repo_id=repo_id,
                 filename="pytorch_model.bin",
                 cache_dir=tempdir,
                 library_name="PaddleNLP",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
在pytorch_model.bin 文件当中，key 的 prefix 在不同版本中间存储数据不一致，此时需要动态读取。
