### PR TITLE
[FastDeploy] Decrease the cost of h2d, d2h in the unet loop to imporve SD model performance

### DIFF
--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -1,24 +1,27 @@
-# FastDeploy Diffusion模型高性能部署
+# FastDeploy Stable Diffusion 模型高性能部署
 
-本示例展现如何通过FastDeploy将我们PPDiffusers训练好的Diffusion模型进行多推理引擎后端高性能部署。
+本示例展现如何通过 FastDeploy 将我们 PPDiffusers 训练好的 Stable Diffusion 模型进行多硬件多推理引擎后端高性能部署。
 
-### 部署模型准备
+## 部署模型准备
 
-本示例需要使用训练模型导出后的部署模型。有两种部署模型的获取方式：
-
-- 模型导出方式，可参考[模型导出文档](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/ppdiffusers/deploy/export.md)导出部署模型。
+本示例需要使用训练模型导出后的部署模型，可参考[模型导出文档](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/ppdiffusers/deploy/export.md)导出部署模型。
 
 ## 环境依赖
 
-在示例中使用了FastDeploy，需要执行以下命令安装依赖。
+在示例中使用了 FastDeploy，需要执行以下命令安装依赖。
 
 ```shell
 pip install fastdeploy-gpu-python -f https://www.paddlepaddle.org.cn/whl/fastdeploy.html
 ```
 
-### 快速体验
+## 快速体验
 
-我们经过部署模型准备，可以开始进行测试。下面将指定模型目录以及推理引擎后端，运行`text_to_img_infer.py`脚本，完成推理。
+我们经过部署模型准备，可以开始进行测试。本目录提供 StableDiffusion 模型支持的三种任务，分别是文图生成、文本引导的图像变换以及文本引导的图像编辑。
+
+### 文图生成 （Text-to-Image Generation）
+
+
+下面将指定模型目录以及推理引擎后端，运行`text_to_img_infer.py`脚本，完成文图生成任务。
 
 ```
 python text_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm" --backend paddle
@@ -52,3 +55,9 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 | --image_path | 生成图片的路径。默认为`fd_astronaut_rides_horse.png`。  |
 | --device_id | gpu设备的id。若`device_id`为-1，视为使用cpu推理。 |
 | --use_fp16 | 是否使用fp16精度。默认为`False`。使用tensorrt或者paddle-tensorrt后端时可以设为`True`开启。 |
+
+### 文本引导的图像变换（Image-to-Image Text-Guided Generation）
+
+
+
+### 文本引导的图像编辑（Text-Guided Image Inpainting）

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -8,7 +8,7 @@
        * [文本引导的图像变换（Image-to-Image Text-Guided Generation）](#文本引导的图像变换)
        * [文本引导的图像编辑（Text-Guided Image Inpainting）](#文本引导的图像编辑)
 
-本示例展现如何通过 FastDeploy 将我们 PPDiffusers 训练好的 Stable Diffusion 模型进行多硬件多推理引擎后端高性能部署。
+⚡️[FastDeploy](https://github.com/PaddlePaddle/FastDeploy)是一款全场景、易用灵活、极致高效的AI推理部署工具，为开发者提供多硬件、多推理引擎后端的部署能力。开发者只需调用一行代码即可随意切换硬件、推理引擎后端。本示例展现如何通过 FastDeploy 将我们 PPDiffusers 训练好的 Stable Diffusion 模型进行多硬件、多推理引擎后端高性能部署。
 
 <a name="部署模型准备"></a>
 

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -131,7 +131,7 @@ mask 图像为：
 
 运行得到的图像文件为 cat_on_bench_new.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 
-![cat_on_bench_new.png](https://user-images.githubusercontent.com/10826371/217200795-811a8c73-9fb3-4445-b363-b445c7ee52cd.png)
+![image](https://user-images.githubusercontent.com/10826371/217449299-19b13fcb-37ca-45fa-a546-cc6b9afc8e91.png)
 
 如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
 
@@ -140,3 +140,44 @@ python inpaint_legacy_infer.py --model_dir stable-diffusion-v1-5/ --scheduler eu
 ```
 
 #### 正式版本
