### PR TITLE
fix 4903

### DIFF
--- a/model_zoo/bert/README.md
+++ b/model_zoo/bert/README.md
@@ -111,7 +111,7 @@ python -m paddle.distributed.launch --xpus "0" run_pretrain.py \
 - `output_dir` 表示模型的保存目录。
 - `logging_steps` 表示日志打印间隔。
 - `save_steps` 表示模型保存及评估间隔。
-- `max_steps` 表示最大训练步数。若训练`num_train_epochs`轮包含的训练步数大于该值，则达到`max_steps`后就提前结束。
+- `max_steps` 表示最大训练步数，达到`max_steps`后就提前结束。注意，我们必须设置 `max_steps`。
 - `device` 表示训练使用的设备, 'gpu'表示使用GPU, 'xpu'表示使用百度昆仑卡, 'cpu'表示使用CPU。
 - `use_amp` 指示是否启用自动混合精度训练。
 

--- a/model_zoo/bert/run_pretrain.py
+++ b/model_zoo/bert/run_pretrain.py
@@ -16,6 +16,7 @@ import argparse
 import logging
 import os
 import random
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -99,16 +100,10 @@ def parse_args():
     parser.add_argument("--adam_epsilon", default=1e-8, type=float, help="Epsilon for Adam optimizer.")
     parser.add_argument("--max_grad_norm", default=1.0, type=float, help="Max gradient norm.")
     parser.add_argument(
-        "--num_train_epochs",
-        default=3,
-        type=int,
-        help="Total number of training epochs to perform.",
-    )
-    parser.add_argument(
         "--max_steps",
-        default=-1,
+        default=1000000,
         type=int,
-        help="If > 0: set total number of training steps to perform. Override num_train_epochs.",
+        help="Set total number of training steps to perform. ",
     )
     parser.add_argument("--warmup_steps", default=0, type=int, help="Linear warmup over warmup_steps.")
 
@@ -294,10 +289,7 @@ def do_train(args):
 
     # If use default last_epoch, lr of the first iteration is 0.
     # Use `last_epoch = 0` to be consistent with nv bert.
-    # BUG: train_data_loader is undefined variable here hence the noqa: F821
-    num_training_steps = (
-        args.max_steps if args.max_steps > 0 else len(train_data_loader) * args.num_train_epochs  # noqa: F821
-    )
+    num_training_steps = args.max_steps
 
     lr_scheduler = LinearDecayWithWarmup(args.learning_rate, num_training_steps, args.warmup_steps, last_epoch=0)
 
@@ -321,7 +313,7 @@ def do_train(args):
 
     pool = ThreadPoolExecutor(1)
     global_step = 0
-    for epoch in range(args.num_train_epochs):
+    for epoch in range(sys.maxsize):
         files = [
             os.path.join(args.input_dir, f)
             for f in os.listdir(args.input_dir)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
由于bert预训练代码的特殊性，无法很好事先知道dataloader长度，因此删除 num_epoch 参数，通过max_steps设置。