### PR TITLE
fix: fix issue #4801

### DIFF
--- a/applications/document_intelligence/doc_vqa/OCR_process/ocr_process.py
+++ b/applications/document_intelligence/doc_vqa/OCR_process/ocr_process.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import json
-from paddleocr import PaddleOCR, __version__ as paddleocr_version
-import numpy as np
+import os
 import re
-import time
-import sys
-from multiprocessing import Process, Queue
+
+from paddleocr import PaddleOCR
+from paddleocr import __version__ as paddleocr_version
 
 from paddlenlp.transformers import LayoutXLMTokenizer
 
@@ -60,7 +58,7 @@ def merge_bbox(tok_bboxes):
 
 
 def xlm_parse(ocr_res, tokenizer):
-    doc_tokens, doc_bboxes = [], []
+    doc_bboxes = []
     all_chr = get_all_chars(tokenizer)
 
     try:
@@ -170,7 +168,7 @@ def xlm_parse(ocr_res, tokenizer):
 
             doc_bboxes.append(merged_bbox)
             i = i + tok_len
-    except:
+    except Exception:
         print("Error")
         span_tokens = ["▁"] * 512
         doc_bboxes = [[0, 0, 0, 0]] * 512

--- a/applications/document_intelligence/doc_vqa/OCR_process/ocr_process.py
+++ b/applications/document_intelligence/doc_vqa/OCR_process/ocr_process.py
@@ -14,7 +14,7 @@
 
 import os
 import json
-from paddleocr import PaddleOCR
+from paddleocr import PaddleOCR, __version__ as paddleocr_version
 import numpy as np
 import re
 import time
@@ -60,7 +60,6 @@ def merge_bbox(tok_bboxes):
 
 
 def xlm_parse(ocr_res, tokenizer):
-
     doc_tokens, doc_bboxes = [], []
     all_chr = get_all_chars(tokenizer)
 
@@ -263,6 +262,8 @@ def ocr_preprocess(img_dir):
         parsing_res = ocr.ocr(img_path, cls=True)
         ocr_res = []
         for para in parsing_res:
+            if paddleocr_version > "2.6.0.1":
+                para = para[0]
             ocr_res.append({"text": para[1][0], "bbox": para[0]})
         ocr_reses.append((img_name, ocr_res))
 


### PR DESCRIPTION
PR types
Bug fixes

PR changes
Demo

Description
fix #4801 , This commit try to fix #4801, which may break `doc_vqa` application. This issue effected by `paddleocr` with version > 2.6, it changed ocr result data structure