### PR TITLE
[BugFix]enable fix-lock in configuration downloading

### DIFF
--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -38,7 +38,7 @@ from paddlenlp.utils.log import logger
 from ..utils import CONFIG_NAME
 from ..utils.downloader import (
     COMMUNITY_MODEL_PREFIX,
-    get_path_from_url,
+    get_path_from_url_with_filelock,
     is_url,
     url_file_exists,
 )
@@ -148,7 +148,7 @@ def cached_path(
             shutil.rmtree(file_path, ignore_errors=True)
 
         # URL, so get it from the cache (downloading if necessary)
-        output_path = get_path_from_url(
+        output_path = get_path_from_url_with_filelock(
             url_or_filename,
             root_dir=cache_dir,
         )
@@ -784,7 +784,7 @@ class PretrainedConfig:
 
         # 3. get the configuration file from url, eg: https://ip/path/to/model_config.jsons
         elif is_url(pretrained_model_name_or_path):
-            resolved_config_file = get_path_from_url(
+            resolved_config_file = get_path_from_url_with_filelock(
                 pretrained_model_name_or_path, cache_dir, check_exist=not force_download
             )
         # 4. get the configuration file from local dir with default name, eg: /local/path


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
虽然config.json 文件很小，可是在多卡多进程下载的时候还是有可能出现问题，所以此时也需要将file-lock 的 feature 引入到Configuration 模块当中。
