### PR TITLE
[AutoNLP] Remove `dirs_exist_ok` in `export` to support py37

### DIFF
--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -126,7 +126,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
         """
         model_result = self._get_model_result(trial_id=trial_id)
         exported_model_path = os.path.join(model_result.log_dir, self.export_path)
-        shutil.copytree(exported_model_path, export_path, dirs_exist_ok=True)
+        shutil.copytree(exported_model_path, export_path)
         logger.info(f"Exported to {export_path}")
 
     @abstractmethod


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
`dirs_exist_ok` was added to `shutil.copytree` in python 3.8. Removing it to support python 3.7
<!-- Describe what this PR does -->
