### PR TITLE
[prompt] fix missing args in autotemplate and labels in trainer

### DIFF
--- a/paddlenlp/prompt/prompt_trainer.py
+++ b/paddlenlp/prompt/prompt_trainer.py
@@ -235,7 +235,7 @@ class PromptTrainer(Trainer):
             loss = self.criterion(logits, labels)
 
             if self.args.use_rdrop:
-                loss = self._compute_rdrop_loss(model, input_dict, logits, loss)
+                loss = self._compute_rdrop_loss(model, input_dict, labels, logits, loss)
 
             if self.args.use_rgl:
                 loss += self._compute_rgl_loss(hidden_states, labels)
@@ -246,9 +246,8 @@ class PromptTrainer(Trainer):
 
         return (loss, outputs) if return_outputs else loss
 
-    def _compute_rdrop_loss(self, model, input_dict, outputs, loss):
+    def _compute_rdrop_loss(self, model, input_dict, labels, outputs, loss):
         re_outputs, _ = model(**input_dict)
-        labels = input_dict["labels"]
         ce_loss = (self.criterion(re_outputs, labels) + loss) * 0.5
         kl_loss = self.rdrop_criterion(outputs, re_outputs)
         loss = ce_loss + self.args.alpha_rdrop * kl_loss

--- a/paddlenlp/prompt/template.py
+++ b/paddlenlp/prompt/template.py
@@ -778,6 +778,7 @@ class AutoTemplate(object):
         max_length: int = 512,
         model: PretrainedModel = None,
         soft_embeddings: Tensor = None,
+        prefix_dropout: float = 0.1,
     ):
         # Default template if not defined.
         if prompt is None:
@@ -795,11 +796,17 @@ class AutoTemplate(object):
 
         # Choose Template according to template keywords.
         if "prefix" in template_keywords:
-            return PrefixTemplate(prompt=prompt, tokenizer=tokenizer, max_length=max_length, model=model)
+            return PrefixTemplate(
+                prompt=prompt, tokenizer=tokenizer, max_length=max_length, model=model, prefix_dropout=prefix_dropout
+            )
         elif "soft" in template_keywords or "soft_id" in template_keywords:
             word_embeddings = model.get_input_embeddings()
             return SoftTemplate(
-                prompt=prompt, tokenizer=tokenizer, max_length=max_length, word_embeddings=word_embeddings
+                prompt=prompt,
+                tokenizer=tokenizer,
+                max_length=max_length,
+                word_embeddings=word_embeddings,
+                soft_embeddings=soft_embeddings,
             )
         else:
             return ManualTemplate(prompt=prompt, tokenizer=tokenizer, max_length=max_length)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
- Fix arguments that failed to  initialize properly  in AutoTemplate
- Fix missing labels when using rdrop loss