### PR TITLE
[AutoNLP] refactor verbosity for more effect log control

### DIFF
--- a/paddlenlp/experimental/autonlp/README.md
+++ b/paddlenlp/experimental/autonlp/README.md
@@ -76,7 +76,7 @@ Args:
 - max_concurrent_trials (int, optional): 同时运行的最大试验数。必须是非负数。如果为 None 或 0，则不应用任何限制。默认为None。
 - time_budget_s: (int|float|datetime.timedelta, optional) 以秒为单位的全局时间预算，超过时间后停止所有模型试验。
 - experiment_name: (str, optional): 实验的名称。实验日志将存储在"<output_dir>/<experiment_name>"下。默认为 UNIX 时间戳。
-- verbosity: (int, optional): 控制日志的详细程度。默认为“0”，将日志级别设置为 INFO。如果需要减少日志量，请使用 `verbosity > 0` 将日志级别设置为 WARNINGS
+- verbosity: (int, optional): 控制日志的详细程度。默认为“1”，可在driver中看见worker的日志。如果需要减少日志量，请使用 `verbosity > 0` 。
 - hp_overrides: (dict[str, Any], optional): （仅限高级用户）。覆盖每个候选模型的超参数。例如，`{"TrainingArguments.max_steps"：5}`。
 - custom_model_candiates: (dict[str, Any], optional): （仅限高级用户）。运行用户提供的候选模型而不 PaddleNLP 的默认候选模型。可以参考 `._model_candidates` 属性
 

--- a/paddlenlp/experimental/autonlp/README.md
+++ b/paddlenlp/experimental/autonlp/README.md
@@ -53,6 +53,7 @@ Args:
 - greater_is_better (bool, optional): 更好的模型是否应该有更大的指标。与`metric_for_best_model`结合使用
 - problem_type (str, optional): 根据问题的性质在 [`multi_class`, `multi_label`] 中选择
 - output_dir (str, optional): 输出目录，默认为`autpnlp_results`
+- verbosity: (int, optional): 控制日志的详细程度。默认为“1”，可在driver中看见worker的日志。如果需要减少日志量，请使用 `verbosity > 0` 。
 
 ### 训练
 
@@ -76,7 +77,6 @@ Args:
 - max_concurrent_trials (int, optional): 同时运行的最大试验数。必须是非负数。如果为 None 或 0，则不应用任何限制。默认为None。
 - time_budget_s: (int|float|datetime.timedelta, optional) 以秒为单位的全局时间预算，超过时间后停止所有模型试验。
 - experiment_name: (str, optional): 实验的名称。实验日志将存储在"<output_dir>/<experiment_name>"下。默认为 UNIX 时间戳。
-- verbosity: (int, optional): 控制日志的详细程度。默认为“1”，可在driver中看见worker的日志。如果需要减少日志量，请使用 `verbosity > 0` 。
 - hp_overrides: (dict[str, Any], optional): （仅限高级用户）。覆盖每个候选模型的超参数。例如，`{"TrainingArguments.max_steps"：5}`。
 - custom_model_candiates: (dict[str, Any], optional): （仅限高级用户）。运行用户提供的候选模型而不 PaddleNLP 的默认候选模型。可以参考 `._model_candidates` 属性
 

--- a/paddlenlp/experimental/autonlp/README_en.md
+++ b/paddlenlp/experimental/autonlp/README_en.md
@@ -54,6 +54,8 @@ Args:
 - greater_is_better (bool, optional): Whether better models should have a greater metric or not. Use in conjuction with `metric_for_best_model`.
 - problem_type (str, optional): Select among ["multi_class", "multi_label"] based on the nature of your problem
 - output_dir (str, optional): Output directory for the experiments, defaults to "autpnlp_results"
+- verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs, use verbosity > 0 to set stop the workers from logging to the driver.
+
 
 ### Train
 
@@ -79,7 +81,6 @@ Args:
 - experiment_name: (str, optional): name of the experiment. Experiment log will be stored under `<output_dir>/<experiment_name>`. Defaults to UNIX timestamp.
 - hp_overrides: (dict[str, Any], optional): Advanced users only. override the hyperparameters of every model candidate.  For example, {"TrainingArguments.max_steps": 5}.
 - custom_model_candiates: (dict[str, Any], optional): Advanced users only. Run the user-provided model candidates instead of the default model candidated from PaddleNLP. See `._model_candidates` property as an example
-- verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs, use verbosity > 0 to set stop the workers from logging to the driver.
 
 ### Evaluations and Examine Results
 

