### PR TITLE
[Function optimization] add fixed input_ids for bert-converter

### DIFF
--- a/tests/transformers/bert/test_modeling.py
+++ b/tests/transformers/bert/test_modeling.py
@@ -592,7 +592,7 @@ class BertCompatibilityTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
 
             # 1. create commmon input
-            input_ids = np.random.randint(100, 200, [1, 20])
+            input_ids = np.array([[i for i in range(20)]])
 
             # 2. forward the paddle model
             from paddlenlp.transformers import BertModel
@@ -639,7 +639,7 @@ class BertCompatibilityTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
 
             # 1. create commmon input
-            input_ids = np.random.randint(100, 200, [1, 20])
+            input_ids = np.array([[i for i in range(20)]])
 
             # 2. forward the torch  model
             import torch

--- a/tests/transformers/bert/test_modeling.py
+++ b/tests/transformers/bert/test_modeling.py
@@ -592,7 +592,7 @@ class BertCompatibilityTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
 
             # 1. create commmon input
-            input_ids = np.array([[i for i in range(20)]])
+            input_ids = np.array([[i + 100 for i in range(20)]])
 
             # 2. forward the paddle model
             from paddlenlp.transformers import BertModel
@@ -639,7 +639,7 @@ class BertCompatibilityTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
 
             # 1. create commmon input
-            input_ids = np.array([[i for i in range(20)]])
+            input_ids = np.array([[i + 100 for i in range(20)]])
 
             # 2. forward the torch  model
             import torch


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
在 converter 的过程中出现随机性错误，目前还不确定是否由于tiny-random模型中权重的问题，不过 fixed input_ids 应该是可以消除这种随机性。