### PR TITLE
Remove standard_config_map and use attribute_map instead

### DIFF
--- a/paddlenlp/transformers/bart/configuration.py
+++ b/paddlenlp/transformers/bart/configuration.py
@@ -130,9 +130,10 @@ class BartConfig(PretrainedConfig):
     """
     model_type = "bart"
     keys_to_ignore_at_inference = ["past_key_values"]
-    standard_config_map: Dict[str, str] = {
+    attribute_map: Dict[str, str] = {
         "num_encoder_layers": "encoder_layers",
         "num_decoder_layers": "decoder_layers",
+        "num_classes": "num_labels",
     }
     pretrained_init_configuration = BART_PRETRAINED_INIT_CONFIGURATION
 

--- a/paddlenlp/transformers/bert/configuration.py
+++ b/paddlenlp/transformers/bert/configuration.py
@@ -365,7 +365,7 @@ class BertConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "bert"
-    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
+    attribute_map: Dict[str, str] = {"dropout": "classifier_dropout", "num_classes": "num_labels"}
     pretrained_init_configuration = BERT_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/clip/configuration.py
+++ b/paddlenlp/transformers/clip/configuration.py
@@ -97,7 +97,7 @@ class Old2NewPretrainedConfig(PretrainedConfig):
         # We remove them so they don't appear in `return_unused_kwargs`.
         # convert local config to legacy config
         # do standard config map: there are some old-school pretrained-config not refactored.
-        config_dict = convert_to_legacy_config(cls.standard_config_map, config_dict)
+        config_dict = convert_to_legacy_config(cls.attribute_map, config_dict)
         config_dict = flatten_model_config(config_dict)
 
         # check old_config?

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -180,22 +180,22 @@ def attribute_map(config: PretrainedConfig, kwargs: Dict[str, Any]) -> Dict[str,
     return kwargs
 
 
-def convert_to_legacy_config(standard_config_map: Dict[str, str], config: Dict[str, Any]) -> Dict[str, Any]:
+def convert_to_legacy_config(attribute_map: Dict[str, str], config: Dict[str, Any]) -> Dict[str, Any]:
     """
     works when there are different fields between huggingface and paddle
     Args:
-        standard_config_map (Dict[str, str]): mapping of between standard config and paddle config
+        attribute_map (Dict[str, str]): mapping of between standard config and paddle config
         config (Dict[str, Any]): config of huggingface transformers models
     Returns: the config which can be mapped into config of paddle model
     """
     if "init_args" in config:
         args = []
         for init_arg in config["init_args"]:
-            init_arg = convert_to_legacy_config(standard_config_map, init_arg)
+            init_arg = convert_to_legacy_config(attribute_map, init_arg)
             args.append(init_arg)
         config["init_args"] = args
 
-    for standard_field, paddle_field in standard_config_map.items():
+    for standard_field, paddle_field in attribute_map.items():
         config[paddle_field] = config.pop(standard_field, None) or config.pop(paddle_field, None)
     return config
 
@@ -467,25 +467,17 @@ class PretrainedConfig:
     # global attribute mapping
     attribute_map: Dict[str, str] = {"num_classes": "num_labels"}
 
-    # model-specific attribute map from hf attribute to paddle attribute
-    # { "paddle_field": "standard_field", ... }
-    standard_config_map: Dict[str, str] = {}
-
     _auto_class: Optional[str] = None
 
     def __setattr__(self, key, value):
         if key in super().__getattribute__("attribute_map"):
             key = super().__getattribute__("attribute_map")[key]
-        elif key in super().__getattribute__("standard_config_map"):
-            key = super().__getattribute__("standard_config_map")[key]
         super().__setattr__(key, value)
         assert hasattr(self, key)
 
     def __getattribute__(self, key):
         if key != "attribute_map" and key in super().__getattribute__("attribute_map"):
             key = super().__getattribute__("attribute_map")[key]
-        elif key != "standard_config_map" and key in super().__getattribute__("standard_config_map"):
-            key = super().__getattribute__("standard_config_map")[key]
         return super().__getattribute__(key)
 
     def __getitem__(self, key):
@@ -558,7 +550,8 @@ class PretrainedConfig:
             self.id2label = dict((int(key), value) for key, value in self.id2label.items())
             # Keys are always strings in JSON so convert ids to int here.
         else:
-            self.num_labels = kwargs.pop("num_labels", 2)
+            num_labels = kwargs.pop("num_labels", 2)
+            self.num_labels = num_labels if num_labels is not None else 2
 
         self.classifier_dropout = kwargs.pop("classifier_dropout", None)
 
@@ -737,7 +730,7 @@ class PretrainedConfig:
         config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
 
         # do standard config map: there are some old-school pretrained-config not refactored.
-        config_dict = convert_to_legacy_config(cls.standard_config_map, config_dict)
+        config_dict = convert_to_legacy_config(cls.attribute_map, config_dict)
 
         config_dict = flatten_model_config(config_dict)
         if "model_type" in config_dict and hasattr(cls, "model_type") and config_dict["model_type"] != cls.model_type:
@@ -870,7 +863,7 @@ class PretrainedConfig:
         # We remove them so they don't appear in `return_unused_kwargs`.
 
         # convert local config to legacy config
-        config_dict = convert_to_legacy_config(cls.standard_config_map, config_dict)
+        config_dict = convert_to_legacy_config(cls.attribute_map, config_dict)
 
         config = cls(**config_dict)
 

--- a/paddlenlp/transformers/ernie/configuration.py
+++ b/paddlenlp/transformers/ernie/configuration.py
@@ -1134,7 +1134,7 @@ class ErnieConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "ernie"
-    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
+    attribute_map: Dict[str, str] = {"dropout": "classifier_dropout", "num_classes": "num_labels"}
     pretrained_init_configuration = ERNIE_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/ernie_layout/configuration.py
+++ b/paddlenlp/transformers/ernie_layout/configuration.py
@@ -150,7 +150,7 @@ class ErnieLayoutConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
     model_type = "ernie_layout"
-    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
+    attribute_map: Dict[str, str] = {"dropout": "classifier_dropout", "num_classes": "num_labels"}
     pretrained_init_configuration = ERNIE_LAYOUT_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/ernie_m/configuration.py
+++ b/paddlenlp/transformers/ernie_m/configuration.py
@@ -144,7 +144,7 @@ class ErnieMConfig(PretrainedConfig):
         >>> configuration = model.config
         ```"""
     model_type = "ernie_m"
