### PR TITLE
Silu op opt disable by default

### DIFF
--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -31,7 +31,10 @@ def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
     model_path: str, output_path: str, sample: bool = False, height: int = None, width: int = None
 ):
     pipeline = StableDiffusionPipeline.from_pretrained(model_path, safety_checker=None, feature_extractor=None)
+    # enable unet pre_temb_act opt
+    pipeline.unet.resnet_pre_temb_non_linearity=True
     output_path = Path(output_path)
+    # calculate latent's H and W
     latent_height = height // 8 if height is not None else None
     latent_width = width // 8 if width is not None else None
     # get arguments

--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -32,7 +32,7 @@ def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
 ):
     pipeline = StableDiffusionPipeline.from_pretrained(model_path, safety_checker=None, feature_extractor=None)
     # enable unet pre_temb_act opt
-    pipeline.unet.resnet_pre_temb_non_linearity = True
+    pipeline.unet.resnet_pre_temb_non_linearity[0] = True
     output_path = Path(output_path)
     # calculate latent's H and W
     latent_height = height // 8 if height is not None else None

--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -32,7 +32,7 @@ def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
 ):
     pipeline = StableDiffusionPipeline.from_pretrained(model_path, safety_checker=None, feature_extractor=None)
     # enable unet pre_temb_act opt
-    pipeline.unet.resnet_pre_temb_non_linearity=True
+    pipeline.unet.resnet_pre_temb_non_linearity = True
     output_path = Path(output_path)
     # calculate latent's H and W
     latent_height = height // 8 if height is not None else None

--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -23,6 +23,7 @@ from ppdiffusers import (
     FastDeployStableDiffusionInpaintPipeline,
     FastDeployStableDiffusionMegaPipeline,
     StableDiffusionPipeline,
+    UNet2DConditionModel,
 )
 from ppdiffusers.fastdeploy_utils import FastDeployRuntimeModel
 
@@ -30,9 +31,9 @@ from ppdiffusers.fastdeploy_utils import FastDeployRuntimeModel
 def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
     model_path: str, output_path: str, sample: bool = False, height: int = None, width: int = None
 ):
-    pipeline = StableDiffusionPipeline.from_pretrained(model_path, safety_checker=None, feature_extractor=None)
-    # enable unet pre_temb_act opt
-    pipeline.unet.resnet_pre_temb_non_linearity[0] = True
+    # specify unet model with unet pre_temb_act opt enabled.
+    unet_model=UNet2DConditionModel.from_pretrained(os.path.join(model_path,'unet'),resnet_pre_temb_non_linearity=True)
+    pipeline = StableDiffusionPipeline.from_pretrained(model_path, unet=unet_model, safety_checker=None, feature_extractor=None)
     output_path = Path(output_path)
     # calculate latent's H and W
     latent_height = height // 8 if height is not None else None

--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -32,7 +32,7 @@ def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
     model_path: str, output_path: str, sample: bool = False, height: int = None, width: int = None
 ):
     # specify unet model with unet pre_temb_act opt enabled.
-    unet_model=UNet2DConditionModel.from_pretrained(os.path.join(model_path,'unet'),resnet_pre_temb_non_linearity=True)
+    unet_model=UNet2DConditionModel.from_pretrained(model_path,resnet_pre_temb_non_linearity=True,subfolder="unet")
     pipeline = StableDiffusionPipeline.from_pretrained(model_path, unet=unet_model, safety_checker=None, feature_extractor=None)
     output_path = Path(output_path)
     # calculate latent's H and W

--- a/ppdiffusers/deploy/export_model.py
+++ b/ppdiffusers/deploy/export_model.py
@@ -32,8 +32,10 @@ def convert_ppdiffusers_pipeline_to_fastdeploy_pipeline(
     model_path: str, output_path: str, sample: bool = False, height: int = None, width: int = None
 ):
     # specify unet model with unet pre_temb_act opt enabled.
