### PR TITLE
fix T5Config

### DIFF
--- a/paddlenlp/transformers/t5/configuration.py
+++ b/paddlenlp/transformers/t5/configuration.py
@@ -217,7 +217,7 @@ class T5Config(PretrainedConfig):
 
     """
     model_type = "t5"
-    standard_config_map: Dict[str, str] = {
+    attribute_map: Dict[str, str] = {
         "hidden_size": "d_model",
         "num_attention_heads": "num_heads",
         "num_hidden_layers": "num_layers",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
Fix #4384 

* attribute_map 使得`config.hidden_size`和`config.d_model`都可以获取`d_model`的值
```python
attribute_map: Dict[str, str] = {"hidden_size": "d_model", ... }
# config.d_model == config.hidden_size == 512
```
* standard_config_map 则使得只有`config.hidden_size`能够取得目标值
```python
standard_config_map: Dict[str, str] = {"hidden_size": "d_model", ... }
# config.d_model is None 
# config.hidden_size == 512
```