+
+下面将指定模型目录，推理引擎后端，硬件以及 scheduler 类型，运行 `inpaint_legacy_infer.py` 脚本，完成文本引导的图像编辑任务。
+
+```
+python inpaint_legacy_infer.py --model_dir stable-diffusion-v1-5-inpainting/ --scheduler euler_ancestral --device gpu --backend paddle
+```
+
+脚本输入的提示语为 **"Face of a yellow cat, high resolution, sitting on a park bench"**，待变换的图像为：
+
+![image](https://user-images.githubusercontent.com/10826371/217423470-b2a3f8ac-618b-41ee-93e2-121bddc9fd36.png)
+
+mask 图像为：
+
+![overture-creations-mask](https://user-images.githubusercontent.com/10826371/217424068-99d0a97d-dbc3-4126-b80c-6409d2fd7ebc.png)
+
+
+运行得到的图像文件为 cat_on_bench_new.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
+
+![image](https://user-images.githubusercontent.com/10826371/217448912-a0d7f01f-511c-480b-bf7a-7cca3e70f40f.png)
+
+
+#### 参数说明
+
+`inpaint_legacy_infer.py` 和 `inpaint_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。展开可查看各命令行参数的说明。
+
+<details><summary>&emsp; 命令行参数说明 </summary>
+
+| 参数 |参数说明 |
+|----------|--------------|
+| --model_dir | 导出后模型的目录。 |
+| --model_format | 模型格式。默认为 `'paddle'`，可选列表：`['paddle', 'onnx']`。 |
+| --backend | 推理引擎后端。默认为 `paddle`，可选列表：`['onnx_runtime', 'paddle', 'paddlelite', 'paddle_tensorrt']`，当模型格式为 `onnx` 时，可选列表为 `['onnx_runtime']`。 |
+| --device | 运行设备。默认为 `cpu`，可选列表：`['cpu', 'gpu', 'huawei_ascend_npu', 'kunlunxin_xpu']`。 |
+| --scheduler | StableDiffusion 模型的 scheduler。默认为 `'pndm'`。可选列表：`['pndm', 'euler_ancestral']`。|
+| --unet_model_prefix | UNet 模型前缀。默认为 `unet`。 |
+| --vae_model_prefix | VAE 模型前缀。默认为 `vae_decoder`。 |
+| --text_encoder_model_prefix | TextEncoder 模型前缀。默认为 `text_encoder`。 |
+| --inference_steps | UNet 模型运行的次数，默认为 50。 |
+| --image_path | 生成图片的路径。默认为 `cat_on_bench_new.png`。  |
+| --device_id | gpu 设备的 id。若 `device_id` 为-1，视为使用 cpu 推理。 |
+| --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -150,7 +150,7 @@ mask 图像为：
 
 运行得到的图像文件为 cat_on_bench_new.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 
-![image](https://user-images.githubusercontent.com/10826371/217449299-19b13fcb-37ca-45fa-a546-cc6b9afc8e91.png)
+![image](https://user-images.githubusercontent.com/10826371/217455594-187aa99c-b321-4535-aca0-9159ad658a97.png)
 
 如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
 
@@ -177,7 +177,7 @@ mask 图像为：
 
 运行得到的图像文件为 cat_on_bench_new.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 
-![image](https://user-images.githubusercontent.com/10826371/217448912-a0d7f01f-511c-480b-bf7a-7cca3e70f40f.png)
+![image](https://user-images.githubusercontent.com/10826371/217454490-7d6c6a89-fde6-4393-af8e-05e84961b354.png)
 
 
 #### 参数说明

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -81,7 +81,7 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm"
 如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
 
 ```
-python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "pndm" --backend paddle --device gpu
+python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler_ancestral" --backend paddle --device gpu
 ```
 
 #### 参数说明

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -39,7 +39,9 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 
 #### 参数说明
 
-`text_to_img_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。以下为各命令行参数的说明。
+`text_to_img_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。展开可查看各命令行参数的说明。
+
+<details><summary>&emsp; 命令行参数说明 </summary>
 
 | 参数 |参数说明 |
 |----------|--------------|
@@ -55,6 +57,8 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 | --image_path | 生成图片的路径。默认为 `fd_astronaut_rides_horse.png`。  |
 | --device_id | gpu 设备的 id。若 `device_id` 为-1，视为使用 cpu 推理。 |
 | --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |
+
+</details>
 
 ### 文本引导的图像变换（Image-to-Image Text-Guided Generation）
 
@@ -82,7 +86,9 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "pndm"
 
 #### 参数说明
 
-`img_to_img_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。以下为各命令行参数的说明。
+`img_to_img_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。展开可查看各命令行参数的说明。
+
+<details><summary>&emsp; 命令行参数说明 </summary>
 
 | 参数 |参数说明 |
 |----------|--------------|
@@ -98,5 +104,8 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "pndm"
 | --image_path | 生成图片的路径。默认为 `fantasy_landscape.png`。  |
 | --device_id | gpu 设备的 id。若 `device_id` 为-1，视为使用 cpu 推理。 |
 | --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |
+
+</details>
+
 
 ### 文本引导的图像编辑（Text-Guided Image Inpainting）

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -27,7 +27,7 @@ pip install fastdeploy-gpu-python -f https://www.paddlepaddle.org.cn/whl/fastdep
 python text_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm" --backend paddle
 ```
 
-脚本的输入提示语句为 "a photo of an astronaut riding a horse on mars"， 得到的图像文件为 fd_astronaut_rides_horse.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
+脚本的输入提示语句为 **"a photo of an astronaut riding a horse on mars"**， 得到的图像文件为 fd_astronaut_rides_horse.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 
 ![fd_astronaut_rides_horse.png](https://user-images.githubusercontent.com/10826371/200261112-68e53389-e0a0-42d1-8c3a-f35faa6627d7.png)
 
@@ -64,9 +64,10 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 python img_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm" --backend paddle --device gpu
 ```
 
-脚本输入的提示语句为 "A fantasy landscape, trending on artstation"，待变换的图像为：
+脚本输入的提示语句为 **"A fantasy landscape, trending on artstation"**，待变换的图像为：
 
-![sketch-mountains-input.png](https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/sketch-mountains-input.png)
+![sketch-mountains-input.png](https://user-images.githubusercontent.com/10826371/217207485-09ee54de-4ba2-4cff-9d6c-fd426d4c1831.png)
+
 
 运行得到的图像文件为 fantasy_landscape.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -109,3 +109,9 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler
 
 
 ### 文本引导的图像编辑（Text-Guided Image Inpainting）
+
+注意！当前有两种版本的图像编辑代码，一个是 Legacy 版本，一个是正式版本，下面将分别介绍两种版本的使用示例。
+
+#### Legacy 版本
+
+#### 正式版本

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -21,20 +21,20 @@ pip install fastdeploy-gpu-python -f https://www.paddlepaddle.org.cn/whl/fastdep
 ### 文图生成 （Text-to-Image Generation）
 
 
-下面将指定模型目录以及推理引擎后端，运行`text_to_img_infer.py`脚本，完成文图生成任务。
+下面将指定模型目录，推理引擎后端，硬件以及 scheduler 类型，运行 `text_to_img_infer.py` 脚本，完成文图生成任务。
 
 ```
 python text_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm" --backend paddle
 ```
 
-得到的图像文件为fd_astronaut_rides_horse.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
+脚本的输入提示语句为 "a photo of an astronaut riding a horse on mars"， 得到的图像文件为 fd_astronaut_rides_horse.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
 
 ![fd_astronaut_rides_horse.png](https://user-images.githubusercontent.com/10826371/200261112-68e53389-e0a0-42d1-8c3a-f35faa6627d7.png)
 
-如果使用stable-diffusion-v1-5模型，则可执行以下命令完成推理：
+如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
 
 ```
-python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler_ancestral" --backend paddle
+python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler_ancestral" --backend paddle --device gpu
 ```
 
 #### 参数说明
@@ -44,20 +44,58 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 | 参数 |参数说明 |
 |----------|--------------|
 | --model_dir | 导出后模型的目录。 |
-| --model_format | 模型格式。默认为`'paddle'`，可选列表：`['paddle', 'onnx']`。 |
-| --backend | 推理引擎后端。默认为`paddle`，可选列表：`['onnx_runtime', 'paddle', 'paddlelite']`，当模型格式为`onnx`时，可选列表为`['onnx_runtime']`。 |
-| --device | 运行设备。默认为`gpu`，可选列表：`['cpu', 'gpu', 'huawei_ascend_npu', 'kunlunxin_xpu']`。 |
-| --scheduler | StableDiffusion 模型的scheduler。默认为`'pndm'`。可选列表：`['pndm', 'euler_ancestral']`，StableDiffusio模型对应的scheduler可参考[ppdiffuser模型列表](https://github.com/PaddlePaddle/PaddleNLP/tree/main/ppdiffusers#ppdiffusers%E6%A8%A1%E5%9E%8B%E6%94%AF%E6%8C%81%E7%9A%84%E6%9D%83%E9%87%8D)。|
-| --unet_model_prefix | UNet模型前缀。默认为`unet`。 |
-| --vae_model_prefix | VAE模型前缀。默认为`vae_decoder`。 |
-| --text_encoder_model_prefix | TextEncoder模型前缀。默认为`text_encoder`。 |
-| --inference_steps | UNet模型运行的次数，默认为100。 |
-| --image_path | 生成图片的路径。默认为`fd_astronaut_rides_horse.png`。  |
-| --device_id | gpu设备的id。若`device_id`为-1，视为使用cpu推理。 |
-| --use_fp16 | 是否使用fp16精度。默认为`False`。使用tensorrt或者paddle-tensorrt后端时可以设为`True`开启。 |
+| --model_format | 模型格式。默认为 `'paddle'`，可选列表：`['paddle', 'onnx']`。 |
+| --backend | 推理引擎后端。默认为 `paddle`，可选列表：`['onnx_runtime', 'paddle', 'paddlelite', 'paddle_tensorrt']`，当模型格式为 `onnx` 时，可选列表为 `['onnx_runtime']`。 |
+| --device | 运行设备。默认为 `cpu`，可选列表：`['cpu', 'gpu', 'huawei_ascend_npu', 'kunlunxin_xpu']`。 |
+| --scheduler | StableDiffusion 模型的 scheduler。默认为 `'pndm'`。可选列表：`['pndm', 'euler_ancestral']`。|
+| --unet_model_prefix | UNet 模型前缀。默认为 `unet`。 |
+| --vae_model_prefix | VAE 模型前缀。默认为 `vae_decoder`。 |
+| --text_encoder_model_prefix | TextEncoder 模型前缀。默认为 `text_encoder`。 |
+| --inference_steps | UNet 模型运行的次数，默认为 50。 |
+| --image_path | 生成图片的路径。默认为 `fd_astronaut_rides_horse.png`。  |
+| --device_id | gpu 设备的 id。若 `device_id` 为-1，视为使用 cpu 推理。 |
+| --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |
 
 ### 文本引导的图像变换（Image-to-Image Text-Guided Generation）
 
+下面将指定模型目录，推理引擎后端，硬件以及 scheduler 类型，运行 `img_to_img_infer.py` 脚本，完成文本引导的图像变换任务。
 
+```
+python img_to_img_infer.py --model_dir stable-diffusion-v1-4/ --scheduler "pndm" --backend paddle --device gpu
+```
+
+脚本输入的提示语句为 "A fantasy landscape, trending on artstation"，待变换的图像为：
+
+![sketch-mountains-input.png](https://paddlenlp.bj.bcebos.com/models/community/CompVis/stable-diffusion-v1-4/sketch-mountains-input.png)
+
+运行得到的图像文件为 fantasy_landscape.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
+
+![fantasy_landscape.png](https://user-images.githubusercontent.com/10826371/217200795-811a8c73-9fb3-4445-b363-b445c7ee52cd.png)
+
+
+如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
+
+```
+python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "pndm" --backend paddle --device gpu
+```
+
+#### 参数说明
+
+`img_to_img_infer.py` 除了以上示例的命令行参数，还支持更多命令行参数的设置。以下为各命令行参数的说明。
+
+| 参数 |参数说明 |
+|----------|--------------|
+| --model_dir | 导出后模型的目录。 |
+| --model_format | 模型格式。默认为 `'paddle'`，可选列表：`['paddle', 'onnx']`。 |
+| --backend | 推理引擎后端。默认为 `paddle`，可选列表：`['onnx_runtime', 'paddle', 'paddlelite', 'paddle_tensorrt']`，当模型格式为 `onnx` 时，可选列表为 `['onnx_runtime']`。 |
+| --device | 运行设备。默认为 `cpu`，可选列表：`['cpu', 'gpu', 'huawei_ascend_npu', 'kunlunxin_xpu']`。 |
+| --scheduler | StableDiffusion 模型的 scheduler。默认为 `'pndm'`。可选列表：`['pndm', 'euler_ancestral']`。|
+| --unet_model_prefix | UNet 模型前缀。默认为 `unet`。 |
+| --vae_model_prefix | VAE 模型前缀。默认为 `vae_decoder`。 |
+| --text_encoder_model_prefix | TextEncoder 模型前缀。默认为 `text_encoder`。 |
+| --inference_steps | UNet 模型运行的次数，默认为 50。 |
+| --image_path | 生成图片的路径。默认为 `fantasy_landscape.png`。  |
+| --device_id | gpu 设备的 id。若 `device_id` 为-1，视为使用 cpu 推理。 |
+| --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |
 
 ### 文本引导的图像编辑（Text-Guided Image Inpainting）

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -114,4 +114,29 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler
 
 #### Legacy 版本
 
+下面将指定模型目录，推理引擎后端，硬件以及 scheduler 类型，运行 `inpaint_legacy_infer.py` 脚本，完成文本引导的图像编辑任务。
+
+```
+python inpaint_legacy_infer.py --model_dir stable-diffusion-v1-4/ --scheduler euler_ancestral --device gpu --backend paddle
+```
+
+脚本输入的提示语为 **"Face of a yellow cat, high resolution, sitting on a park bench"**，待变换的图像为：
+
+![image](https://user-images.githubusercontent.com/10826371/217423470-b2a3f8ac-618b-41ee-93e2-121bddc9fd36.png)
+
+mask 图像为：
+
+![overture-creations-mask](https://user-images.githubusercontent.com/10826371/217424068-99d0a97d-dbc3-4126-b80c-6409d2fd7ebc.png)
+
+
+运行得到的图像文件为 cat_on_bench_new.png。生成的图片示例如下（每次生成的图片都不相同，示例仅作参考）：
+
+![cat_on_bench_new.png](https://user-images.githubusercontent.com/10826371/217200795-811a8c73-9fb3-4445-b363-b445c7ee52cd.png)
+
+如果使用 stable-diffusion-v1-5 模型，则可执行以下命令完成推理：
+
+```
+python inpaint_legacy_infer.py --model_dir stable-diffusion-v1-5/ --scheduler euler_ancestral --device gpu --backend paddle
+```
+
 #### 正式版本

--- a/ppdiffusers/deploy/README.md
+++ b/ppdiffusers/deploy/README.md
@@ -1,10 +1,22 @@
 # FastDeploy Stable Diffusion 模型高性能部署
 
+ **目录**
+   * [部署模型准备](#部署模型准备)
+   * [环境依赖](#环境依赖)
+   * [快速体验](#快速体验)
+       * [文图生成（Text-to-Image Generation）](#文图生成)
+       * [文本引导的图像变换（Image-to-Image Text-Guided Generation）](#文本引导的图像变换)
+       * [文本引导的图像编辑（Text-Guided Image Inpainting）](#文本引导的图像编辑)
+
 本示例展现如何通过 FastDeploy 将我们 PPDiffusers 训练好的 Stable Diffusion 模型进行多硬件多推理引擎后端高性能部署。
+
+<a name="部署模型准备"></a>
 
 ## 部署模型准备
 
 本示例需要使用训练模型导出后的部署模型，可参考[模型导出文档](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/ppdiffusers/deploy/export.md)导出部署模型。
+
+<a name="环境依赖"></a>
 
 ## 环境依赖
 
@@ -14,11 +26,15 @@
 pip install fastdeploy-gpu-python -f https://www.paddlepaddle.org.cn/whl/fastdeploy.html
 ```
 
+<a name="快速体验"></a>
+
 ## 快速体验
 
 我们经过部署模型准备，可以开始进行测试。本目录提供 StableDiffusion 模型支持的三种任务，分别是文图生成、文本引导的图像变换以及文本引导的图像编辑。
 
-### 文图生成 （Text-to-Image Generation）
+<a name="文图生成"></a>
+
+### 文图生成（Text-to-Image Generation）
 
 
 下面将指定模型目录，推理引擎后端，硬件以及 scheduler 类型，运行 `text_to_img_infer.py` 脚本，完成文图生成任务。
@@ -59,6 +75,8 @@ python text_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "eule
 | --use_fp16 | 是否使用 fp16 精度。默认为 `False`。使用 tensorrt 或者 paddle-tensorrt 后端时可以设为 `True` 开启。 |
 
 </details>
+
+<a name="文本引导的图像变换"></a>
 
 ### 文本引导的图像变换（Image-to-Image Text-Guided Generation）
 
@@ -107,6 +125,7 @@ python img_to_img_infer.py --model_dir stable-diffusion-v1-5/ --scheduler "euler
 
 </details>
 
+<a name="文本引导的图像编辑"></a>
 
 ### 文本引导的图像编辑（Text-Guided Image Inpainting）
 

--- a/ppdiffusers/deploy/export.md
+++ b/ppdiffusers/deploy/export.md
@@ -59,6 +59,6 @@ python export_model.py --pretrained_model_name_or_path runwayml/stable-diffusion
 
 | 参数 |参数说明 |
 |----------|--------------|
-| <div style="width: 230pt"> --pretrained_model_name_or_path </div> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4"。更多 StableDiffusion 预训练模型可参考 [ppdiffusers 模型列表](../README.md#ppdiffusers模型支持的权重)。|
+| <span style="display:inline-block;width: 230pt"> --pretrained_model_name_or_path </span> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4"。更多 StableDiffusion 预训练模型可参考 [ppdiffusers 模型列表](../README.md#ppdiffusers模型支持的权重)。|
 | --output_path | 导出的模型目录。 |
 | --sample | vae encoder 的输出是否调整为 sample 模式，注意：sample模式会引入随机因素，默认是 False。|

--- a/ppdiffusers/deploy/export.md
+++ b/ppdiffusers/deploy/export.md
@@ -44,9 +44,9 @@ stable-diffusion-v1-5/
     └── inference.pdmodel
 ```
 
-#### Inpaint任务模型导出
+#### Inpaint 任务模型导出
 
-除了支持常规StableDiffusion文生图、图生图任务的模型导出以外，还支持Inpaint任务模型 (注意：这个不是legacy版本的inpaint) 的导出、如果需要导出inpaint模型，可以执行以下命令：
+除了支持常规 StableDiffusion 文生图、图生图任务的模型导出以外，还支持Inpaint任务模型 (注意：这个不是 legacy 版本的 inpaint) 的导出、如果需要导出 inpaint 模型，可以执行以下命令：
 
 ```shell
 python export_model.py --pretrained_model_name_or_path runwayml/stable-diffusion-inpainting --output_path stable-diffusion-v1-5-inpainting
@@ -58,6 +58,6 @@ python export_model.py --pretrained_model_name_or_path runwayml/stable-diffusion
 
 | 参数 |参数说明 |
 |----------|--------------|
-|<div style="width: 230pt">--pretrained_model_name_or_path </div> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4    "。更多diffusion预训练模型可参考[ppdiffuser模型列表](https://github.com/PaddlePaddle/PaddleNLP/tree/main/ppdiffusers#ppdiffusers%E6%A8%A1%E5%9E%8B%E6%94%AF%E6%8C%81%E7%9A%84%E6%9D%83%E9%87%8D)。|
+|<div style="width: 230pt"> --pretrained_model_name_or_path </div> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4"。更多 StableDiffusion 预训练模型可参考 [ppdiffuser 模型列表](../README.md#ppdiffusers模型支持的权重)。|
 |--output_path | 导出的模型目录。 |
-|--sample | vae encode的输出是否调整为sample模式，注意：sample模式会引入随机因素，默认是不开启！ |
+|--sample | vae encoder 的输出是否调整为 sample 模式，注意：sample模式会引入随机因素，默认是 False。|

--- a/ppdiffusers/deploy/export.md
+++ b/ppdiffusers/deploy/export.md
@@ -1,13 +1,13 @@
 # Diffusion 模型导出教程
 
 
-[PPDiffusers](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/ppdiffusers) 是一款支持跨模态（如图像与语音）训练和推理的扩散模型（Diffusion Model）工具箱，其借鉴了🤗 Huggingface 团队的[Diffusers](https://github.com/huggingface/diffusers)的优秀设计，并且依托[PaddlePaddle](https://github.com/PaddlePaddle/Paddle)框架和 [PaddleNLP](https://github.com/PaddlePaddle/PaddleNLP)自然语言处理库。下面将介绍如何将 PPDiffusers 提供的预训练模型进行模型导出。
+[PPDiffusers](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/ppdiffusers) 是一款支持跨模态（如图像与语音）训练和推理的扩散模型（Diffusion Model）工具箱，其借鉴了🤗 Huggingface 团队的 [Diffusers](https://github.com/huggingface/diffusers) 的优秀设计，并且依托 [PaddlePaddle](https://github.com/PaddlePaddle/Paddle) 框架和 [PaddleNLP](https://github.com/PaddlePaddle/PaddleNLP) 自然语言处理库。下面将介绍如何将 PPDiffusers 提供的预训练模型进行模型导出。
 
 ### 模型导出
 
 ___注意：模型导出过程中，需要下载 StableDiffusion 模型。为了使用该模型与权重，你必须接受该模型所要求的 License，请访问 HuggingFace 的[model card](https://huggingface.co/runwayml/stable-diffusion-v1-5), 仔细阅读里面的 License，然后签署该协议。___
 
-___Tips: Stable Diffusion是基于以下的License: The CreativeML OpenRAIL M license is an Open RAIL M license, adapted from the work that BigScience and the RAIL Initiative are jointly carrying in the area of responsible AI licensing. See also the article about the BLOOM Open RAIL license on which this license is based.___
+___Tips: Stable Diffusion 是基于以下的 License: The CreativeML OpenRAIL M license is an Open RAIL M license, adapted from the work that BigScience and the RAIL Initiative are jointly carrying in the area of responsible AI licensing. See also the article about the BLOOM Open RAIL license on which this license is based.___
 
 可执行以下命令行完成模型导出。
 

--- a/ppdiffusers/deploy/export.md
+++ b/ppdiffusers/deploy/export.md
@@ -1,11 +1,11 @@
-# Diffusion模型导出教程
+# Diffusion 模型导出教程
 
 
-[PPDiffusers](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/ppdiffusers)是一款支持跨模态（如图像与语音）训练和推理的扩散模型（Diffusion Model）工具箱，其借鉴了🤗 Huggingface团队的[Diffusers](https://github.com/huggingface/diffusers)的优秀设计，并且依托[PaddlePaddle](https://github.com/PaddlePaddle/Paddle)框架和[PaddleNLP](https://github.com/PaddlePaddle/PaddleNLP)自然语言处理库。下面将介绍如何将PPDiffusers提供的预训练模型进行模型导出。
+[PPDiffusers](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/ppdiffusers) 是一款支持跨模态（如图像与语音）训练和推理的扩散模型（Diffusion Model）工具箱，其借鉴了🤗 Huggingface 团队的[Diffusers](https://github.com/huggingface/diffusers)的优秀设计，并且依托[PaddlePaddle](https://github.com/PaddlePaddle/Paddle)框架和 [PaddleNLP](https://github.com/PaddlePaddle/PaddleNLP)自然语言处理库。下面将介绍如何将 PPDiffusers 提供的预训练模型进行模型导出。
 
 ### 模型导出
 
-___注意：模型导出过程中，需要下载StableDiffusion模型。为了使用该模型与权重，你必须接受该模型所要求的License，请访问HuggingFace的[model card](https://huggingface.co/runwayml/stable-diffusion-v1-5), 仔细阅读里面的License，然后签署该协议。___
+___注意：模型导出过程中，需要下载 StableDiffusion 模型。为了使用该模型与权重，你必须接受该模型所要求的 License，请访问 HuggingFace 的[model card](https://huggingface.co/runwayml/stable-diffusion-v1-5), 仔细阅读里面的 License，然后签署该协议。___
 
 ___Tips: Stable Diffusion是基于以下的License: The CreativeML OpenRAIL M license is an Open RAIL M license, adapted from the work that BigScience and the RAIL Initiative are jointly carrying in the area of responsible AI licensing. See also the article about the BLOOM Open RAIL license on which this license is based.___
 
@@ -16,6 +16,7 @@ python export_model.py --pretrained_model_name_or_path runwayml/stable-diffusion
 ```
 
 输出的模型目录结构如下：
+
 ```shell
 stable-diffusion-v1-5/
 ├── model_index.json
@@ -58,6 +59,6 @@ python export_model.py --pretrained_model_name_or_path runwayml/stable-diffusion
 
 | 参数 |参数说明 |
 |----------|--------------|
-|<div style="width: 230pt"> --pretrained_model_name_or_path </div> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4"。更多 StableDiffusion 预训练模型可参考 [ppdiffuser 模型列表](../README.md#ppdiffusers模型支持的权重)。|
-|--output_path | 导出的模型目录。 |
-|--sample | vae encoder 的输出是否调整为 sample 模式，注意：sample模式会引入随机因素，默认是 False。|
+| <div style="width: 230pt"> --pretrained_model_name_or_path </div> | ppdiffuers提供的diffusion预训练模型。默认为："CompVis/stable-diffusion-v1-4"。更多 StableDiffusion 预训练模型可参考 [ppdiffusers 模型列表](../README.md#ppdiffusers模型支持的权重)。|
+| --output_path | 导出的模型目录。 |
+| --sample | vae encoder 的输出是否调整为 sample 模式，注意：sample模式会引入随机因素，默认是 False。|

--- a/ppdiffusers/deploy/img_to_img_infer.py
+++ b/ppdiffusers/deploy/img_to_img_infer.py
@@ -73,7 +73,7 @@ def parse_arguments():
         help="The inference runtime device of models.",
     )
     parser.add_argument(
-        "--image_path", default="fd_astronaut_rides_horse.png", help="The model directory of diffusion_model."
+        "--image_path", default="fantasy_landscape.png", help="The model directory of diffusion_model."
     )
     parser.add_argument("--use_fp16", type=distutils.util.strtobool, default=False, help="Wheter to use FP16 mode")
     parser.add_argument("--device_id", type=int, default=0, help="The selected gpu id. -1 means use cpu")
@@ -357,4 +357,4 @@ if __name__ == "__main__":
     prompt = "A fantasy landscape, trending on artstation"
     images = pipe(prompt=prompt, image=init_image, num_inference_steps=args.inference_steps).images
 
-    images[0].save("fantasy_landscape.png")
+    images[0].save(args.image_path)

--- a/ppdiffusers/deploy/inpaint_legacy_infer.py
+++ b/ppdiffusers/deploy/inpaint_legacy_infer.py
@@ -388,3 +388,4 @@ if __name__ == "__main__":
     )
 
     images[0].save(args.image_path)
+    print(f"Image saved in {args.image_path}!")

--- a/ppdiffusers/deploy/inpaint_legacy_infer.py
+++ b/ppdiffusers/deploy/inpaint_legacy_infer.py
@@ -18,6 +18,7 @@ import time
 from io import BytesIO
 
 import fastdeploy as fd
+import paddle
 import PIL
 import requests
 from fastdeploy import ModelFormat
@@ -72,9 +73,7 @@ def parse_arguments():
         ],
         help="The inference runtime device of models.",
     )
-    parser.add_argument(
-        "--image_path", default="fd_astronaut_rides_horse.png", help="The model directory of diffusion_model."
-    )
+    parser.add_argument("--image_path", default="cat_on_bench_new.png", help="The model directory of diffusion_model.")
     parser.add_argument("--use_fp16", type=distutils.util.strtobool, default=False, help="Wheter to use FP16 mode")
     parser.add_argument("--device_id", type=int, default=0, help="The selected gpu id. -1 means use cpu")
     parser.add_argument(
@@ -200,6 +199,13 @@ def get_scheduler(args):
 
 if __name__ == "__main__":
     args = parse_arguments()
+    # 0. Init device id
+    device_id = args.device_id
+    if args.device == "cpu":
+        device_id = -1
+        paddle.set_device("cpu")
+    else:
+        paddle.set_device(f"gpu:{device_id}")
     # 1. Init scheduler
     scheduler = get_scheduler(args)
 
@@ -242,9 +248,6 @@ if __name__ == "__main__":
     }
 
     # 4. Init runtime
-    device_id = args.device_id
-    if args.device == "cpu":
-        device_id = -1
     if args.backend == "onnx_runtime":
         text_encoder_runtime = create_ort_runtime(
             args.model_dir, args.text_encoder_model_prefix, args.model_format, device_id=device_id
@@ -368,4 +371,4 @@ if __name__ == "__main__":
         num_inference_steps=args.inference_steps,
     ).images
 
-    images[0].save("cat_on_bench_new.png")
+    images[0].save(args.image_path)

--- a/ppdiffusers/deploy/text_to_img_infer.py
+++ b/ppdiffusers/deploy/text_to_img_infer.py
@@ -196,6 +196,13 @@ def get_scheduler(args):
 
 if __name__ == "__main__":
     args = parse_arguments()
+    # 0. Init device id
+    device_id = args.device_id
+    if args.device == "cpu":
+        device_id = -1
+        paddle.set_device("cpu")
+    else:
+        paddle.set_device(f"gpu:{device_id}")
     # 1. Init scheduler
     scheduler = get_scheduler(args)
 
@@ -230,12 +237,6 @@ if __name__ == "__main__":
     }
 
     # 4. Init runtime
-    device_id = args.device_id
-    if args.device == "cpu":
-        device_id = -1
-        paddle.set_device("cpu")
-    else:
-        paddle.set_device(f"gpu:{device_id}")
     if args.backend == "onnx_runtime":
         text_encoder_runtime = create_ort_runtime(
             args.model_dir, args.text_encoder_model_prefix, args.model_format, device_id=device_id

--- a/ppdiffusers/deploy/text_to_img_infer.py
+++ b/ppdiffusers/deploy/text_to_img_infer.py
@@ -18,6 +18,7 @@ import time
 
 import fastdeploy as fd
 import numpy as np
+import paddle
 from fastdeploy import ModelFormat
 
 from paddlenlp.transformers import CLIPTokenizer
@@ -232,6 +233,9 @@ if __name__ == "__main__":
     device_id = args.device_id
     if args.device == "cpu":
         device_id = -1
+        paddle.set_device("cpu")
+    else:
+        paddle.set_device(f"gpu:{device_id}")
     if args.backend == "onnx_runtime":
         text_encoder_runtime = create_ort_runtime(
             args.model_dir, args.text_encoder_model_prefix, args.model_format, device_id=device_id

--- a/ppdiffusers/ppdiffusers/fastdeploy_utils.py
+++ b/ppdiffusers/ppdiffusers/fastdeploy_utils.py
@@ -31,8 +31,20 @@ from .utils import (
 
 if is_fastdeploy_available():
     import fastdeploy as fd
+    import paddle
 
 logger = logging.get_logger(__name__)
+
+
+def pdtensor2fdtensor(pdtensor: paddle.Tensor, name: str = ""):
+    dltensor = paddle.utils.dlpack.to_dlpack(pdtensor)
+    return fd.C.FDTensor.from_dlpack(name, dltensor)
+
+
+def fdtensor2pdtensor(fdtensor: fd.C.FDTensor):
+    dltensor = fdtensor.to_dlpack()
+    pdtensor = paddle.utils.dlpack.from_dlpack(dltensor)
+    return pdtensor
 
 
 class FastDeployRuntimeModel:

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
@@ -374,19 +374,10 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
             unet = self.unet.model
             unet_output_name = unet.get_output_info(0).name
             for i, t in enumerate(timesteps):
-                # tensor_t = paddle.to_tensor(t)
                 # expand the latents if we are doing classifier free guidance
-                # latent_model_input = np.concatenate([latents] * 2) if do_classifier_free_guidance else latents
-                # latent_model_input = self.scheduler.scale_model_input(paddle.to_tensor(latent_model_input), tensor_t)
-                # latent_model_input = latent_model_input.numpy()
                 latent_model_input = paddle.concat([latents] * 2) if do_classifier_free_guidance else latents
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
                 # predict the noise residual
-                # noise_pred = self.unet(
-                #     sample=latent_model_input.astype(np.float32),
-                #     timestep=np.array([t], dtype=np.int64),
-                #     encoder_hidden_states=text_embeddings.astype(np.float32),
-                # )[0]
                 input1 = fd.C.FDTensor()
                 input2 = fd.C.FDTensor()
                 input3 = fd.C.FDTensor()
@@ -402,8 +393,6 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
                 noise_pred = paddle.utils.dlpack.from_dlpack(dlpack)
                 # perform guidance
                 if do_classifier_free_guidance:
-                    # noise_pred_uncond, noise_pred_text = np.split(noise_pred, 2)
-                    # noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
@@ -258,8 +258,7 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
 
         latents_shape = (batch_size, num_channels_latents, height // 8, width // 8)
         if latents is None:
-            latents = paddle.randn(latents_shape, dtype=dtype)
-            # latents = generator.randn(*latents_shape).astype(dtype)
+            latents = generator.randn(*latents_shape).astype(dtype)
         elif latents.shape != latents_shape:
             raise ValueError(f"Unexpected latents shape, got {latents.shape}, expected {latents_shape}")
 
@@ -368,6 +367,8 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
             generator,
             latents,
         )
+        if isinstance(latents, np.ndarray):
+            latents = paddle.to_tensor(latents)
         # 6. Prepare extra step kwargs.
         extra_step_kwargs = self.prepare_extra_step_kwargs(eta)
 

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
@@ -399,7 +399,7 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
 
                 # compute the previous noisy sample x_t -> x_t-1
                 scheduler_output = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)
-                latents = scheduler_output.prev_sample  # .numpy()
+                latents = scheduler_output.prev_sample
 
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
@@ -379,12 +379,6 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
                 latent_model_input = paddle.concat([latents] * 2) if do_classifier_free_guidance else latents
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
                 # predict the noise residual
-                # input1 = fd.C.FDTensor()
-                # input2 = fd.C.FDTensor()
-                # input3 = fd.C.FDTensor()
-                # input1.from_numpy(latent_model_input.numpy().astype(np.float32), False)
-                # input2.from_numpy(np.array(t, dtype=np.int64), False)
-                # input3.from_numpy(text_embeddings.astype(np.float32), False)
                 dlpack1 = paddle.utils.dlpack.to_dlpack(latent_model_input)
                 dlpack2 = paddle.utils.dlpack.to_dlpack(t)
                 dlpack3 = paddle.utils.dlpack.to_dlpack(text_embeddings)

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion.py
@@ -21,11 +21,7 @@ import paddle
 
 from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTokenizer
 
-from ...fastdeploy_utils import (
-    FastDeployRuntimeModel,
-    fdtensor2pdtensor,
-    pdtensor2fdtensor,
-)
+from ...fastdeploy_utils import FastDeployRuntimeModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import (
     DDIMScheduler,
@@ -375,8 +371,6 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
         # 7. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
-            unet_runtime = self.unet.model
-            unet_output_name = unet_runtime.get_output_info(0).name
             text_embeddings = paddle.to_tensor(text_embeddings, dtype="float32")
             for i, t in enumerate(timesteps):
                 # expand the latents if we are doing classifier free guidance
@@ -384,17 +378,9 @@ class FastDeployStableDiffusionPipeline(DiffusionPipeline):
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                 # predict the noise residual
-                sample = pdtensor2fdtensor(latent_model_input, "sample")
-                timestep = pdtensor2fdtensor(t, "timestep")
-                encoder_hidden_states = pdtensor2fdtensor(text_embeddings, "encoder_hidden_states")
-                unet_runtime.bind_input_tensor("sample", sample)
-                unet_runtime.bind_input_tensor("timestep", timestep)
-                unet_runtime.bind_input_tensor("encoder_hidden_states", encoder_hidden_states)
-
-                unet_runtime.zero_copy_infer()
-
-                noise_pred = unet_runtime.get_output_tensor(unet_output_name)
-                noise_pred = fdtensor2pdtensor(noise_pred)
+                noise_pred = self.unet.zero_copy_infer(
+                    sample=latent_model_input, timestep=t, encoder_hidden_states=text_embeddings
+                )[0]
                 # perform guidance
                 if do_classifier_free_guidance:
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_img2img.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_img2img.py
@@ -21,7 +21,11 @@ import PIL
 
 from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTokenizer
 
-from ...fastdeploy_utils import FastDeployRuntimeModel
+from ...fastdeploy_utils import (
+    FastDeployRuntimeModel,
+    fdtensor2pdtensor,
+    pdtensor2fdtensor,
+)
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import (
     DDIMScheduler,
@@ -277,7 +281,7 @@ class FastDeployStableDiffusionImg2ImgPipeline(DiffusionPipeline):
         init_timestep = min(init_timestep, num_inference_steps)
 
         t_start = max(num_inference_steps - init_timestep + offset, 0)
-        timesteps = self.scheduler.timesteps.numpy()
+        timesteps = self.scheduler.timesteps
         timesteps = timesteps[t_start:]
         return timesteps, num_inference_steps - t_start
 
@@ -305,8 +309,8 @@ class FastDeployStableDiffusionImg2ImgPipeline(DiffusionPipeline):
             noise = paddle.to_tensor(noise, dtype=dtype)
 
         # get latents
-        init_latents = self.scheduler.add_noise(paddle.to_tensor(init_latents), noise, paddle.to_tensor(timestep))
-        latents = init_latents.numpy()
+        init_latents = self.scheduler.add_noise(paddle.to_tensor(init_latents), noise, timestep)
+        latents = init_latents
 
         return latents
 
@@ -404,7 +408,7 @@ class FastDeployStableDiffusionImg2ImgPipeline(DiffusionPipeline):
         # 5. set timesteps
         self.scheduler.set_timesteps(num_inference_steps)
         timesteps, num_inference_steps = self.get_timesteps(num_inference_steps, strength)
-        latent_timestep = timesteps[:1].repeat(batch_size * num_images_per_prompt)
+        latent_timestep = timesteps[:1].tile([batch_size * num_images_per_prompt])
 
         # 6. Prepare latent variables
         latents = self.prepare_latents(
@@ -417,30 +421,35 @@ class FastDeployStableDiffusionImg2ImgPipeline(DiffusionPipeline):
         # 8. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
+            unet_runtime = self.unet.model
+            unet_output_name = unet_runtime.get_output_info(0).name
+            text_embeddings = paddle.to_tensor(text_embeddings)
             for i, t in enumerate(timesteps):
-                tensor_t = paddle.to_tensor(t)
                 # expand the latents if we are doing classifier free guidance
-                latent_model_input = np.concatenate([latents] * 2) if do_classifier_free_guidance else latents
-                latent_model_input = self.scheduler.scale_model_input(paddle.to_tensor(latent_model_input), tensor_t)
-                latent_model_input = latent_model_input.numpy()
+                latent_model_input = paddle.concat([latents] * 2) if do_classifier_free_guidance else latents
+                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                 # predict the noise residual
-                noise_pred = self.unet(
-                    sample=latent_model_input.astype(np.float32),
-                    timestep=np.array([t], dtype=np.int64),
-                    encoder_hidden_states=text_embeddings.astype(np.float32),
-                )[0]
+                sample = pdtensor2fdtensor(latent_model_input, "sample")
+                timestep = pdtensor2fdtensor(t, "timestep")
+                encoder_hidden_states = pdtensor2fdtensor(text_embeddings, "encoder_hidden_states")
+                unet_runtime.bind_input_tensor("sample", sample)
+                unet_runtime.bind_input_tensor("timestep", timestep)
+                unet_runtime.bind_input_tensor("encoder_hidden_states", encoder_hidden_states)
+
+                unet_runtime.zero_copy_infer()
+
+                noise_pred = unet_runtime.get_output_tensor(unet_output_name)
+                noise_pred = fdtensor2pdtensor(noise_pred)
 
                 # perform guidance
                 if do_classifier_free_guidance:
-                    noise_pred_uncond, noise_pred_text = np.split(noise_pred, 2)
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
                 # compute the previous noisy sample x_t -> x_t-1
-                scheduler_output = self.scheduler.step(
-                    paddle.to_tensor(noise_pred), tensor_t, paddle.to_tensor(latents), **extra_step_kwargs
-                )
-                latents = scheduler_output.prev_sample.numpy()
+                scheduler_output = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)
+                latents = scheduler_output.prev_sample
 
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
@@ -449,7 +458,7 @@ class FastDeployStableDiffusionImg2ImgPipeline(DiffusionPipeline):
                         callback(i, t, latents)
 
         # 9. Post-processing
-        image = self.decode_latents(latents)
+        image = self.decode_latents(latents.numpy())
 
         # 10. Run safety checker
         image, has_nsfw_concept = self.run_safety_checker(image, text_embeddings.dtype)

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint.py
@@ -275,7 +275,7 @@ class FastDeployStableDiffusionInpaintPipeline(DiffusionPipeline):
 
         latents_shape = (batch_size, num_channels_latents, height // 8, width // 8)
         if latents is None:
-            latents = generator.randn(*latents_shape).astype(dtype)
+            latents = paddle.to_tensor(generator.randn(*latents_shape), dtype=dtype)
         elif latents.shape != latents_shape:
             raise ValueError(f"Unexpected latents shape, got {latents.shape}, expected {latents_shape}")
 
@@ -399,7 +399,7 @@ class FastDeployStableDiffusionInpaintPipeline(DiffusionPipeline):
 
         # 4. set timesteps
         self.scheduler.set_timesteps(num_inference_steps)
-        timesteps = self.scheduler.timesteps.numpy()
+        timesteps = self.scheduler.timesteps
 
         # 5. Prepare latent variables
         num_channels_latents = NUM_LATENT_CHANNELS
@@ -427,6 +427,8 @@ class FastDeployStableDiffusionInpaintPipeline(DiffusionPipeline):
         )
         num_channels_mask = mask.shape[1]
         num_channels_masked_image = masked_image_latents.shape[1]
+        mask = paddle.to_tensor(mask)
+        masked_image_latents = paddle.to_tensor(masked_image_latents)
 
         # 8. Check that sizes of mask, masked image and latents match
         unet_input_channels = NUM_UNET_INPUT_CHANNELS
@@ -445,32 +447,27 @@ class FastDeployStableDiffusionInpaintPipeline(DiffusionPipeline):
         # 10. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
+            text_embeddings = paddle.to_tensor(text_embeddings, dtype="float32")
             for i, t in enumerate(timesteps):
-                tensor_t = paddle.to_tensor(t)
                 # expand the latents if we are doing classifier free guidance
-                latent_model_input = np.concatenate([latents] * 2) if do_classifier_free_guidance else latents
+                latent_model_input = paddle.concat([latents] * 2) if do_classifier_free_guidance else latents
                 # concat latents, mask, masked_image_latnets in the channel dimension
-                latent_model_input = self.scheduler.scale_model_input(paddle.to_tensor(latent_model_input), tensor_t)
-                latent_model_input = latent_model_input.numpy()
-                latent_model_input = np.concatenate([latent_model_input, mask, masked_image_latents], axis=1)
+                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+                latent_model_input = paddle.concat([latent_model_input, mask, masked_image_latents], axis=1)
 
                 # predict the noise residual
-                noise_pred = self.unet(
-                    sample=latent_model_input.astype(np.float32),
-                    timestep=np.array([t], dtype=np.int64),
-                    encoder_hidden_states=text_embeddings.astype(np.float32),
+                noise_pred = self.unet.zero_copy_infer(
+                    sample=latent_model_input, timestep=t, encoder_hidden_states=text_embeddings
                 )[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:
-                    noise_pred_uncond, noise_pred_text = np.split(noise_pred, 2)
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
                 # compute the previous noisy sample x_t -> x_t-1
-                scheduler_output = self.scheduler.step(
-                    paddle.to_tensor(noise_pred), tensor_t, paddle.to_tensor(latents), **extra_step_kwargs
-                )
-                latents = scheduler_output.prev_sample.numpy()
+                scheduler_output = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)
+                latents = scheduler_output.prev_sample
 
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
@@ -479,7 +476,7 @@ class FastDeployStableDiffusionInpaintPipeline(DiffusionPipeline):
                         callback(i, t, latents)
 
         # 11. Post-processing
-        image = self.decode_latents(latents)
+        image = self.decode_latents(latents.numpy())
 
         # 12. Run safety checker
         image, has_nsfw_concept = self.run_safety_checker(image, text_embeddings.dtype)

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
@@ -22,11 +22,7 @@ import PIL
 
 from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTokenizer
 
-from ...fastdeploy_utils import (
-    FastDeployRuntimeModel,
-    fdtensor2pdtensor,
-    pdtensor2fdtensor,
-)
+from ...fastdeploy_utils import FastDeployRuntimeModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import (
     DDIMScheduler,
@@ -436,8 +432,6 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         # 9. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
-            unet_runtime = self.unet.model
-            unet_output_name = unet_runtime.get_output_info(0).name
             text_embeddings = paddle.to_tensor(text_embeddings, dtype="float32")
             for i, t in enumerate(timesteps):
                 # expand the latents if we are doing classifier free guidance
@@ -446,18 +440,9 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
                 latent_model_input = latent_model_input
 
                 # predict the noise residual
-                sample = pdtensor2fdtensor(latent_model_input, "sample")
-                timestep = pdtensor2fdtensor(t, "timestep")
-                encoder_hidden_states = pdtensor2fdtensor(text_embeddings, "encoder_hidden_states")
-                unet_runtime.bind_input_tensor("sample", sample)
-                unet_runtime.bind_input_tensor("timestep", timestep)
-                unet_runtime.bind_input_tensor("encoder_hidden_states", encoder_hidden_states)
-
-                unet_runtime.zero_copy_infer()
-
-                noise_pred = unet_runtime.get_output_tensor(unet_output_name)
-                noise_pred = fdtensor2pdtensor(noise_pred)
-
+                noise_pred = self.unet.zero_copy_infer(
+                    sample=latent_model_input, timestep=t, encoder_hidden_states=text_embeddings
+                )[0]
                 # perform guidance
                 if do_classifier_free_guidance:
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
@@ -433,7 +433,8 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
-                tensor_t = paddle.to_tensor(t)
+                tensor_t = paddle.to_tensor([t])
+
                 # expand the latents if we are doing classifier free guidance
                 latent_model_input = np.concatenate([latents] * 2) if do_classifier_free_guidance else latents
                 latent_model_input = self.scheduler.scale_model_input(paddle.to_tensor(latent_model_input), tensor_t)
@@ -456,7 +457,6 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
                     paddle.to_tensor(noise_pred), tensor_t, paddle.to_tensor(latents), **extra_step_kwargs
                 )
                 latents = scheduler_output.prev_sample.numpy()
-
                 init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, tensor_t)
 
                 init_latents_proper = init_latents_proper.numpy()

--- a/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
+++ b/ppdiffusers/ppdiffusers/pipelines/stable_diffusion/pipeline_fastdeploy_stable_diffusion_inpaint_legacy.py
@@ -22,7 +22,11 @@ import PIL
 
 from paddlenlp.transformers import CLIPFeatureExtractor, CLIPTokenizer
 
-from ...fastdeploy_utils import FastDeployRuntimeModel
+from ...fastdeploy_utils import (
+    FastDeployRuntimeModel,
+    fdtensor2pdtensor,
+    pdtensor2fdtensor,
+)
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import (
     DDIMScheduler,
@@ -279,8 +283,7 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         init_timestep = min(init_timestep, num_inference_steps)
 
         t_start = max(num_inference_steps - init_timestep + offset, 0)
-        timesteps = self.scheduler.timesteps.numpy()
-        timesteps = timesteps[t_start:]
+        timesteps = self.scheduler.timesteps[t_start:]
 
         return timesteps, num_inference_steps - t_start
 
@@ -291,9 +294,10 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         image = image.astype(dtype)
         init_latents = self.vae_encoder(sample=image)[0]
         init_latents = 0.18215 * init_latents
+        init_latents = paddle.to_tensor(init_latents)
 
         # Expand init_latents for batch_size and num_images_per_prompt
-        init_latents = np.concatenate([init_latents] * batch_size * num_images_per_prompt, axis=0)
+        init_latents = paddle.concat([init_latents] * batch_size * num_images_per_prompt, axis=0)
         init_latents_orig = paddle.to_tensor(init_latents)
 
         # add noise to latents using the timesteps
@@ -304,8 +308,8 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         elif isinstance(noise, np.ndarray):
             noise = paddle.to_tensor(noise, dtype=dtype)
 
-        init_latents = self.scheduler.add_noise(paddle.to_tensor(init_latents), noise, paddle.to_tensor(timestep))
-        latents = init_latents.numpy()
+        init_latents = self.scheduler.add_noise(init_latents, noise, timestep)
+        latents = init_latents
         return latents, init_latents_orig, noise
 
     def __call__(
@@ -414,7 +418,7 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         # 5. set timesteps
         self.scheduler.set_timesteps(num_inference_steps)
         timesteps, num_inference_steps = self.get_timesteps(num_inference_steps, strength)
-        latent_timestep = timesteps[:1].repeat(batch_size * num_images_per_prompt)
+        latent_timestep = timesteps[:1].tile([batch_size * num_images_per_prompt])
 
         # 6. Prepare latent variables
         # encode the init image into latents and scale the latents
@@ -423,8 +427,8 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         )
 
         # 7. Prepare mask latent
-        mask = mask_image.astype(latents.dtype)
-        mask = np.concatenate([mask] * batch_size * num_images_per_prompt)
+        mask = paddle.to_tensor(mask_image, dtype=latents.dtype)
+        mask = paddle.concat([mask] * batch_size * num_images_per_prompt)
 
         # 8. Prepare extra step kwargs.
         extra_step_kwargs = self.prepare_extra_step_kwargs(eta)
@@ -432,34 +436,37 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         # 9. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
         with self.progress_bar(total=num_inference_steps) as progress_bar:
+            unet_runtime = self.unet.model
+            unet_output_name = unet_runtime.get_output_info(0).name
+            text_embeddings = paddle.to_tensor(text_embeddings, dtype="float32")
             for i, t in enumerate(timesteps):
-                tensor_t = paddle.to_tensor([t])
-
                 # expand the latents if we are doing classifier free guidance
-                latent_model_input = np.concatenate([latents] * 2) if do_classifier_free_guidance else latents
-                latent_model_input = self.scheduler.scale_model_input(paddle.to_tensor(latent_model_input), tensor_t)
-                latent_model_input = latent_model_input.numpy()
+                latent_model_input = paddle.concat([latents] * 2) if do_classifier_free_guidance else latents
+                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+                latent_model_input = latent_model_input
 
                 # predict the noise residual
-                noise_pred = self.unet(
-                    sample=latent_model_input.astype(np.float32),
-                    timestep=np.array([t], dtype=np.int64),
-                    encoder_hidden_states=text_embeddings.astype(np.float32),
-                )[0]
+                sample = pdtensor2fdtensor(latent_model_input, "sample")
+                timestep = pdtensor2fdtensor(t, "timestep")
+                encoder_hidden_states = pdtensor2fdtensor(text_embeddings, "encoder_hidden_states")
+                unet_runtime.bind_input_tensor("sample", sample)
+                unet_runtime.bind_input_tensor("timestep", timestep)
+                unet_runtime.bind_input_tensor("encoder_hidden_states", encoder_hidden_states)
+
+                unet_runtime.zero_copy_infer()
+
+                noise_pred = unet_runtime.get_output_tensor(unet_output_name)
+                noise_pred = fdtensor2pdtensor(noise_pred)
 
                 # perform guidance
                 if do_classifier_free_guidance:
-                    noise_pred_uncond, noise_pred_text = np.split(noise_pred, 2)
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
 
                 # compute the previous noisy sample x_t -> x_t-1
-                scheduler_output = self.scheduler.step(
-                    paddle.to_tensor(noise_pred), tensor_t, paddle.to_tensor(latents), **extra_step_kwargs
-                )
-                latents = scheduler_output.prev_sample.numpy()
-                init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, tensor_t)
-
-                init_latents_proper = init_latents_proper.numpy()
+                scheduler_output = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)
+                latents = scheduler_output.prev_sample
+                init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, t)
 
                 latents = (init_latents_proper * mask) + (latents * (1 - mask))
 
@@ -470,7 +477,7 @@ class FastDeployStableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
                         callback(i, t, latents)
 
         # 10. Post-processing
-        image = self.decode_latents(latents)
+        image = self.decode_latents(latents.numpy())
 
         # 11. Run safety checker
         image, has_nsfw_concept = self.run_safety_checker(image, text_embeddings.dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
FastDeploy
### Description
<!-- Describe what this PR does -->
Decrease the cost of h2d, d2h in the unet loop to imporve SD model performance.  

The average end to end latency of FastDeployStableDiffusionPipeline decreases from **3.36s** to **3.29s**.

 The new feature is applied in following pipelines.

- [x] FastDeployStableDiffusionPipeline
- [x] FastDeployStableDiffusionMegaPipeline
- [x] FastDeployStableDiffusionInpaintPipeline
- [x] FastDeployStableDiffusionInpaintPipelineLegacy
- [x] FastDeployStableDiffusionImg2ImgPipeline