-    unet_model=UNet2DConditionModel.from_pretrained(model_path,resnet_pre_temb_non_linearity=True,subfolder="unet")
-    pipeline = StableDiffusionPipeline.from_pretrained(model_path, unet=unet_model, safety_checker=None, feature_extractor=None)
+    unet_model = UNet2DConditionModel.from_pretrained(model_path, resnet_pre_temb_non_linearity=True, subfolder="unet")
+    pipeline = StableDiffusionPipeline.from_pretrained(
+        model_path, unet=unet_model, safety_checker=None, feature_extractor=None
+    )
     output_path = Path(output_path)
     # calculate latent's H and W
     latent_height = height // 8 if height is not None else None

--- a/ppdiffusers/deploy/text_to_img_infer.py
+++ b/ppdiffusers/deploy/text_to_img_infer.py
@@ -217,7 +217,6 @@ if __name__ == "__main__":
     else:
         paddle.set_device(f"gpu:{device_id}")
         paddle_stream = paddle.device.cuda.current_stream(device_id).cuda_stream
-
     # 1. Init scheduler
     scheduler = get_scheduler(args)
 

--- a/ppdiffusers/deploy/text_to_img_infer.py
+++ b/ppdiffusers/deploy/text_to_img_infer.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
 
     # 4. Init runtime
     if args.backend == "onnx_runtime":
-        text_encoder_runtime = create_ort_runtime(
+        text_encoder_runtime = create_paddle_inference_runtime(
             args.model_dir, args.text_encoder_model_prefix, args.model_format, device_id=device_id
         )
         vae_decoder_runtime = create_ort_runtime(

--- a/ppdiffusers/deploy/text_to_img_infer.py
+++ b/ppdiffusers/deploy/text_to_img_infer.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
 
     # 4. Init runtime
     if args.backend == "onnx_runtime":
-        text_encoder_runtime = create_paddle_inference_runtime(
+        text_encoder_runtime = create_ort_runtime(
             args.model_dir, args.text_encoder_model_prefix, args.model_format, device_id=device_id
         )
         vae_decoder_runtime = create_ort_runtime(

--- a/ppdiffusers/ppdiffusers/models/resnet.py
+++ b/ppdiffusers/ppdiffusers/models/resnet.py
@@ -395,7 +395,7 @@ class ResnetBlock2D(nn.Layer):
         use_in_shortcut=None,
         up=False,
         down=False,
-        pre_temb_non_linearity=[False],
+        pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.pre_temb_non_linearity = pre_temb_non_linearity

--- a/ppdiffusers/ppdiffusers/models/resnet.py
+++ b/ppdiffusers/ppdiffusers/models/resnet.py
@@ -480,7 +480,7 @@ class ResnetBlock2D(nn.Layer):
         hidden_states = self.conv1(hidden_states)
 
         if temb is not None:
-            if not self.pre_temb_non_linearity[0]:
+            if not self.pre_temb_non_linearity:
                 temb = self.time_emb_proj(self.nonlinearity(temb))[:, :, None, None]
             else:
                 temb = self.time_emb_proj(temb)[:, :, None, None]

--- a/ppdiffusers/ppdiffusers/models/resnet.py
+++ b/ppdiffusers/ppdiffusers/models/resnet.py
@@ -397,6 +397,7 @@ class ResnetBlock2D(nn.Layer):
         down=False,
     ):
         super().__init__()
+        self.pre_temb_non_linearity = pre_temb_non_linearity
         self.pre_norm = pre_norm
         self.pre_norm = True
         self.in_channels = in_channels
@@ -478,7 +479,10 @@ class ResnetBlock2D(nn.Layer):
         hidden_states = self.conv1(hidden_states)
 
         if temb is not None:
-            temb = self.time_emb_proj(self.nonlinearity(temb))[:, :, None, None]
+            if not self.pre_temb_non_linearity:
+                temb = self.time_emb_proj(self.nonlinearity(temb))[:, :, None, None]
+            else:
+                temb = self.time_emb_proj(temb)[:, :, None, None]
 
         if temb is not None and self.time_embedding_norm == "default":
             hidden_states = hidden_states + temb

--- a/ppdiffusers/ppdiffusers/models/resnet.py
+++ b/ppdiffusers/ppdiffusers/models/resnet.py
@@ -395,6 +395,7 @@ class ResnetBlock2D(nn.Layer):
         use_in_shortcut=None,
         up=False,
         down=False,
+        pre_temb_non_linearity=[False],
     ):
         super().__init__()
         self.pre_temb_non_linearity = pre_temb_non_linearity
@@ -479,7 +480,7 @@ class ResnetBlock2D(nn.Layer):
         hidden_states = self.conv1(hidden_states)
 
         if temb is not None:
-            if not self.pre_temb_non_linearity:
+            if not self.pre_temb_non_linearity[0]:
                 temb = self.time_emb_proj(self.nonlinearity(temb))[:, :, None, None]
             else:
                 temb = self.time_emb_proj(temb)[:, :, None, None]

--- a/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
@@ -46,7 +46,7 @@ def get_down_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
-    resnet_pre_temb_non_linearity=[False],
+    resnet_pre_temb_non_linearity=False,
 ):
     down_block_type = down_block_type[7:] if down_block_type.startswith("UNetRes") else down_block_type
     if down_block_type == "DownBlock2D":
@@ -198,7 +198,7 @@ def get_up_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
-    resnet_pre_temb_non_linearity=[False],
+    resnet_pre_temb_non_linearity=False,
 ):
     up_block_type = up_block_type[7:] if up_block_type.startswith("UNetRes") else up_block_type
     if up_block_type == "UpBlock2D":
