### PR TITLE
Remove "stop at first failure" in CI Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 test: unit-test
 
 unit-test:
-	PYTHONPATH=$(shell pwd) pytest -x \
+	PYTHONPATH=$(shell pwd) pytest \
 		-n auto --cov paddlenlp \
 		--cov-report xml:coverage.xml
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
