### PR TITLE
fix elmo bug

### DIFF
--- a/examples/language_model/elmo/elmo.py
+++ b/examples/language_model/elmo/elmo.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 from typing import List
+
+import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.nn.initializer as I
-
-from dataset import load_vocab, create_batches
+from dataset import create_batches, load_vocab
 
 
 def reverse_sequence(x, sequence_lengths):
@@ -179,7 +179,9 @@ class ELMoCharacterEncoderLayer(nn.Layer):
         self._char_embedding_layer = nn.Embedding(
             num_embeddings=char_vocab_size, embedding_dim=char_embed_dim, weight_attr=paramAttr
         )
-        self._char_embedding_layer.weight[0, :] = 0
+
+        with paddle.no_grad():
+            self._char_embedding_layer.weight[0, :] = 0
 
         self._convolution_layers = []
         for i, (width, num) in enumerate(cnn_filters):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
ELMO训练时报错“ValueError: (InvalidArgument) Leaf Tensor (embedding_0.w_0) that doesn't stop gradient can't use inplace strategy.”，所以这里在更改weight值时将stop_gradient属性设为了True。
已在 #4495 中反馈了此bug。