### PR TITLE
[BugFix] Update trainer.py

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1342,7 +1342,8 @@ class Trainer:
 
         if self.sharding is not None:
             dist.barrier()
-            if self.dp_group.rank == 0:
+            # If only one dp_group, the rank is -1 by default.
+            if self.dp_group.rank <= 0:
                 paddle.save(
                     self.optimizer.state_dict(),
                     os.path.join(output_dir, OPTIMIZER_NAME + f"_shard{self.sharding_group.rank}"),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Trainer
### Description
<!-- Describe what this PR does -->
If only one dp_group, the rank is -1 by default.