--- a/paddlenlp/experimental/autonlp/README_en.md
+++ b/paddlenlp/experimental/autonlp/README_en.md
@@ -79,7 +79,7 @@ Args:
 - experiment_name: (str, optional): name of the experiment. Experiment log will be stored under `<output_dir>/<experiment_name>`. Defaults to UNIX timestamp.
 - hp_overrides: (dict[str, Any], optional): Advanced users only. override the hyperparameters of every model candidate.  For example, {"TrainingArguments.max_steps": 5}.
 - custom_model_candiates: (dict[str, Any], optional): Advanced users only. Run the user-provided model candidates instead of the default model candidated from PaddleNLP. See `._model_candidates` property as an example
-- verbosity: (int, optional): controls the verbosity of the logger. Defaults to `0`, which set the logger level at INFO. To reduce the amount of logs, use `verbosity > 0` to set the logger level to WARNINGS
+- verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs, use verbosity > 0 to set stop the workers from logging to the driver.
 
 ### Evaluations and Examine Results
 

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -80,7 +80,6 @@ class AutoTrainerBase(metaclass=ABCMeta):
         self.output_dir = output_dir
         self.kwargs = kwargs
         # use log_to_driver to control verbosity
-        print("verbosity", verbosity)
         ray.init(ignore_reinit_error=True, log_to_driver=True if verbosity >= 1 else False)
 
     @property

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -18,7 +18,7 @@ import shutil
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Union
 
-# import ray
+import ray
 from hyperopt import hp
 from paddle.io import Dataset
 from ray import tune
@@ -45,6 +45,8 @@ class AutoTrainerBase(metaclass=ABCMeta):
         metric_for_best_model (string, optional): the name of the metrc for selecting the best model.
         greater_is_better (bool, required): Whether better models should have a greater metric or not. Use in conjuction with `metric_for_best_model`.
         output_dir (str, optional): Output directory for the experiments, defaults to "autpnlp_results"
+        verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs,
+                use verbosity > 0 to set stop the workers from logging to the driver.
     """
 
     training_path = "training"
@@ -59,6 +61,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
         greater_is_better: bool,
         language: str = "Chinese",
         output_dir: str = "autonlp_results",
+        verbosity: int = 1,
         **kwargs,
     ):
         if not metric_for_best_model.startswith("eval_"):
@@ -76,8 +79,9 @@ class AutoTrainerBase(metaclass=ABCMeta):
         self.language = language
         self.output_dir = output_dir
         self.kwargs = kwargs
-        # disable JSON, CSV and TensorBoardX logger callbacks
-        os.environ["TUNE_DISABLE_AUTO_CALLBACK_LOGGERS"] = "1"
+        # use log_to_driver to control verbosity
+        print("verbosity", verbosity)
+        ray.init(ignore_reinit_error=True, log_to_driver=True if verbosity >= 1 else False)
 
     @property
     @abstractmethod
@@ -243,7 +247,6 @@ class AutoTrainerBase(metaclass=ABCMeta):
         max_concurrent_trials: Optional[int] = None,
         time_budget_s: Optional[Union[int, float, datetime.timedelta]] = None,
         experiment_name: str = None,
-        verbosity: int = 1,
         hp_overrides: Dict[str, Any] = None,
         custom_model_candidates: List[Dict[str, Any]] = None,
     ) -> ResultGrid:
@@ -260,8 +263,6 @@ class AutoTrainerBase(metaclass=ABCMeta):
             time_budget_s: (int|float|datetime.timedelta, optional) global time budget in seconds after which all model trials are stopped.
             experiment_name: (str, optional): name of the experiment. Experiment log will be stored under <output_dir>/<experiment_name>.
                 Defaults to UNIX timestamp.
-            verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs,
-                use verbosity > 0 to set stop the workers from logging to the driver.
             hp_overrides: (dict[str, Any], optional): Advanced users only.
                 override the hyperparameters of every model candidate.  For example, {"TrainingArguments.max_steps": 5}.
             custom_model_candiates: (dict[str, Any], optional): Advanced users only.
@@ -297,13 +298,14 @@ class AutoTrainerBase(metaclass=ABCMeta):
         if experiment_name is None:
             experiment_name = datetime.datetime.now().strftime("%s")
 
-        # ray.init(ignore_reinit_error=True, log_to_driver=True if verbosity >=1 else False)
-
         self.tuner = tune.Tuner(
             trainable,
             tune_config=tune_config,
             run_config=RunConfig(
-                name=experiment_name, log_to_file=True, local_dir=self.output_dir if self.output_dir else None
+                name=experiment_name,
+                log_to_file=True,  # TODO: log_to_file doesn't stream logger output to file for some reason
+                local_dir=self.output_dir if self.output_dir else None,
+                callbacks=[tune.logger.CSVLoggerCallback()],
             ),
         )
         self.training_results = self.tuner.fit()

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -18,6 +18,7 @@ import shutil
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import ray
 from hyperopt import hp
 from paddle.io import Dataset
 from ray import tune
@@ -75,6 +76,8 @@ class AutoTrainerBase(metaclass=ABCMeta):
         self.language = language
         self.output_dir = output_dir
         self.kwargs = kwargs
+        # disable JSON, CSV and TensorBoardX logger callbacks
+        os.environ["TUNE_DISABLE_AUTO_CALLBACK_LOGGERS"] = "1"
 
     @property
     @abstractmethod
@@ -303,6 +306,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
         if experiment_name is None:
             experiment_name = datetime.datetime.now().strftime("%s")
 
+        ray.init(log_to_driver=False)
         self.tuner = tune.Tuner(
             trainable,
             tune_config=tune_config,

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -298,9 +298,9 @@ class AutoTrainerBase(metaclass=ABCMeta):
             experiment_name = datetime.datetime.now().strftime("%s")
 
         if verbosity >= 1:
-            ray.init()
+            ray.init(ignore_reinit_error=True)
         else:
-            ray.init(log_to_driver=False)
+            ray.init(log_to_driver=False, ignore_reinit_error=True)
         self.tuner = tune.Tuner(
             trainable,
             tune_config=tune_config,

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -214,12 +214,6 @@ class AutoTrainerBase(metaclass=ABCMeta):
                 "'AutoTrainer' has no attribute 'training_results'. Have you called the 'train' method?"
             )
 
-    def set_log_level(self):
-        if self.verbosity > 0:
-            logger.set_level("WARNING")
-        else:
-            logger.set_level("INFO")
-
     def show_training_results(self):
         if hasattr(self, "training_results"):
             return self.training_results.get_dataframe()
@@ -276,9 +270,6 @@ class AutoTrainerBase(metaclass=ABCMeta):
         Returns:
             A set of objects for interacting with Ray Tune results. You can use it to inspect the trials and obtain the best result.
         """
