### PR TITLE
Fix generating attention_mask of ernie-m

### DIFF
--- a/paddlenlp/transformers/ernie_m/configuration.py
+++ b/paddlenlp/transformers/ernie_m/configuration.py
@@ -160,7 +160,7 @@ class ErnieMConfig(PretrainedConfig):
         max_position_embeddings: int = 514,
         type_vocab_size: int = 16,
         initializer_range: float = 0.02,
-        pad_token_id: int = 0,
+        pad_token_id: int = 1,
         **kwargs
     ):
         super().__init__(pad_token_id=pad_token_id, **kwargs)

--- a/paddlenlp/transformers/ernie_m/modeling.py
+++ b/paddlenlp/transformers/ernie_m/modeling.py
@@ -278,7 +278,7 @@ class ErnieMModel(ErnieMPretrainedModel):
 
         if attention_mask is None:
             attention_mask = paddle.unsqueeze(
-                (input_ids == 0).astype(self.pooler.dense.weight.dtype) * -1e4, axis=[1, 2]
+                (input_ids == self.pad_token_id).astype(self.pooler.dense.weight.dtype) * -1e4, axis=[1, 2]
             )
             if past_key_values is not None:
                 batch_size = past_key_values[0][0].shape[0]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models 
### Description
<!-- Describe what this PR does -->
ErnieMModel will detect pad_token_id and generate attention_mask correctly.