@@ -353,7 +353,7 @@ class UNetMidBlock2D(nn.Layer):
         add_attention: bool = True,
         attn_num_head_channels=1,
         output_scale_factor=1.0,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -440,7 +440,7 @@ class UNetMidBlock2DCrossAttn(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -541,7 +541,7 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         cross_attention_dim=1280,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -657,7 +657,7 @@ class AttnDownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -745,7 +745,7 @@ class CrossAttnDownBlock2D(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -870,7 +870,7 @@ class DownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -950,7 +950,7 @@ class DownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1013,7 +1013,7 @@ class AttnDownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1088,7 +1088,7 @@ class AttnSkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         downsample_padding=1,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1180,7 +1180,7 @@ class SkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -1262,7 +1262,7 @@ class ResnetDownsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1354,7 +1354,7 @@ class SimpleCrossAttnDownBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -1468,7 +1468,7 @@ class AttnUpBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1550,7 +1550,7 @@ class CrossAttnUpBlock2D(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1677,7 +1677,7 @@ class UpBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1750,7 +1750,7 @@ class UpDecoderBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1807,7 +1807,7 @@ class AttnUpDecoderBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1878,7 +1878,7 @@ class AttnSkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         upsample_padding=1,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1986,7 +1986,7 @@ class SkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_upsample=True,
         upsample_padding=1,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -2083,7 +2083,7 @@ class ResnetUpsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -2178,7 +2178,7 @@ class SimpleCrossAttnUpBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []

--- a/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
@@ -46,6 +46,7 @@ def get_down_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
+    resnet_pre_temb_non_linearity=False,
 ):
     down_block_type = down_block_type[7:] if down_block_type.startswith("UNetRes") else down_block_type
     if down_block_type == "DownBlock2D":
@@ -197,6 +198,7 @@ def get_up_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
+    resnet_pre_temb_non_linearity=False,
 ):
     up_block_type = up_block_type[7:] if up_block_type.startswith("UNetRes") else up_block_type
     if up_block_type == "UpBlock2D":
@@ -351,6 +353,7 @@ class UNetMidBlock2D(nn.Layer):
         add_attention: bool = True,
         attn_num_head_channels=1,
         output_scale_factor=1.0,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -402,7 +405,6 @@ class UNetMidBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -438,6 +440,7 @@ class UNetMidBlock2DCrossAttn(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -501,7 +504,6 @@ class UNetMidBlock2DCrossAttn(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -539,6 +541,7 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         cross_attention_dim=1280,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -563,7 +566,6 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
                 output_scale_factor=output_scale_factor,
                 pre_norm=resnet_pre_norm,
                 pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
             )
         ]
         attentions = []
@@ -595,7 +597,6 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -656,6 +657,7 @@ class AttnDownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_downsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -678,7 +680,6 @@ class AttnDownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             attentions.append(
@@ -744,6 +745,7 @@ class CrossAttnDownBlock2D(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -767,7 +769,6 @@ class CrossAttnDownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             if not dual_cross_attention:
@@ -869,6 +870,7 @@ class DownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -888,7 +890,6 @@ class DownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -949,6 +950,7 @@ class DownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -968,7 +970,6 @@ class DownEncoderBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1012,6 +1013,7 @@ class AttnDownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1032,7 +1034,6 @@ class AttnDownEncoderBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             attentions.append(
@@ -1087,6 +1088,7 @@ class AttnSkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         downsample_padding=1,
         add_downsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1108,7 +1110,6 @@ class AttnSkipDownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             self.attentions.append(
@@ -1136,7 +1137,6 @@ class AttnSkipDownBlock2D(nn.Layer):
                 down=True,
                 kernel="fir",
                 pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
             )
             self.downsamplers = nn.LayerList([FirDownsample2D(out_channels, out_channels=out_channels)])
             self.skip_conv = nn.Conv2D(3, out_channels, kernel_size=(1, 1), stride=(1, 1))
@@ -1180,6 +1180,7 @@ class SkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_downsample=True,
         downsample_padding=1,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -1200,7 +1201,6 @@ class SkipDownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1220,7 +1220,6 @@ class SkipDownBlock2D(nn.Layer):
                 down=True,
                 kernel="fir",
                 pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
             )
             self.downsamplers = nn.LayerList([FirDownsample2D(out_channels, out_channels=out_channels)])
             self.skip_conv = nn.Conv2D(3, out_channels, kernel_size=(1, 1), stride=(1, 1))
@@ -1263,6 +1262,7 @@ class ResnetDownsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_downsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1282,7 +1282,6 @@ class ResnetDownsampleBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1355,6 +1354,7 @@ class SimpleCrossAttnDownBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_downsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -1381,7 +1381,6 @@ class SimpleCrossAttnDownBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             attentions.append(
@@ -1469,6 +1468,7 @@ class AttnUpBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1491,7 +1491,6 @@ class AttnUpBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             attentions.append(
@@ -1676,6 +1675,7 @@ class UpBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1697,7 +1697,6 @@ class UpBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1749,6 +1748,7 @@ class UpDecoderBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1769,7 +1769,6 @@ class UpDecoderBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1806,6 +1805,7 @@ class AttnUpDecoderBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -1827,7 +1827,6 @@ class AttnUpDecoderBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
             attentions.append(
@@ -1877,6 +1876,7 @@ class AttnSkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         upsample_padding=1,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1900,7 +1900,6 @@ class AttnSkipUpBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -1985,6 +1984,7 @@ class SkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_upsample=True,
         upsample_padding=1,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -2007,7 +2007,6 @@ class SkipUpBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -2082,6 +2081,7 @@ class ResnetUpsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []
@@ -2103,7 +2103,6 @@ class ResnetUpsampleBlock2D(nn.Layer):
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
                     pre_temb_non_linearity=resnet_pre_temb_non_linearity,
-
                 )
             )
 
@@ -2176,6 +2175,7 @@ class SimpleCrossAttnUpBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_upsample=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
         resnets = []

--- a/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
@@ -46,7 +46,7 @@ def get_down_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
-    resnet_pre_temb_non_linearity=False,
+    resnet_pre_temb_non_linearity=[False],
 ):
     down_block_type = down_block_type[7:] if down_block_type.startswith("UNetRes") else down_block_type
     if down_block_type == "DownBlock2D":
@@ -198,7 +198,7 @@ def get_up_block(
     only_cross_attention=False,
     upcast_attention=False,
     resnet_time_scale_shift="default",
-    resnet_pre_temb_non_linearity=False,
+    resnet_pre_temb_non_linearity=[False],
 ):
     up_block_type = up_block_type[7:] if up_block_type.startswith("UNetRes") else up_block_type
     if up_block_type == "UpBlock2D":
@@ -353,7 +353,7 @@ class UNetMidBlock2D(nn.Layer):
         add_attention: bool = True,
         attn_num_head_channels=1,
         output_scale_factor=1.0,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
 
@@ -440,7 +440,7 @@ class UNetMidBlock2DCrossAttn(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
 
@@ -541,7 +541,7 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         cross_attention_dim=1280,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
 
@@ -657,7 +657,7 @@ class AttnDownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -745,7 +745,7 @@ class CrossAttnDownBlock2D(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -870,7 +870,7 @@ class DownBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -950,7 +950,7 @@ class DownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1013,7 +1013,7 @@ class AttnDownEncoderBlock2D(nn.Layer):
         output_scale_factor=1.0,
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1088,7 +1088,7 @@ class AttnSkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         downsample_padding=1,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1180,7 +1180,7 @@ class SkipDownBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_downsample=True,
         downsample_padding=1,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -1262,7 +1262,7 @@ class ResnetDownsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1354,7 +1354,7 @@ class SimpleCrossAttnDownBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_downsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
 
@@ -1468,7 +1468,7 @@ class AttnUpBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1550,6 +1550,7 @@ class CrossAttnUpBlock2D(nn.Layer):
         use_linear_projection=False,
         only_cross_attention=False,
         upcast_attention=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1573,6 +1574,7 @@ class CrossAttnUpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
                 )
             )
             if not dual_cross_attention:
@@ -1675,7 +1677,7 @@ class UpBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1748,7 +1750,7 @@ class UpDecoderBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1805,7 +1807,7 @@ class AttnUpDecoderBlock2D(nn.Layer):
         attn_num_head_channels=1,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -1876,7 +1878,7 @@ class AttnSkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         upsample_padding=1,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         self.attentions = nn.LayerList([])
@@ -1984,7 +1986,7 @@ class SkipUpBlock2D(nn.Layer):
         output_scale_factor=np.sqrt(2.0),
         add_upsample=True,
         upsample_padding=1,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         self.resnets = nn.LayerList([])
@@ -2081,7 +2083,7 @@ class ResnetUpsampleBlock2D(nn.Layer):
         resnet_pre_norm: bool = True,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -2123,6 +2125,7 @@ class ResnetUpsampleBlock2D(nn.Layer):
                         output_scale_factor=output_scale_factor,
                         pre_norm=resnet_pre_norm,
                         up=True,
+                        pre_temb_non_linearity=resnet_pre_temb_non_linearity,
                     )
                 ]
             )
