### PR TITLE
Temporary disable isort due to upstream bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,13 @@ repos:
     -   id: black
         files: \.(py|pyi)$
         additional_dependencies: [toml]
--   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-    -   id: isort
+# Turning off isort temporary due to https://github.com/PyCQA/isort/issues/2077
+# As of 2023.1.29, bumping isort to 5.12.0 would resolve the error but requires python3.8+
+# Track the issue: https://github.com/PyCQA/isort/issues/2083
+# -   repo: https://github.com/PyCQA/isort
+#     rev: 5.10.1
+#     hooks:
+#     -   id: isort
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
Turning off isort temporary due to https://github.com/PyCQA/isort/issues/2077
As of 2023.1.29, bumping isort to 5.12.0 would resolve the error but requires python3.8+
Track the issue: https://github.com/PyCQA/isort/issues/2083

<!-- Describe what this PR does -->
