### PR TITLE
add npu device support for uie

### DIFF
--- a/paddlenlp/taskflow/task.py
+++ b/paddlenlp/taskflow/task.py
@@ -169,12 +169,11 @@ class Task(metaclass=abc.ABCMeta):
         Construct the input data and predictor in the PaddlePaddele static mode.
         """
         if paddle.get_device() == "cpu":
-            if "npu" in paddle.device.get_all_custom_device_type():
-                self._config.disable_gpu()
-                self._config.enable_npu()
-            else:
-                self._config.disable_gpu()
-                self._config.enable_mkldnn()
+            self._config.disable_gpu()
+            self._config.enable_mkldnn()
+        elif paddle.get_device().split(":", 1)[0] == "npu":
+            self._config.disable_gpu()
+            self._config.enable_npu(self.kwargs["device_id"])
         else:
             self._config.enable_use_gpu(100, self.kwargs["device_id"])
             # TODO(linjieccc): enable after fixed

--- a/paddlenlp/taskflow/task.py
+++ b/paddlenlp/taskflow/task.py
@@ -169,8 +169,12 @@ class Task(metaclass=abc.ABCMeta):
         Construct the input data and predictor in the PaddlePaddele static mode.
         """
         if paddle.get_device() == "cpu":
-            self._config.disable_gpu()
-            self._config.enable_mkldnn()
+            if "npu" in paddle.device.get_all_custom_device_type():
+                self._config.disable_gpu()
+                self._config.enable_npu()
+            else:
+                self._config.disable_gpu()
+                self._config.enable_mkldnn()
         else:
             self._config.enable_use_gpu(100, self.kwargs["device_id"])
             # TODO(linjieccc): enable after fixed

--- a/paddlenlp/utils/tools.py
+++ b/paddlenlp/utils/tools.py
@@ -122,7 +122,7 @@ def get_env_device():
     """
     if paddle.is_compiled_with_cuda():
         return "gpu"
-    elif paddle.is_compiled_with_npu():
+    elif "npu" in paddle.device.get_all_custom_device_type():
         return "npu"
     elif paddle.is_compiled_with_rocm():
         return "rocm"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others 

### PR changes
Others

### Description
Add npu device support for TaskFlow. The NPU implementation is based on paddlepaddle-cpu and paddle-custom-npu.
We also update `get_device() `API in Paddle. Link to https://github.com/PaddlePaddle/Paddle/pull/49721. 
`paddle.get_device()` will return "`npu:0"` when running with paddle & paddle-custom-npu.
