### PR TITLE
[Bug fixes] disable model config accessing warning

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -294,10 +294,11 @@ class PretrainedModel(Layer, GenerationMixin):
         except AttributeError:
             result = getattr(self.config, name)
 
-            logger.warning(
-                f"Do not access config from `model.{name}` which will be deprecated after v2.6.0, "
-                f"Instead, do `model.config.{name}`"
-            )
+            # FIXME(wj-Mcat): there are a lot of consistent errors, so temporary disable.
+            # logger.warning(
+            #     f"Do not access config from `model.{name}` which will be deprecated after v2.6.0, "
+            #     f"Instead, do `model.config.{name}`"
+            # )
             return result
 
     @property


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
在模型参数初始化函数中，有一个`self.initializer_range`此时会造成大量的 warning。