@@ -2175,7 +2178,7 @@ class SimpleCrossAttnUpBlock2D(nn.Layer):
         cross_attention_dim=1280,
         output_scale_factor=1.0,
         add_upsample=True,
-        resnet_pre_temb_non_linearity=False,
+        resnet_pre_temb_non_linearity=[False],
     ):
         super().__init__()
         resnets = []
@@ -2236,6 +2239,7 @@ class SimpleCrossAttnUpBlock2D(nn.Layer):
                         output_scale_factor=output_scale_factor,
                         pre_norm=resnet_pre_norm,
                         up=True,
+                        pre_temb_non_linearity=resnet_pre_temb_non_linearity,
                     )
                 ]
             )

--- a/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_blocks.py
@@ -60,6 +60,7 @@ def get_down_block(
             resnet_groups=resnet_groups,
             downsample_padding=downsample_padding,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif down_block_type == "ResnetDownsampleBlock2D":
         return ResnetDownsampleBlock2D(
@@ -107,6 +108,7 @@ def get_down_block(
             only_cross_attention=only_cross_attention,
             upcast_attention=upcast_attention,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif down_block_type == "SimpleCrossAttnDownBlock2D":
         if cross_attention_dim is None:
@@ -222,6 +224,7 @@ def get_up_block(
             resnet_act_fn=resnet_act_fn,
             resnet_groups=resnet_groups,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "CrossAttnUpBlock2D":
         if cross_attention_dim is None:
@@ -243,6 +246,7 @@ def get_up_block(
             only_cross_attention=only_cross_attention,
             upcast_attention=upcast_attention,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "SimpleCrossAttnUpBlock2D":
         if cross_attention_dim is None:
@@ -260,6 +264,7 @@ def get_up_block(
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attn_num_head_channels,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "AttnUpBlock2D":
         return AttnUpBlock2D(
@@ -274,6 +279,7 @@ def get_up_block(
             resnet_groups=resnet_groups,
             attn_num_head_channels=attn_num_head_channels,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "SkipUpBlock2D":
         return SkipUpBlock2D(
@@ -286,6 +292,7 @@ def get_up_block(
             resnet_eps=resnet_eps,
             resnet_act_fn=resnet_act_fn,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "AttnSkipUpBlock2D":
         return AttnSkipUpBlock2D(
@@ -299,6 +306,7 @@ def get_up_block(
             resnet_act_fn=resnet_act_fn,
             attn_num_head_channels=attn_num_head_channels,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "UpDecoderBlock2D":
         return UpDecoderBlock2D(
@@ -310,6 +318,7 @@ def get_up_block(
             resnet_act_fn=resnet_act_fn,
             resnet_groups=resnet_groups,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     elif up_block_type == "AttnUpDecoderBlock2D":
         return AttnUpDecoderBlock2D(
@@ -322,6 +331,7 @@ def get_up_block(
             resnet_groups=resnet_groups,
             attn_num_head_channels=attn_num_head_channels,
             resnet_time_scale_shift=resnet_time_scale_shift,
+            resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity,
         )
     raise ValueError(f"{up_block_type} does not exist.")
 
@@ -360,6 +370,7 @@ class UNetMidBlock2D(nn.Layer):
                 non_linearity=resnet_act_fn,
                 output_scale_factor=output_scale_factor,
                 pre_norm=resnet_pre_norm,
+                pre_temb_non_linearity=resnet_pre_temb_non_linearity,
             )
         ]
         attentions = []
@@ -390,6 +401,8 @@ class UNetMidBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -487,6 +500,8 @@ class UNetMidBlock2DCrossAttn(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -547,6 +562,8 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
                 non_linearity=resnet_act_fn,
                 output_scale_factor=output_scale_factor,
                 pre_norm=resnet_pre_norm,
+                pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
             )
         ]
         attentions = []
@@ -577,6 +594,8 @@ class UNetMidBlock2DSimpleCrossAttn(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -658,6 +677,8 @@ class AttnDownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             attentions.append(
@@ -745,6 +766,8 @@ class CrossAttnDownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             if not dual_cross_attention:
@@ -864,6 +887,8 @@ class DownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -942,6 +967,8 @@ class DownEncoderBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1004,6 +1031,8 @@ class AttnDownEncoderBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             attentions.append(
@@ -1078,6 +1107,8 @@ class AttnSkipDownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             self.attentions.append(
@@ -1104,6 +1135,8 @@ class AttnSkipDownBlock2D(nn.Layer):
                 use_in_shortcut=True,
                 down=True,
                 kernel="fir",
+                pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
             )
             self.downsamplers = nn.LayerList([FirDownsample2D(out_channels, out_channels=out_channels)])
             self.skip_conv = nn.Conv2D(3, out_channels, kernel_size=(1, 1), stride=(1, 1))
@@ -1166,6 +1199,8 @@ class SkipDownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1184,6 +1219,8 @@ class SkipDownBlock2D(nn.Layer):
                 use_in_shortcut=True,
                 down=True,
                 kernel="fir",
+                pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
             )
             self.downsamplers = nn.LayerList([FirDownsample2D(out_channels, out_channels=out_channels)])
             self.skip_conv = nn.Conv2D(3, out_channels, kernel_size=(1, 1), stride=(1, 1))
@@ -1244,6 +1281,8 @@ class ResnetDownsampleBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1341,6 +1380,8 @@ class SimpleCrossAttnDownBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             attentions.append(
@@ -1449,6 +1490,8 @@ class AttnUpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             attentions.append(
@@ -1653,6 +1696,8 @@ class UpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1723,6 +1768,8 @@ class UpDecoderBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1779,6 +1826,8 @@ class AttnUpDecoderBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
             attentions.append(
@@ -1850,6 +1899,8 @@ class AttnSkipUpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -1955,6 +2006,8 @@ class SkipUpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -2049,6 +2102,8 @@ class ResnetUpsampleBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
+
                 )
             )
 
@@ -2147,6 +2202,7 @@ class SimpleCrossAttnUpBlock2D(nn.Layer):
                     non_linearity=resnet_act_fn,
                     output_scale_factor=output_scale_factor,
                     pre_norm=resnet_pre_norm,
+                    pre_temb_non_linearity=resnet_pre_temb_non_linearity,
                 )
             )
             attentions.append(

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -166,7 +166,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             attention_head_dim = (attention_head_dim,) * len(down_block_types)
 
         # pre_temb_act_fun opt
-        self.resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity
+        self.resnet_pre_temb_non_linearity = resnet_pre_temb_non_linearity
         if act_fn == "swish":
             self.down_resnet_temb_nonlinearity = lambda x: F.silu(x)
         elif act_fn == "mish":

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -491,7 +491,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
 
         # 3. down
         down_block_res_samples = (sample,)
-        if self.resnet_pre_temb_non_linearity[0]:
+        if self.resnet_pre_temb_non_linearity:
             down_nonlinear_temb = self.down_resnet_temb_nonlinearity(emb)
         else:
             down_nonlinear_temb = emb

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -229,10 +229,6 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 cross_attention_dim=cross_attention_dim,
                 attn_num_head_channels=attention_head_dim[-1],
                 resnet_groups=norm_num_groups,
-<<<<<<< HEAD
-=======
-                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
->>>>>>> ca1a55533... silu opt disable by default and enable on sd export
                 resnet_time_scale_shift=resnet_time_scale_shift,
                 resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
             )

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -129,7 +129,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         num_class_embeds: Optional[int] = None,
         upcast_attention: bool = False,
         resnet_time_scale_shift: str = "default",
-        resnet_pre_temb_non_linearity=[False],
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -129,7 +129,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         num_class_embeds: Optional[int] = None,
         upcast_attention: bool = False,
         resnet_time_scale_shift: str = "default",
-        resnet_pre_temb_non_linearity=True,
+        resnet_pre_temb_non_linearity=False,
     ):
         super().__init__()
 
@@ -165,6 +165,14 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         if isinstance(attention_head_dim, int):
             attention_head_dim = (attention_head_dim,) * len(down_block_types)
 
+        # pre_temb_act_fun opt
+        self.resnet_pre_temb_non_linearity=resnet_pre_temb_non_linearity
+        if act_fn == "swish":
+            self.down_resnet_temb_nonlinearity = lambda x: F.silu(x)
+        elif act_fn == "mish":
+            self.down_resnet_temb_nonlinearity = Mish()
+        elif act_fn == "silu":
+            self.down_resnet_temb_nonlinearity = nn.Silu()
         # down
         output_channel = block_out_channels[0]
         for i, down_block_type in enumerate(down_block_types):
@@ -185,6 +193,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 cross_attention_dim=cross_attention_dim,
                 attn_num_head_channels=attention_head_dim[i],
                 downsample_padding=downsample_padding,
+                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
                 dual_cross_attention=dual_cross_attention,
                 use_linear_projection=use_linear_projection,
                 only_cross_attention=only_cross_attention[i],
@@ -208,6 +217,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 dual_cross_attention=dual_cross_attention,
                 use_linear_projection=use_linear_projection,
                 upcast_attention=upcast_attention,
+                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
             )
         elif mid_block_type == "UNetMidBlock2DSimpleCrossAttn":
             self.mid_block = UNetMidBlock2DSimpleCrossAttn(
@@ -220,6 +230,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 attn_num_head_channels=attention_head_dim[-1],
                 resnet_groups=norm_num_groups,
                 resnet_time_scale_shift=resnet_time_scale_shift,
+                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
             )
         else:
             raise ValueError(f"unknown mid_block_type : {mid_block_type}")
@@ -265,6 +276,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 only_cross_attention=reversed_only_cross_attention[i],
                 upcast_attention=upcast_attention,
                 resnet_time_scale_shift=resnet_time_scale_shift,
+                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel
@@ -479,7 +491,10 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
 
         # 3. down
         down_block_res_samples = (sample,)
-        down_nonlinear_temb = self.down_resnet_temb_nonlinearity(emb)
+        if self.resnet_pre_temb_non_linearity:
+            down_nonlinear_temb = self.down_resnet_temb_nonlinearity(emb)
+        else:
+            down_nonlinear_temb = emb
         for downsample_block in self.down_blocks:
             if hasattr(downsample_block, "has_cross_attention") and downsample_block.has_cross_attention:
                 sample, res_samples = downsample_block(

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import paddle
 import paddle.nn as nn
+import paddle.nn.functional as F
 
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..loaders import UNet2DConditionLoadersMixin
@@ -36,6 +37,11 @@ from .unet_2d_blocks import (
 )
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+class Mish(nn.Layer):
+    def forward(self, hidden_states):
+        return hidden_states * paddle.tanh(F.softplus(hidden_states))
 
 
 @dataclass
@@ -473,7 +479,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
 
         # 3. down
         down_block_res_samples = (sample,)
-        down_nonlinear_temb=self.down_resnet_temb_nonlinearity(emb)
+        down_nonlinear_temb = self.down_resnet_temb_nonlinearity(emb)
         for downsample_block in self.down_blocks:
             if hasattr(downsample_block, "has_cross_attention") and downsample_block.has_cross_attention:
                 sample, res_samples = downsample_block(
@@ -520,7 +526,10 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 )
             else:
                 sample = upsample_block(
-                    hidden_states=sample, temb=emb, res_hidden_states_tuple=res_samples, upsample_size=upsample_size
+                    hidden_states=sample,
+                    temb=down_nonlinear_temb,
+                    res_hidden_states_tuple=res_samples,
+                    upsample_size=upsample_size,
                 )
         # 6. post-process
         sample = self.conv_norm_out(sample)

--- a/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
+++ b/ppdiffusers/ppdiffusers/models/unet_2d_condition.py
@@ -229,6 +229,10 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 cross_attention_dim=cross_attention_dim,
                 attn_num_head_channels=attention_head_dim[-1],
                 resnet_groups=norm_num_groups,
+<<<<<<< HEAD
+=======
+                resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
+>>>>>>> ca1a55533... silu opt disable by default and enable on sd export
                 resnet_time_scale_shift=resnet_time_scale_shift,
                 resnet_pre_temb_non_linearity=self.resnet_pre_temb_non_linearity,
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Performance optimization

### PR changes
Models

### Description
This PR reduce the reductant silu of time embeding to speed up the inference of stable-diffusion model.
This optimization is disable by default in modeling and enable in the export model process.
Such a optimization reduce the latency of stable-diffusion about 0.01s/0.78s in A100