### PR TITLE
Add flatten_param_grads method to improve NPU performance

### DIFF
--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -555,7 +555,7 @@ Trainer 是一个简单，但功能完整的 Paddle训练和评估模块，并�
                        to metrics.(default:True)
 
   --flatten_param_grads
-                       是否在优化器中使用flatten_param_grads策略，该策略目前仅在NPU设备上生效。（可选，默认为False）
+                       是否在优化器中使用flatten_param_grads策略，该策略将素有参数摊平后输入Optimizer更新。目前该策略仅在NPU设备上生效。（可选，默认为False）
                        Whether use flatten_param_grads method in optimizer,
                        only used on NPU devices.(default:False)
 

--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -548,10 +548,15 @@ Trainer 是一个简单，但功能完整的 Paddle训练和评估模块，并�
                         是否从断点重启恢复训练，(可选，默认为 None)
                         The path to a folder with a valid checkpoint for your
                         model. (default: None)
-                        
+
   --skip_memory_metrics
                        是否跳过内存profiler检测。（可选，默认为True，跳过）
                        Whether or not to skip adding of memory profiler reports
                        to metrics.(default:True)
+
+  --flatten_param_grads
+                       是否在优化器中使用flatten_param_grads策略，该策略目前仅在NPU设备上生效。（可选，默认为False）
+                       Whether use flatten_param_grads method in optimizer,
+                       only used on NPU devices.(default:False)
 
 ```

--- a/paddlenlp/trainer/plugin/npu_funcs.py
+++ b/paddlenlp/trainer/plugin/npu_funcs.py
@@ -1,0 +1,118 @@
+# Copyright 2020-present the HuggingFace Inc. team.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import paddle
+from paddle.fluid.layer_helper import LayerHelper
+
+from ...utils.log import logger
+
+
+def opt_npu_warp(optimizer):
+    optimizer.step = _optimizer_step_with_flatten_param_grads
+
+
+def _optimizer_step_with_flatten_param_grads(optimizer):
+    if not isinstance(optimizer._param_groups[0], dict):
+        params_grads = []
+        for param in optimizer._param_groups:
+            if param.stop_gradient:
+                continue
+            if param._grad_ivar() is not None:
+                grad_var = param._grad_ivar()
+                params_grads.append((param, grad_var))
+
+        # currently, only support ClipGradByGlobalNorm and without regularization.
+        if isinstance(params_grads, list) and optimizer.regularization is None:
+            if optimizer._grad_clip is None or isinstance(optimizer._grad_clip, paddle.nn.ClipGradByGlobalNorm):
+                params_grads = _flatten_param_grads(optimizer, params_grads)
+
+        optimizer._apply_optimize(
+            loss=None,
+            startup_program=None,
+            params_grads=params_grads,
+            param_group_idx=0,
+        )
+    else:
+        raise RuntimeError("flatten_param_grads is not supported when _param_groups[0] is dict.")
+
+
+def _flatten_param_grads(optimizer, params_grads):
+    optimizer.helper = LayerHelper(optimizer.__class__.__name__)
+    need_flatten_params = []
+    need_flatten_grads = []
+    for p, g in params_grads:
+        if g is None:
+            continue
+        g.persistable = True
+        if getattr(p, "need_clip", True) is False or getattr(p, "regularizer", None) is not None:
+            logger.warning(
+                f"flatten_param_grads=True will be discarded since paramter {p.name}'s need_clip is False or "
+                "the regularizer is set."
+            )
+            return params_grads
+
+        need_flatten_params.append(p)
+        need_flatten_grads.append(g)
+
+    shape = [np.prod(p.shape) for p in need_flatten_params]
+
+    flatten_param = optimizer.helper.create_global_variable(
+        name="flatten_param",
+        persistable=True,
+        dtype=need_flatten_params[0].dtype,
+        shape=[np.sum(shape)],
+        belong_to_optimizer=True,
+    )
+
+    flatten_grad = optimizer.helper.create_global_variable(
+        name="flatten_grad",
+        persistable=True,
+        dtype=need_flatten_grads[0].dtype,
+        shape=[np.sum(shape)],
+        belong_to_optimizer=True,
+    )
+
+    flatten_param.stop_gradient = False
+    # In the final state of the dynamic graph, the `coalesce_tensor` op
+    # does not support passing the output as an input into the op in
+    # temporary, so _legacy_C_ops is temporarily used here.
+    # `use_align` is set to false, which is different from the behavior
+    # under static graphs. `use_align` can be set to true after calling
+    # the coalesce_tensor op of the final state (_C_ops).
+    paddle._legacy_C_ops.coalesce_tensor(
+        need_flatten_params,
+        need_flatten_params,
+        flatten_param,
+        "copy_data",
+        True,
+        "use_align",
+        False,
+        "dtype",
+        need_flatten_params[0].dtype,
+    )
+
+    paddle._legacy_C_ops.coalesce_tensor(
+        need_flatten_grads,
+        need_flatten_grads,
+        flatten_grad,
+        "copy_data",
+        True,
+        "use_align",
+        False,
+        "dtype",
+        need_flatten_grads[0].dtype,
+    )
+    return [(flatten_param, flatten_grad)]

--- a/paddlenlp/trainer/plugin/npu_funcs.py
+++ b/paddlenlp/trainer/plugin/npu_funcs.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
+
 import numpy as np
 import paddle
 from paddle.fluid.layer_helper import LayerHelper
@@ -21,7 +23,7 @@ from ...utils.log import logger
 
 
 def opt_npu_warp(optimizer):
-    optimizer.step = _optimizer_step_with_flatten_param_grads
+    optimizer.step = types.MethodType(_optimizer_step_with_flatten_param_grads, optimizer)
 
 
 def _optimizer_step_with_flatten_param_grads(optimizer):

--- a/paddlenlp/trainer/plugins/npu_plugin.py
+++ b/paddlenlp/trainer/plugins/npu_plugin.py
@@ -22,7 +22,14 @@ from paddle.fluid.layer_helper import LayerHelper
 from ...utils.log import logger
 
 
-def opt_npu_warp(optimizer):
+def npu_accelerate_plugin(optimizer):
+    """npu_accelerate_plugin uses the flatten_param_grads method to speed up the performance of the model on NPU devices.
+    flatten_param_grads method will be added to `step` function of optimizer.
+
+    Args:
+        optimizer (`paddle.optimizer.Optimizer`):
+            The Optimizer whose `step` method will be modified.
+    """
     optimizer.step = types.MethodType(_optimizer_step_with_flatten_param_grads, optimizer)
 
 

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -775,7 +775,7 @@ class Trainer:
 
     def _npu_grad_scaler_step(self):
         if not self.scaler._enable:
-            return self._npu_step(self.optimizer)
+            return self._npu_step()
 
         optimizer_state = self.scaler._optimizer_states[id(self.optimizer)]
         if optimizer_state["state"] is OptimizerState.STEPPED:
@@ -788,7 +788,7 @@ class Trainer:
         if self.scaler._found_inf:
             self.scaler._cache_founf_inf = True
         else:
-            self._npu_step(self.optimizer)
+            self._npu_step()
             self.scaler._cache_founf_inf = False
 
         optimizer_state["state"] = OptimizerState.STEPPED
@@ -811,7 +811,7 @@ class Trainer:
                 if self.optimizer._grad_clip is None or isinstance(
                     self.optimizer._grad_clip, paddle.nn.ClipGradByGlobalNorm
                 ):
-                    params_grads = self._flatten_param_grads(self.optimizer, params_grads)
+                    params_grads = self._flatten_param_grads(params_grads)
 
             self.optimizer._apply_optimize(
                 loss=None,
@@ -835,7 +835,7 @@ class Trainer:
                     f"flatten_param_grads=True will be discarded since paramter {p.name}'s need_clip is False or "
                     "the regularizer is set."
                 )
-                # self._flatten_param_grads = False
+                self.args.flatten_param_grads_on_npu = False
                 return params_grads
 
             need_flatten_params.append(p)

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -27,7 +27,6 @@ import shutil
 import sys
 import time
 import types
-from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -38,13 +37,11 @@ import paddle.amp.auto_cast as autocast
 import paddle.distributed as dist
 import paddle.nn as nn
 from packaging import version
-from paddle.amp.grad_scaler import OptimizerState, _refresh_optimizer_state
 from paddle.distributed import fleet
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
     fused_allreduce_gradients,
 )
 from paddle.fluid.dygraph.parallel import sync_params_buffers
-from paddle.fluid.layer_helper import LayerHelper
 from paddle.io import DataLoader, Dataset, DistributedBatchSampler
 from tqdm.auto import tqdm
 
@@ -54,6 +51,7 @@ from ..transformers.tokenizer_utils import PretrainedTokenizer
 from ..utils.batch_sampler import DistributedBatchSampler as NlpDistributedBatchSampler
 from ..utils.log import logger
 from .integrations import get_reporting_integration_callbacks
+from .plugin.npu_funcs import opt_npu_warp
 from .trainer_callback import (
     CallbackHandler,
     DefaultFlowCallback,
@@ -260,6 +258,8 @@ class Trainer:
         self.compute_metrics = compute_metrics
         self.preprocess_logits_for_metrics = preprocess_logits_for_metrics
         self.optimizer, self.lr_scheduler = optimizers
+        if self.args.device == "npu" and self.args.flatten_param_grads:
+            opt_npu_warp(self.optimizer)
 
         self.state = TrainerState()
         self.control = TrainerControl()
@@ -688,18 +688,12 @@ class Trainer:
                     optimizer_was_run = True
                     if self.do_grad_scaling:
                         scale_before = self.scaler._scale.numpy()
-                        if self.args.device == "npu" and self.args.flatten_param_grads_on_npu:
-                            self._npu_grad_scaler_step()
-                        else:
-                            self.scaler.step(self.optimizer)
+                        self.scaler.step(self.optimizer)
                         self.scaler.update()
                         scale_after = self.scaler._scale.numpy()
                         optimizer_was_run = scale_before <= scale_after
                     else:
-                        if self.args.device == "npu" and self.args.flatten_param_grads_on_npu:
-                            self._npu_step()
-                        else:
-                            self.optimizer.step()
+                        self.optimizer.step()
 
                     if optimizer_was_run:
                         self.lr_scheduler.step()
@@ -772,124 +766,6 @@ class Trainer:
         self.control = self.callback_handler.on_train_end(args, self.state, self.control)
 
         return TrainOutput(self.state.global_step, train_loss, metrics)
-
-    def _npu_grad_scaler_step(self):
-        if not self.scaler._enable:
-            return self._npu_step()
-
-        optimizer_state = self.scaler._optimizer_states[id(self.optimizer)]
-        if optimizer_state["state"] is OptimizerState.STEPPED:
-            raise RuntimeError("step() has already been called since the last update().")
-
-        #  unscale the grad
-        if optimizer_state["state"] is OptimizerState.INIT:
-            self.scaler._unscale(self.optimizer)
-
-        if self.scaler._found_inf:
-            self.scaler._cache_founf_inf = True
-        else:
-            self._npu_step()
-            self.scaler._cache_founf_inf = False
-
-        optimizer_state["state"] = OptimizerState.STEPPED
-
-        if not self.scaler._use_dynamic_loss_scaling:
-            self.scaler._optimizer_states = defaultdict(_refresh_optimizer_state)
-
-    def _npu_step(self):
-        if not isinstance(self.optimizer._param_groups[0], dict):
-            params_grads = []
-            for param in self.optimizer._param_groups:
-                if param.stop_gradient:
-                    continue
-                if param._grad_ivar() is not None:
-                    grad_var = param._grad_ivar()
-                    params_grads.append((param, grad_var))
-
-            # currently, only support ClipGradByGlobalNorm and without regularization.
-            if isinstance(params_grads, list) and self.optimizer.regularization is None:
-                if self.optimizer._grad_clip is None or isinstance(
-                    self.optimizer._grad_clip, paddle.nn.ClipGradByGlobalNorm
-                ):
-                    params_grads = self._flatten_param_grads(params_grads)
-
-            self.optimizer._apply_optimize(
-                loss=None,
-                startup_program=None,
-                params_grads=params_grads,
-                param_group_idx=0,
-            )
-        else:
-            raise RuntimeError("flatten_param_grads is not supported when _param_groups[0] is dict.")
-
-    def _flatten_param_grads(self, params_grads):
-        self.optimizer.helper = LayerHelper(self.optimizer.__class__.__name__)
-        need_flatten_params = []
-        need_flatten_grads = []
-        for p, g in params_grads:
-            if g is None:
-                continue
-            g.persistable = True
-            if getattr(p, "need_clip", True) is False or getattr(p, "regularizer", None) is not None:
-                logger.warning(
-                    f"flatten_param_grads=True will be discarded since paramter {p.name}'s need_clip is False or "
-                    "the regularizer is set."
-                )
-                self.args.flatten_param_grads_on_npu = False
-                return params_grads
-
-            need_flatten_params.append(p)
-            need_flatten_grads.append(g)
-
-        shape = [np.prod(p.shape) for p in need_flatten_params]
-
-        flatten_param = self.optimizer.helper.create_global_variable(
-            name="flatten_param",
-            persistable=True,
-            dtype=need_flatten_params[0].dtype,
-            shape=[np.sum(shape)],
-            belong_to_optimizer=True,
-        )
-
-        flatten_grad = self.optimizer.helper.create_global_variable(
-            name="flatten_grad",
-            persistable=True,
-            dtype=need_flatten_grads[0].dtype,
-            shape=[np.sum(shape)],
-            belong_to_optimizer=True,
-        )
-
-        flatten_param.stop_gradient = False
-        # In the final state of the dynamic graph, the `coalesce_tensor` op
-        # does not support passing the output as an input into the op in
-        # temporary, so _legacy_C_ops is temporarily used here.
-        # `use_align` is set to false, which is different from the behavior
-        # under static graphs. `use_align` can be set to true after calling
-        # the coalesce_tensor op of the final state (_C_ops).
-        paddle._legacy_C_ops.coalesce_tensor(
-            need_flatten_params,
-            need_flatten_params,
-            flatten_param,
-            "copy_data",
-            True,
-            "use_align",
-            False,
-            "dtype",
-            need_flatten_params[0].dtype,
-        )
-
-        paddle._legacy_C_ops.coalesce_tensor(
-            need_flatten_grads,
-            need_flatten_grads,
-            flatten_grad,
-            "copy_data",
-            True,
-            "use_align",
-            False,
-            "dtype",
-            need_flatten_grads[0].dtype,
-        )
-        return [(flatten_param, flatten_grad)]
 
     def _get_train_sampler(self) -> Optional[paddle.io.Sampler]:
         if self.train_dataset is None or not has_length(self.train_dataset):

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -51,7 +51,6 @@ from ..transformers.tokenizer_utils import PretrainedTokenizer
 from ..utils.batch_sampler import DistributedBatchSampler as NlpDistributedBatchSampler
 from ..utils.log import logger
 from .integrations import get_reporting_integration_callbacks
-from .plugins.npu_plugin import npu_accelerate_plugin
 from .trainer_callback import (
     CallbackHandler,
     DefaultFlowCallback,
@@ -596,6 +595,8 @@ class Trainer:
         self._globalstep_last_logged = self.state.global_step
 
         if self.args.device == "npu" and self.args.flatten_param_grads:
+            from .plugins.npu_plugin import npu_accelerate_plugin
+
             npu_accelerate_plugin(self.optimizer)
 
         for epoch in range(epochs_trained, num_train_epochs):

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -263,7 +263,7 @@ class TrainingArguments:
             The path to a folder with a valid checkpoint for your model. This argument is not directly used by
             [`Trainer`], it's intended to be used by your training/evaluation scripts instead. See the [example
             scripts](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/examples) for more details.
-        flatten_param_grads_on_npu (`bool`, *optional*):
+        flatten_param_grads (`bool`, *optional*):
             Whether use flatten_param_grads method in optimizer, only used on NPU devices. Default is `False`.
     """
 

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -263,6 +263,8 @@ class TrainingArguments:
             The path to a folder with a valid checkpoint for your model. This argument is not directly used by
             [`Trainer`], it's intended to be used by your training/evaluation scripts instead. See the [example
             scripts](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/examples) for more details.
+        flatten_param_grads_on_npu (`bool`, *optional*):
+            Whether use flatten_param_grads method in optimizer, only used on NPU devices. Default is `False`.
     """
 
     output_dir: str = field(
@@ -495,6 +497,10 @@ class TrainingArguments:
     )
     skip_memory_metrics: bool = field(
         default=True, metadata={"help": "Whether or not to skip adding of memory profiler reports to metrics."}
+    )
+    flatten_param_grads_on_npu: Optional[bool] = field(
+        default=False,
+        metadata={"help": "Whether use flatten_param_grads method in optimizer, only used on NPU devices."},
     )
 
     def __post_init__(self):

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -498,7 +498,7 @@ class TrainingArguments:
     skip_memory_metrics: bool = field(
         default=True, metadata={"help": "Whether or not to skip adding of memory profiler reports to metrics."}
     )
-    flatten_param_grads_on_npu: Optional[bool] = field(
+    flatten_param_grads: Optional[bool] = field(
         default=False,
         metadata={"help": "Whether use flatten_param_grads method in optimizer, only used on NPU devices."},
     )
@@ -629,6 +629,9 @@ class TrainingArguments:
             logger.info(
                 "Both warmup_ratio and warmup_steps given, warmup_steps will override any effect of warmup_ratio during training"
             )
+
+        if self.flatten_param_grads and self.device != "npu":
+            raise ValueError("flatten_param_grads can only be used on npu devices in temporary.")
 
     def __str__(self):
         self_as_dict = asdict(self)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

在NPU设备上的优化中，ernie模型的优化器阶段耗时非常长，主要原因是优化器阶段需要拉起非常多的小kernel。
这个PR实现了flatten_params_grads的方法，调用coalesce_tensor op将所有的parameters和grads合并到一起，形成一个parameter和一个grad，这样就只用调用一次优化器op即可，极大的减少了kernel拉起的时间。