-        # Changing logger verbosity here doesn't work. Need to change in the worker's code via the _construct_trainable method.
-        self.verbosity = verbosity
-
         if hasattr(self, "tuner") and self.tuner is not None:
             logger.info("Overwriting the existing Tuner and any previous training results")
 
@@ -306,7 +297,10 @@ class AutoTrainerBase(metaclass=ABCMeta):
         if experiment_name is None:
             experiment_name = datetime.datetime.now().strftime("%s")
 
-        ray.init(log_to_driver=False)
+        if verbosity >= 1:
+            ray.init()
+        else:
+            ray.init(log_to_driver=False)
         self.tuner = tune.Tuner(
             trainable,
             tune_config=tune_config,

--- a/paddlenlp/experimental/autonlp/text_classification.py
+++ b/paddlenlp/experimental/autonlp/text_classification.py
@@ -41,7 +41,6 @@ from paddlenlp.transformers import (
     AutoTokenizer,
     PretrainedTokenizer,
 )
-from paddlenlp.utils.log import logger
 
 from .auto_trainer_base import AutoTrainerBase
 
@@ -314,6 +313,9 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
 
     def _construct_trainable(self) -> Callable:
         def trainable(config):
+            # import is required for proper pickling
+            from paddlenlp.utils.log import logger
+
             config = config["candidates"]
             trainer = self._construct_trainer(config)
             trainer.train()

--- a/paddlenlp/experimental/autonlp/text_classification.py
+++ b/paddlenlp/experimental/autonlp/text_classification.py
@@ -41,6 +41,7 @@ from paddlenlp.transformers import (
     AutoTokenizer,
     PretrainedTokenizer,
 )
+from paddlenlp.utils.log import logger
 
 from .auto_trainer_base import AutoTrainerBase
 
@@ -313,10 +314,6 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
 
     def _construct_trainable(self) -> Callable:
         def trainable(config):
-            # import is required for proper pickling
-            from paddlenlp.utils.log import logger
-
-            self.set_log_level()
             config = config["candidates"]
             trainer = self._construct_trainer(config)
             trainer.train()

--- a/paddlenlp/experimental/autonlp/text_classification.py
+++ b/paddlenlp/experimental/autonlp/text_classification.py
@@ -61,6 +61,8 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
             language (string, required): language of the text.
             output_dir (str, optional): Output directory for the experiments, defaults to "autpnlp_results".
             id2label(dict(int,string)): The dictionary to map the predictions from class ids to class names.
+            verbosity: (int, optional): controls the verbosity of the run. Defaults to 1, which let the workers log to the driver.To reduce the amount of logs,
+                use verbosity > 0 to set stop the workers from logging to the driver.
 
     """
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
- use `log_to_driver` in `ray.init` for more effective log control
- refactor verbosity to be at the constructor instead of at train
- add CsvLogger to avoid logging with Csv, json and tensorboardx by default
<!-- Describe what this PR does -->
