### PR TITLE
[PretrainedConfig] Bring back deprecation warning and fix redundant warnings

### DIFF
--- a/paddlenlp/transformers/bart/modeling.py
+++ b/paddlenlp/transformers/bart/modeling.py
@@ -23,8 +23,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.nn import Embedding, Layer, MultiHeadAttention
 
-from paddlenlp.utils.env import CONFIG_NAME
-
+from ...utils.env import CONFIG_NAME
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import (
@@ -92,7 +91,7 @@ class BartPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.init_std if hasattr(self, "init_std") else self.bart.config["init_std"],
+                        std=self.config.init_std,
                         shape=layer.weight.shape,
                     )
                 )
@@ -1127,7 +1126,4 @@ class BartForConditionalGeneration(BartPretrainedModel):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                return getattr(getattr(self, self.base_model_prefix).config, name)
+            return getattr(getattr(self, self.base_model_prefix), name)

--- a/paddlenlp/transformers/bert/configuration.py
+++ b/paddlenlp/transformers/bert/configuration.py
@@ -365,7 +365,7 @@ class BertConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "bert"
-    standard_config: Dict[str, str] = {"dropout": "classifier_dropout"}
+    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
     pretrained_init_configuration = BERT_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/bert/configuration.py
+++ b/paddlenlp/transformers/bert/configuration.py
@@ -15,7 +15,8 @@
 from __future__ import annotations
 
 from typing import Dict
-from paddlenlp.transformers.configuration_utils import PretrainedConfig, attribute_map
+
+from paddlenlp.transformers.configuration_utils import PretrainedConfig
 
 __all__ = ["BERT_PRETRAINED_INIT_CONFIGURATION", "BertConfig", "BERT_PRETRAINED_RESOURCE_FILES_MAP"]
 
@@ -364,7 +365,7 @@ class BertConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "bert"
-    attribute_map: Dict[str, str] = {"num_classes": "num_labels", "dropout": "classifier_dropout"}
+    standard_config: Dict[str, str] = {"dropout": "classifier_dropout"}
     pretrained_init_configuration = BERT_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -44,6 +44,7 @@ from .configuration import (
     BERT_PRETRAINED_RESOURCE_FILES_MAP,
     BertConfig,
 )
