### PR TITLE
Add set_level to logger

### DIFF
--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -75,6 +75,10 @@ class Logger(object):
 
     def enable(self):
         self._is_enable = True
+    
+    def set_level(self, log_level: str):
+        assert log_level in log_config,f"Invalid log level. Choose among {log_config.keys()}"
+        self.logger.setLevel(log_level)
 
     @property
     def is_enable(self) -> bool:

--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -14,17 +14,12 @@
 # limitations under the License.
 
 import contextlib
-import copy
 import functools
 import logging
-import os
-import sys
-import time
 import threading
-from typing import List
+import time
 
 import colorlog
-from colorama import Fore
 
 loggers = {}
 
@@ -75,9 +70,9 @@ class Logger(object):
 
     def enable(self):
         self._is_enable = True
-    
+
     def set_level(self, log_level: str):
-        assert log_level in log_config,f"Invalid log level. Choose among {log_config.keys()}"
+        assert log_level in log_config, f"Invalid log level. Choose among {log_config.keys()}"
         self.logger.setLevel(log_level)
 
     @property


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
```
from paddlenlp.utils.log import logger
logger.set_level("WARNING")

model ...
trainer ...
```

If we do `logger.set_level`, all the subsequent usage of logger (e.g. Trainer, AutoModel) will respect the log level
<!-- Describe what this PR does -->