-    standard_config_map: Dict[str, str] = {"dropout": "classifier_dropout"}
+    attribute_map: Dict[str, str] = {"dropout": "classifier_dropout", "num_classes": "num_labels"}
     pretrained_init_configuration = ERNIE_M_PRETRAINED_INIT_CONFIGURATION
 
     def __init__(

--- a/paddlenlp/transformers/mbart/configuration.py
+++ b/paddlenlp/transformers/mbart/configuration.py
@@ -215,9 +215,10 @@ class MBartConfig(PretrainedConfig):
     """
     model_type = "mbart"
     keys_to_ignore_at_inference = ["past_key_values"]
-    standard_config_map: Dict[str, str] = {
+    attribute_map: Dict[str, str] = {
         "num_encoder_layers": "encoder_layers",
         "num_decoder_layers": "decoder_layers",
+        "num_classes": "num_labels",
     }
     pretrained_init_configuration = MBART_PRETRAINED_INIT_CONFIGURATION
 

--- a/paddlenlp/transformers/t5/configuration.py
+++ b/paddlenlp/transformers/t5/configuration.py
@@ -217,10 +217,11 @@ class T5Config(PretrainedConfig):
 
     """
     model_type = "t5"
-    standard_config_map: Dict[str, str] = {
+    attribute_map: Dict[str, str] = {
         "hidden_size": "d_model",
         "num_attention_heads": "num_heads",
         "num_hidden_layers": "num_layers",
+        "num_classes": "num_labels",
     }
     pretrained_init_configuration = T5_PRETRAINED_INIT_CONFIGURATION
 

--- a/tests/transformers/test_configuration_utils.py
+++ b/tests/transformers/test_configuration_utils.py
@@ -150,7 +150,7 @@ class StandardConfigMappingTest(unittest.TestCase):
         config = FakeBertConfig.from_pretrained("__internal_testing__/bert")
         hidden_size = config.hidden_size
 
-        FakeBertConfig.standard_config_map = {"fake_field": "hidden_size"}
+        FakeBertConfig.attribute_map = {"fake_field": "hidden_size"}
 
         loaded_config = FakeBertConfig.from_pretrained("__internal_testing__/bert")
         fake_field = loaded_config.fake_field
@@ -181,7 +181,7 @@ class StandardConfigMappingTest(unittest.TestCase):
             # rename `config.json` -> `model_config.json`
             shutil.move(os.path.join(tempdir, CONFIG_NAME), os.path.join(tempdir, LEGACY_CONFIG_NAME))
 
-            FakeBertConfig.standard_config_map = {"fake_field": "hidden_size"}
+            FakeBertConfig.attribute_map = {"fake_field": "hidden_size"}
 
             loaded_config = FakeBertConfig.from_pretrained(tempdir)
             self.assertEqual(loaded_config.fake_field, config.hidden_size)

--- a/tests/transformers/test_modeling_common.py
+++ b/tests/transformers/test_modeling_common.py
@@ -556,7 +556,6 @@ class ModelTesterMixin:
             model = self._make_model_instance(config, model_class)
 
             all_maps: dict = copy.deepcopy(model_class.config_class.attribute_map)
-            all_maps.update(model_class.config_class.standard_config_map)
 
             for old_attribute, new_attribute in all_maps.items():
                 old_value = getattr(model, old_attribute)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->

1. Removing standard_config_map for PretrainedConfig while using attribute_map instead.
2. Check **Config for all the models
3. fix #4384
