### PR TITLE
[Benchmark] Disable train benchmark temporarily

### DIFF
--- a/tests/test_tipc/configs/gpt_for_sequence_classification/train_infer_python.txt
+++ b/tests/test_tipc/configs/gpt_for_sequence_classification/train_infer_python.txt
@@ -51,7 +51,7 @@ null:null
 null:null
 ===========================to_static_train_benchmark_params===========================
 to_static_train:--to_static
-===========================train_benchmark_params==========================
+===========================disable_train_benchmark==========================
 batch_size:2|8
 fp_items:fp32|fp16
 epoch:500

--- a/tests/test_tipc/configs/t5_for_conditional_generation/train_infer_python.txt
+++ b/tests/test_tipc/configs/t5_for_conditional_generation/train_infer_python.txt
@@ -51,7 +51,7 @@ null:null
 null:null
 ===========================to_static_train_benchmark_params===========================
 to_static_train:--to_static
-===========================train_benchmark_params==========================
+===========================disable_train_benchmark==========================
 batch_size:2
 fp_items:fp32|fp16
 epoch:500


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
[Benchmark] Disable train benchmark temporarily
* dy2sta still fails.