+from ...utils.env import CONFIG_NAME
 
 __all__ = [
     "BertModel",
@@ -138,7 +139,7 @@ class BertPretrainedModel(PretrainedModel):
     See :class:`~paddlenlp.transformers.model_utils.PretrainedModel` for more details.
     """
 
-    model_config_file = "config.json"
+    model_config_file = CONFIG_NAME
     config_class = BertConfig
     resource_files_names = {"model_state": "model_state.pdparams"}
     base_model_prefix = "bert"
@@ -155,9 +156,7 @@ class BertPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range
-                        if hasattr(self, "initializer_range")
-                        else self.config.initializer_range,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 
 from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
 
+from ...utils.env import CONFIG_NAME
 from ..model_outputs import (
     BaseModelOutputWithPoolingAndCrossAttentions,
     MaskedLMOutput,
@@ -44,7 +45,6 @@ from .configuration import (
     BERT_PRETRAINED_RESOURCE_FILES_MAP,
     BertConfig,
 )
-from ...utils.env import CONFIG_NAME
 
 __all__ = [
     "BertModel",

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -442,7 +442,7 @@ class PretrainedConfig:
     attribute_map: Dict[str, str] = {"num_classes": "num_labels"}
 
     # model-specific attribute map from hf attribute to paddle attribute
-    # { "standard_field": "paddle_field", ... }
+    # { "paddle_field": "standard_field", ... }
     standard_config_map: Dict[str, str] = {}
 
     _auto_class: Optional[str] = None

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -441,7 +441,7 @@ class PretrainedConfig:
     # global attribute mapping
     attribute_map: Dict[str, str] = {"num_classes": "num_labels"}
 
-    # map hf attribute to paddle attribute
+    # model-specific attribute map from hf attribute to paddle attribute
     # { "standard_field": "paddle_field", ... }
     standard_config_map: Dict[str, str] = {}
 
@@ -450,12 +450,16 @@ class PretrainedConfig:
     def __setattr__(self, key, value):
         if key in super().__getattribute__("attribute_map"):
             key = super().__getattribute__("attribute_map")[key]
+        elif key in super().__getattribute__("standard_config_map"):
+            key = super().__getattribute__("standard_config_map")[key]
         super().__setattr__(key, value)
         assert hasattr(self, key)
 
     def __getattribute__(self, key):
         if key != "attribute_map" and key in super().__getattribute__("attribute_map"):
             key = super().__getattribute__("attribute_map")[key]
+        elif key != "standard_config_map" and key in super().__getattribute__("standard_config_map"):
+            key = super().__getattribute__("standard_config_map")[key]
         return super().__getattribute__(key)
 
     def __getitem__(self, key):

--- a/paddlenlp/transformers/ernie/configuration.py
+++ b/paddlenlp/transformers/ernie/configuration.py
@@ -1065,7 +1065,7 @@ class ErnieConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "ernie"
-    attribute_map: Dict[str, str] = {"num_classes": "num_labels", "dropout": "classifier_dropout"}
+    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
     pretrained_init_configuration = ERNIE_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -35,6 +35,7 @@ from .configuration import (
     ERNIE_PRETRAINED_RESOURCE_FILES_MAP,
     ErnieConfig,
 )
+from ...utils.env import CONFIG_NAME
 
 __all__ = [
     "ErnieModel",
@@ -148,7 +149,7 @@ class ErniePretrainedModel(PretrainedModel):
 
     """
 
-    model_config_file = "model_config.json"
+    model_config_file = CONFIG_NAME
     config_class = ErnieConfig
     resource_files_names = {"model_state": "model_state.pdparams"}
     base_model_prefix = "ernie"
@@ -161,13 +162,11 @@ class ErniePretrainedModel(PretrainedModel):
         if isinstance(layer, (nn.Linear, nn.Embedding)):
             # only support dygraph, use truncated_normal and make it inplace
             # and configurable later
-            if isinstance(layer.weight, paddle.Tensor):
+            if isinstance(layer.weight, paddle.Tensor):    
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range
-                        if hasattr(self, "initializer_range")
-                        else self.ernie.config["initializer_range"],
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -20,6 +20,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle import Tensor
 
+from ...utils.env import CONFIG_NAME
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import (
     BaseModelOutputWithPoolingAndCrossAttentions,
@@ -35,7 +36,6 @@ from .configuration import (
     ERNIE_PRETRAINED_RESOURCE_FILES_MAP,
     ErnieConfig,
 )
-from ...utils.env import CONFIG_NAME
 
 __all__ = [
     "ErnieModel",
@@ -162,7 +162,7 @@ class ErniePretrainedModel(PretrainedModel):
         if isinstance(layer, (nn.Linear, nn.Embedding)):
             # only support dygraph, use truncated_normal and make it inplace
             # and configurable later
-            if isinstance(layer.weight, paddle.Tensor):    
+            if isinstance(layer.weight, paddle.Tensor):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,

--- a/paddlenlp/transformers/ernie_layout/configuration.py
+++ b/paddlenlp/transformers/ernie_layout/configuration.py
@@ -150,7 +150,7 @@ class ErnieLayoutConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "ernie_layout"
-    attribute_map: Dict[str, str] = {"num_classes": "num_labels", "dropout": "classifier_dropout"}
+    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
     pretrained_init_configuration = ERNIE_LAYOUT_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/ernie_layout/modeling.py
+++ b/paddlenlp/transformers/ernie_layout/modeling.py
@@ -24,12 +24,14 @@ from paddle.nn import Layer
 from paddlenlp.utils.log import logger
 
 from .. import PretrainedModel, register_base_model
+from ...utils.env import CONFIG_NAME
 from .configuration import (
     ERNIE_LAYOUT_PRETRAINED_INIT_CONFIGURATION,
     ERNIE_LAYOUT_PRETRAINED_RESOURCE_FILES_MAP,
     ErnieLayoutConfig,
 )
 from .visual_backbone import ResNet
+
 
 __all__ = [
     "ErnieLayoutModel",
@@ -171,7 +173,7 @@ class ErnieLayoutEmbeddings(Layer):
 
 
 class ErnieLayoutPretrainedModel(PretrainedModel):
-    model_config_file = "config.json"
+    model_config_file = CONFIG_NAME
     pretrained_init_configuration = ERNIE_LAYOUT_PRETRAINED_INIT_CONFIGURATION
     pretrained_resource_files_map = ERNIE_LAYOUT_PRETRAINED_RESOURCE_FILES_MAP
     base_model_prefix = "ernie_layout"
@@ -184,9 +186,7 @@ class ErnieLayoutPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.pretrained_init_configuration["initializer_range"]
-                        if "initializer_range" in self.pretrained_init_configuration
-                        else 0.02,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/ernie_layout/modeling.py
+++ b/paddlenlp/transformers/ernie_layout/modeling.py
@@ -23,15 +23,14 @@ from paddle.nn import Layer
 
 from paddlenlp.utils.log import logger
 
-from .. import PretrainedModel, register_base_model
 from ...utils.env import CONFIG_NAME
+from .. import PretrainedModel, register_base_model
 from .configuration import (
     ERNIE_LAYOUT_PRETRAINED_INIT_CONFIGURATION,
     ERNIE_LAYOUT_PRETRAINED_RESOURCE_FILES_MAP,
     ErnieLayoutConfig,
 )
 from .visual_backbone import ResNet
-
 
 __all__ = [
     "ErnieLayoutModel",

--- a/paddlenlp/transformers/ernie_m/configuration.py
+++ b/paddlenlp/transformers/ernie_m/configuration.py
@@ -144,7 +144,7 @@ class ErnieMConfig(PretrainedConfig):
         >>> configuration = model.config
         ```"""
     model_type = "ernie_m"
-    attribute_map: Dict[str, str] = {"num_classes": "num_labels", "dropout": "classifier_dropout"}
+    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
     pretrained_init_configuration = ERNIE_M_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/ernie_m/modeling.py
+++ b/paddlenlp/transformers/ernie_m/modeling.py
@@ -133,9 +133,7 @@ class ErnieMPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range
-                        if hasattr(self, "initializer_range")
-                        else self.ernie_m.config["initializer_range"],
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/mbart/modeling.py
+++ b/paddlenlp/transformers/mbart/modeling.py
@@ -94,7 +94,7 @@ class MBartPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.init_std if hasattr(self, "init_std") else self.mbart.config.init_std,
+                        std=self.config.init_std,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/mbart/modeling.py
+++ b/paddlenlp/transformers/mbart/modeling.py
@@ -22,8 +22,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.nn import Embedding, Layer, MultiHeadAttention
 
-from paddlenlp.utils.env import CONFIG_NAME
-
+from ...utils.env import CONFIG_NAME
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import (
@@ -1132,7 +1131,4 @@ class MBartForConditionalGeneration(MBartPretrainedModel):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                return getattr(getattr(self, self.base_model_prefix).config, name)
+            return getattr(getattr(self, self.base_model_prefix), name)

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -289,17 +289,13 @@ class PretrainedModel(Layer, GenerationMixin):
         Returns: the value of attribute
 
         """
-        try:
-            return super(PretrainedModel, self).__getattr__(name)
-        except AttributeError:
-            result = getattr(self.config, name)
+        result = getattr(self.config, name)
 
-            # FIXME(wj-Mcat): there are a lot of consistent errors, so temporary disable.
-            # logger.warning(
-            #     f"Do not access config from `model.{name}` which will be deprecated after v2.6.0, "
-            #     f"Instead, do `model.config.{name}`"
-            # )
-            return result
+        logger.warning(
+            f"Accessing `{name}` through `model.{name}` will be deprecated after v2.6.0. "
+            f"Instead, do `model.config.{name}`"
+        )
+        return result
 
     @property
     def base_model(self):

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -289,13 +289,16 @@ class PretrainedModel(Layer, GenerationMixin):
         Returns: the value of attribute
 
         """
-        result = getattr(self.config, name)
+        try:
+            return super(PretrainedModel, self).__getattr__(name)
+        except AttributeError:
+            result = getattr(self.config, name)
 
-        logger.warning(
-            f"Accessing `{name}` through `model.{name}` will be deprecated after v2.6.0. "
-            f"Instead, do `model.config.{name}`"
-        )
-        return result
+            logger.warning(
+                f"Accessing `{name}` through `model.{name}` will be deprecated after v2.6.0. "
+                f"Instead, do `model.config.{name}`"
+            )
+            return result
 
     @property
     def base_model(self):

--- a/paddlenlp/transformers/t5/configuration.py
+++ b/paddlenlp/transformers/t5/configuration.py
@@ -217,7 +217,7 @@ class T5Config(PretrainedConfig):
 
     """
     model_type = "t5"
-    attribute_map: Dict[str, str] = {
+    standard_config_map: Dict[str, str] = {
         "hidden_size": "d_model",
         "num_attention_heads": "num_heads",
         "num_hidden_layers": "num_layers",

--- a/paddlenlp/transformers/t5/modeling.py
+++ b/paddlenlp/transformers/t5/modeling.py
@@ -593,13 +593,12 @@ class T5PretrainedModel(PretrainedModel):
 
     def _init_weights(self, layer):
         """Initialize the weights"""
-        factor = (
-            self.initializer_factor if hasattr(self, "initializer_factor") else self.t5.config["initializer_factor"]
-        )  # Used for testing weights initialization
-        d_model = self.d_model if hasattr(self, "d_model") else self.t5.config["d_model"]
-        d_ff = self.d_ff if hasattr(self, "d_ff") else self.t5.config["d_ff"]
-        n_heads = self.num_heads if hasattr(self, "num_heads") else self.t5.config["num_heads"]
-        key_value_proj_dim = self.d_kv if hasattr(self, "d_kv") else self.t5.config["d_kv"]
+        # Used for testing weights initialization
+        factor = self.config.initializer_factor
+        d_model = self.config.d_model
+        d_ff = self.config.d_ff
+        n_heads = self.config.num_heads
+        key_value_proj_dim = self.config.d_kv
 
         if isinstance(layer, T5LayerNorm):
             layer.weight.set_value(paddle.ones_like(layer.weight) * factor)
@@ -681,8 +680,8 @@ class T5PretrainedModel(PretrainedModel):
                 )
 
     def _shift_right(self, input_ids):
-        bos_token_id = self.bos_token_id if hasattr(self, "bos_token_id") else self.t5.config["bos_token_id"]
-        pad_token_id = self.pad_token_id if hasattr(self, "pad_token_id") else self.t5.config["pad_token_id"]
+        bos_token_id = self.config.bos_token_id
+        pad_token_id = self.config.pad_token_id
 
         assert (
             bos_token_id is not None

--- a/paddlenlp/transformers/unified_transformer/modeling.py
+++ b/paddlenlp/transformers/unified_transformer/modeling.py
@@ -20,8 +20,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle import Tensor
 
-from paddlenlp.utils.env import CONFIG_NAME
-
+from ...utils.env import CONFIG_NAME
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import CausalLMOutputWithCrossAttentions
@@ -66,9 +65,7 @@ class UnifiedTransformerPretrainedModel(PretrainedModel):
                     # big models.
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range
-                        if hasattr(self, "initializer_range")
-                        else self.unified_transformer.config.initializer_range,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/unimo/modeling.py
+++ b/paddlenlp/transformers/unimo/modeling.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Modeling classes for UNIMO model."""
 
+from ast import excepthandler
 from typing import Optional, Tuple
 
 import paddle
@@ -64,9 +65,7 @@ class UNIMOPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range
-                        if hasattr(self, "initializer_range")
-                        else self.unimo.config.initializer_range,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )
@@ -540,12 +539,18 @@ class UNIMOLMHeadModel(UNIMOPretrainedModel):
 
     def __getattr__(self, name):
         try:
-            return super().__getattr__(name)
+            base_model = getattr(self, self.base_model_prefix)
+            print(base_model)
+            return getattr(base_model, name)
         except AttributeError:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                return getattr(getattr(self, self.base_model_prefix).config, name)
+            return super().__getattr__(name)
+        # try:
+        #     return super().__getattr__(name)
+        # except AttributeError:
+        #     try:
+        #         return getattr(getattr(self, self.base_model_prefix), name)
+        #     except AttributeError:
+        #         return getattr(getattr(self, self.base_model_prefix).config, name)
 
 
 UNIMOForMaskedLM = UNIMOLMHeadModel

--- a/paddlenlp/transformers/unimo/modeling.py
+++ b/paddlenlp/transformers/unimo/modeling.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Modeling classes for UNIMO model."""
 
-from ast import excepthandler
 from typing import Optional, Tuple
 
 import paddle
@@ -21,8 +20,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle import Tensor
 
-from paddlenlp.utils.env import CONFIG_NAME
-
+from ...utils.env import CONFIG_NAME
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import CausalLMOutputWithCrossAttentions
@@ -539,18 +537,9 @@ class UNIMOLMHeadModel(UNIMOPretrainedModel):
 
     def __getattr__(self, name):
         try:
-            base_model = getattr(self, self.base_model_prefix)
-            print(base_model)
-            return getattr(base_model, name)
-        except AttributeError:
             return super().__getattr__(name)
-        # try:
-        #     return super().__getattr__(name)
-        # except AttributeError:
-        #     try:
-        #         return getattr(getattr(self, self.base_model_prefix), name)
-        #     except AttributeError:
-        #         return getattr(getattr(self, self.base_model_prefix).config, name)
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 UNIMOForMaskedLM = UNIMOLMHeadModel

--- a/tests/transformers/test_configuration_utils.py
+++ b/tests/transformers/test_configuration_utils.py
@@ -150,7 +150,7 @@ class StandardConfigMappingTest(unittest.TestCase):
         config = FakeBertConfig.from_pretrained("__internal_testing__/bert")
         hidden_size = config.hidden_size
 
-        FakeBertConfig.standard_config_map = {"hidden_size": "fake_field"}
+        FakeBertConfig.standard_config_map = {"fake_field": "hidden_size"}
 
         loaded_config = FakeBertConfig.from_pretrained("__internal_testing__/bert")
         fake_field = loaded_config.fake_field
@@ -181,7 +181,7 @@ class StandardConfigMappingTest(unittest.TestCase):
             # rename `config.json` -> `model_config.json`
             shutil.move(os.path.join(tempdir, CONFIG_NAME), os.path.join(tempdir, LEGACY_CONFIG_NAME))
 
-            FakeBertConfig.standard_config_map = {"hidden_size": "fake_field"}
+            FakeBertConfig.standard_config_map = {"fake_field": "hidden_size"}
 
             loaded_config = FakeBertConfig.from_pretrained(tempdir)
             self.assertEqual(loaded_config.fake_field, config.hidden_size)

--- a/tests/transformers/test_modeling_common.py
+++ b/tests/transformers/test_modeling_common.py
@@ -67,7 +67,7 @@ class ModelTesterMixin:
     test_resize_position_embeddings = False
     test_mismatched_shapes = True
     test_missing_keys = True
-    test_model_compatibility_keys = False
+    test_model_compatibility_keys = True
     use_test_inputs_embeds = False
     use_test_model_name_list = True
     is_encoder_decoder = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
Previously, all the warnings were triggered by `hasattr`, which calls `__get_attr__` underneath and triggered all the warning. Changing everything to access from config now.

Also remove the get from config branch of __get_attr__ of Bart/MBart/CodeGen/Unimo/Unified Transformers

Tested that all the warnings go away after this PR
<!-- Describe what this PR does -->
