### PR TITLE
[PretrainedConfig]set ensure_ascii to False

### DIFF
--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -988,7 +988,7 @@ class PretrainedConfig:
             config_dict = self.to_diff_dict()
         else:
             config_dict = self.to_dict()
-        return json.dumps(config_dict, indent=2, sort_keys=True) + "\n"
+        return json.dumps(config_dict, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
     def to_json_file(self, json_file_path: Union[str, os.PathLike], use_diff: bool = True):
         """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes
### PR changes
Others 

### Description
目前保存config的时候中文会变成unicode编码，在json.dumps设置ensure_ascii=False修复这个问题

![image](https://user-images.githubusercontent.com/63761690/218917139-9125888e-6c09-4867-9e92-1c5c896cf501.png)
