### PR TITLE
[AutoNLP]add predict

### DIFF
--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -171,15 +171,23 @@ class AutoTrainerBase(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def predict(self, test_dataset: Dataset, trial_id: Optional[str] = None):
+        """
+        Run prediction and returns predictions and potential metrics from a certain `trial_id` on the given dataset
+        Args:
+            test_dataset (Dataset, required): Custom test dataset and must contains the 'text_column' and 'label_column' fields.
+            trial_id (str, optional): Specify the model to be evaluated through the `trial_id`. Defaults to the best model selected by `metric_for_best_model`.
+        """
+        raise NotImplementedError
+
     def _override_hp(self, config: Dict[str, Any], default_hp: Any) -> Any:
         """
         Overrides the arguments with the provided hyperparameter config
         """
         new_hp = copy.deepcopy(default_hp)
         for key, value in config.items():
-            if key.startswith(default_hp.__class__.__name__):
-                _, hp_key = key.split(".")
-                setattr(new_hp, hp_key, value)
+            if key in new_hp.to_dict():
+                setattr(new_hp, key, value)
         return new_hp
 
     def _filter_model_candidates(
@@ -264,7 +272,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
             experiment_name: (str, optional): name of the experiment. Experiment log will be stored under <output_dir>/<experiment_name>.
                 Defaults to UNIX timestamp.
             hp_overrides: (dict[str, Any], optional): Advanced users only.
-                override the hyperparameters of every model candidate.  For example, {"TrainingArguments.max_steps": 5}.
+                override the hyperparameters of every model candidate.  For example, {"max_steps": 5}.
             custom_model_candiates: (dict[str, Any], optional): Advanced users only.
                 Run the user-provided model candidates instead of the default model candidated from PaddleNLP. See `._model_candidates` property as an example
 

--- a/paddlenlp/experimental/autonlp/auto_trainer_base.py
+++ b/paddlenlp/experimental/autonlp/auto_trainer_base.py
@@ -138,6 +138,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
         preprocess an example from raw features to input features that Transformers models expect (e.g. input_ids, attention_mask, labels, etc)
         """
 
+    @abstractmethod
     def export(self, export_path, trial_id=None):
         """
         Export the model from a certain `trial_id` to the given file path.
@@ -171,6 +172,7 @@ class AutoTrainerBase(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def predict(self, test_dataset: Dataset, trial_id: Optional[str] = None):
         """
         Run prediction and returns predictions and potential metrics from a certain `trial_id` on the given dataset

--- a/paddlenlp/experimental/autonlp/text_classification.py
+++ b/paddlenlp/experimental/autonlp/text_classification.py
@@ -16,7 +16,7 @@ import functools
 import json
 import os
 import shutil
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import paddle
@@ -97,7 +97,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
             raise NotImplementedError(
                 f"'{problem_type}' is not a supported problem_type. Please select among ['multi_label', 'multi_class']"
             )
-        self._data_checks_and_inference()
+        self._data_checks_and_inference([self.train_dataset, self.eval_dataset])
 
     @property
     def supported_languages(self) -> List[str]:
@@ -180,22 +180,22 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "language": "Chinese",
                 "trainer_type": "Trainer",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "TrainingArguments.per_device_train_batch_size": train_batch_size,
-                "TrainingArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "TrainingArguments.num_train_epochs": 100,
-                "TrainingArguments.model_name_or_path": chinese_finetune_models,
-                "TrainingArguments.learning_rate": 3e-5,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": chinese_finetune_models,
+                "learning_rate": 3e-5,
             },
             {
                 "preset": "finetune",
                 "language": "English",
                 "trainer_type": "Trainer",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "TrainingArguments.per_device_train_batch_size": train_batch_size,
-                "TrainingArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "TrainingArguments.num_train_epochs": 100,
-                "TrainingArguments.model_name_or_path": english_finetune_models,
-                "TrainingArguments.learning_rate": 3e-5,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": english_finetune_models,
+                "learning_rate": 3e-5,
             },
             # slow learning: small LR, large early stop patience
             {
@@ -203,22 +203,22 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "language": "Chinese",
                 "trainer_type": "Trainer",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "TrainingArguments.per_device_train_batch_size": train_batch_size,
-                "TrainingArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "TrainingArguments.num_train_epochs": 100,
-                "TrainingArguments.model_name_or_path": chinese_finetune_models,
-                "TrainingArguments.learning_rate": 5e-6,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": chinese_finetune_models,
+                "learning_rate": 5e-6,
             },
             {
                 "preset": "finetune",
                 "language": "English",
                 "trainer_type": "Trainer",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "TrainingArguments.per_device_train_batch_size": train_batch_size,
-                "TrainingArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "TrainingArguments.num_train_epochs": 100,
-                "TrainingArguments.model_name_or_path": english_finetune_models,
-                "TrainingArguments.learning_rate": 5e-6,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": english_finetune_models,
+                "learning_rate": 5e-6,
             },
             # prompt tuning candidates
             {
@@ -227,12 +227,12 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "trainer_type": "PromptTrainer",
                 "template.prompt": "{'mask'}{'soft'}“{'text': '" + self.text_column + "'}”",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "PromptTuningArguments.per_device_train_batch_size": train_batch_size,
-                "PromptTuningArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "PromptTuningArguments.num_train_epochs": 100,
-                "PromptTuningArguments.model_name_or_path": chinese_prompt_models,
-                "PromptTuningArguments.learning_rate": 1e-5,
-                "PromptTuningArguments.ppt_learning_rate": 1e-4,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": chinese_prompt_models,
+                "learning_rate": 1e-5,
+                "ppt_learning_rate": 1e-4,
             },
             {
                 "preset": "prompt",
@@ -240,20 +240,23 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "trainer_type": "PromptTrainer",
                 "template.prompt": "{'mask'}{'soft'}“{'text': '" + self.text_column + "'}”",
                 "EarlyStoppingCallback.early_stopping_patience": 5,
-                "PromptTuningArguments.per_device_train_batch_size": train_batch_size,
-                "PromptTuningArguments.per_device_eval_batch_size": train_batch_size * 2,
-                "PromptTuningArguments.num_train_epochs": 100,
-                "PromptTuningArguments.model_name_or_path": english_prompt_models,
-                "PromptTuningArguments.learning_rate": 1e-5,
-                "PromptTuningArguments.ppt_learning_rate": 1e-4,
+                "per_device_train_batch_size": train_batch_size,
+                "per_device_eval_batch_size": train_batch_size * 2,
+                "num_train_epochs": 100,
+                "model_name_or_path": english_prompt_models,
+                "learning_rate": 1e-5,
+                "ppt_learning_rate": 1e-4,
             },
         ]
 
-    def _data_checks_and_inference(self):
+    def _data_checks_and_inference(self, dataset_list: List[Dataset]):
+        """
+        Performs different data checks and generate id to label mapping on the datasets.
+        """
         if self.id2label is None:
             self.id2label, self.label2id = {}, {}
             if self.problem_type == "multi_class":
-                for dataset in [self.train_dataset, self.eval_dataset]:
+                for dataset in dataset_list:
                     for example in dataset:
                         label = example[self.label_column]
                         if label not in self.label2id:
@@ -261,7 +264,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                             self.id2label[len(self.id2label)] = label
             # multi_label
             else:
-                for dataset in [self.train_dataset, self.eval_dataset]:
+                for dataset in dataset_list:
                     for example in dataset:
                         labels = example[self.label_column]
                         for label in labels:
@@ -274,7 +277,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 self.label2id[self.id2label[i]] = i
 
             if self.problem_type == "multi_class":
-                for dataset in [self.train_dataset, self.eval_dataset]:
+                for dataset in dataset_list:
                     for example in dataset:
                         label = example[self.label_column]
                         if label not in self.label2id:
@@ -283,7 +286,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                             )
             # multi_label
             else:
-                for dataset in [self.train_dataset, self.eval_dataset]:
+                for dataset in dataset_list:
                     for example in dataset:
                         labels = example[self.label_column]
                         for label in labels:
@@ -292,59 +295,65 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                                     f"Label {label} is not found in the user-provided id2label argument: {self.id2label}"
                                 )
 
-    def _construct_trainer(self, config, eval_dataset=None) -> Trainer:
-        if "EarlyStoppingCallback.early_stopping_patience" in config:
+    def _construct_trainer(self, model_config) -> Trainer:
+        if "EarlyStoppingCallback.early_stopping_patience" in model_config:
             callbacks = [
-                EarlyStoppingCallback(early_stopping_patience=config["EarlyStoppingCallback.early_stopping_patience"])
+                EarlyStoppingCallback(
+                    early_stopping_patience=model_config["EarlyStoppingCallback.early_stopping_patience"]
+                )
             ]
         else:
             callbacks = None
-        if config["trainer_type"] == "Trainer":
-            model_path = config["TrainingArguments.model_name_or_path"]
+
+        if self.problem_type == "multi_class":
+            criterion = paddle.nn.CrossEntropyLoss()
+        else:
+            criterion = paddle.nn.BCEWithLogitsLoss()
+
+        if model_config["trainer_type"] == "Trainer":
+            model_path = model_config["model_name_or_path"]
             tokenizer = AutoTokenizer.from_pretrained(model_path)
             model = AutoModelForSequenceClassification.from_pretrained(
                 model_path, num_labels=len(self.id2label), id2label=self.id2label, label2id=self.label2id
             )
-            max_length = config.get("PreprocessArguments.max_length", model.config.max_position_embeddings)
-            trans_func = functools.partial(
-                self._preprocess_fn,
-                tokenizer=tokenizer,
-                max_length=max_length,  # truncate to the max length allowed by the model
+            max_length = model_config.get("max_length", model.config.max_position_embeddings)
+
+            training_args = self._override_hp(model_config, self._default_training_argument)
+            processed_train_dataset = self._preprocess_dataset(
+                self.train_dataset, max_length, tokenizer, model_config["trainer_type"]
             )
-            processed_train_dataset = copy.deepcopy(self.train_dataset).map(trans_func, lazy=False)
-            if eval_dataset is None:
-                processed_eval_dataset = copy.deepcopy(self.eval_dataset).map(trans_func, lazy=False)
-            else:
-                processed_eval_dataset = copy.deepcopy(eval_dataset).map(trans_func, lazy=False)
-            training_args = self._override_hp(config, self._default_training_argument)
+            processed_eval_dataset = self._preprocess_dataset(
+                self.eval_dataset, max_length, tokenizer, model_config["trainer_type"]
+            )
+
             trainer = Trainer(
                 model=model,
                 tokenizer=tokenizer,
                 args=training_args,
+                criterion=criterion,
                 train_dataset=processed_train_dataset,
                 eval_dataset=processed_eval_dataset,
                 data_collator=DataCollatorWithPadding(tokenizer),
                 compute_metrics=self._compute_metrics,
                 callbacks=callbacks,
             )
-        elif config["trainer_type"] == "PromptTrainer":
-            model_path = config["PromptTuningArguments.model_name_or_path"]
+        elif model_config["trainer_type"] == "PromptTrainer":
+            model_path = model_config["model_name_or_path"]
             tokenizer = AutoTokenizer.from_pretrained(model_path)
-            processed_train_dataset = copy.deepcopy(self.train_dataset).map(self._preprocess_labels, lazy=False)
-            if eval_dataset is None:
-                processed_eval_dataset = copy.deepcopy(self.eval_dataset).map(self._preprocess_labels, lazy=False)
-            else:
-                processed_eval_dataset = copy.deepcopy(eval_dataset).map(self._preprocess_labels, lazy=False)
-
             model = AutoModelForMaskedLM.from_pretrained(model_path)
-            max_length = config.get("PreprocessArguments.max_length", model.config.max_position_embeddings)
-            template = AutoTemplate.create_from(
-                prompt=config["template.prompt"],
-                tokenizer=tokenizer,
-                max_length=max_length,
-                model=model,
+            max_length = model_config.get("max_length", model.config.max_position_embeddings)
+
+            training_args = self._override_hp(model_config, self._default_prompt_tuning_arguments)
+            processed_train_dataset = self._preprocess_dataset(
+                self.train_dataset, max_length, tokenizer, model_config["trainer_type"]
             )
-            training_args = self._override_hp(config, self._default_prompt_tuning_arguments)
+            processed_eval_dataset = self._preprocess_dataset(
+                self.eval_dataset, max_length, tokenizer, model_config["trainer_type"]
+            )
+
+            template = AutoTemplate.create_from(
+                prompt=model_config["template.prompt"], tokenizer=tokenizer, max_length=max_length, model=model
+            )
             verbalizer = SoftVerbalizer(label_words=self.id2label, tokenizer=tokenizer, model=model)
             prompt_model = PromptModelForSequenceClassification(
                 model,
@@ -353,10 +362,6 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 freeze_plm=training_args.freeze_plm,
                 freeze_dropout=training_args.freeze_dropout,
             )
-            if self.problem_type == "multi_class":
-                criterion = paddle.nn.CrossEntropyLoss()
-            else:  # multi_label
-                criterion = paddle.nn.BCEWithLogitsLoss()
             trainer = PromptTrainer(
                 model=prompt_model,
                 tokenizer=tokenizer,
@@ -372,14 +377,22 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
         return trainer
 
     def _construct_trainable(self) -> Callable:
-        def trainable(config):
+        """
+        Returns the Trainable functions that contains the main preprocessing and training logic
+        """
+
+        def trainable(model_config):
             # import is required for proper pickling
             from paddlenlp.utils.log import logger
 
-            config = config["candidates"]
-            trainer = self._construct_trainer(config)
+            # construct trainer
+            model_config = model_config["candidates"]
+            trainer = self._construct_trainer(model_config)
+            # train
             trainer.train()
+            # evaluate
             eval_metrics = trainer.evaluate()
+            # save dygraph model
             trainer.save_model(self.save_path)
 
             if os.path.exists(self.training_path):
@@ -389,29 +402,71 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
 
         return trainable
 
-    def evaluate(self, trial_id=None, eval_dataset=None):
+    def evaluate(self, eval_dataset: Optional[Dataset] = None, trial_id: Optional[str] = None):
         """
-        Evaluate the models from a certain `trial_id` on the given dataset
-
+        Run evaluation and returns metrics from a certain `trial_id` on the given dataset.
         Args:
+            eval_dataset (Dataset, optional): custom evaluation dataset and must contains the 'text_column' and 'label_column' fields. If not provided, defaults to the evaluation dataset used at construction.
             trial_id (str, optional): specify the model to be evaluated through the `trial_id`. Defaults to the best model selected by `metric_for_best_model`
-            eval_dataset (Dataset, optional): custom evaluation dataset and must contains the 'text_column' and 'label_column' fields.
-                If not provided, defaults to the evaluation dataset used at construction
         """
         model_result = self._get_model_result(trial_id=trial_id)
         model_config = model_result.metrics["config"]["candidates"]
-
-        trainer = self._construct_trainer(model_config, eval_dataset)
+        trainer = self._construct_trainer(model_config)
         trainer.load_state_dict_from_checkpoint(
             resume_from_checkpoint=os.path.join(model_result.log_dir, self.save_path)
         )
 
-        eval_metrics = trainer.evaluate()
+        if eval_dataset is not None:
+            self._data_checks_and_inference([eval_dataset])
+            if model_config["trainer_type"] == "PromptTrainer":
+                max_length = model_config.get("max_length", trainer.model.plm.config.max_position_embeddings)
+            else:
+                max_length = model_config.get("max_length", trainer.model.config.max_position_embeddings)
+            processed_eval_dataset = self._preprocess_dataset(
+                eval_dataset, max_length, trainer.tokenizer, model_config["trainer_type"]
+            )
+            eval_metrics = trainer.evaluate(eval_dataset=processed_eval_dataset)
+        else:
+            eval_metrics = trainer.evaluate()
+        trainer.log_metrics("eval", eval_metrics)
+
         if os.path.exists(self.training_path):
             logger.info(f"Removing {self.training_path} to conserve disk space")
             shutil.rmtree(self.training_path)
-        trainer.log_metrics("eval", eval_metrics)
+
         return eval_metrics
+
+    def predict(self, test_dataset: Dataset, trial_id: Optional[str] = None):
+        """
+        Run prediction and returns predictions and potential metrics from a certain `trial_id` on the given dataset
+        Args:
+            test_dataset (Dataset): Custom test dataset and must contains the 'text_column' and 'label_column' fields.
+            trial_id (str, optional): Specify the model to be evaluated through the `trial_id`. Defaults to the best model selected by `metric_for_best_model`.
+        """
+        self._data_checks_and_inference([test_dataset])
+        model_result = self._get_model_result(trial_id=trial_id)
+        model_config = model_result.metrics["config"]["candidates"]
+
+        trainer = self._construct_trainer(model_config)
+        trainer.load_state_dict_from_checkpoint(
+            resume_from_checkpoint=os.path.join(model_result.log_dir, self.save_path)
+        )
+
+        if model_config["trainer_type"] == "PromptTrainer":
+            max_length = model_config.get("max_length", trainer.model.plm.config.max_position_embeddings)
+        else:
+            max_length = model_config.get("max_length", trainer.model.config.max_position_embeddings)
+        processed_test_dataset = self._preprocess_dataset(
+            test_dataset, max_length, trainer.tokenizer, model_config["trainer_type"]
+        )
+        test_output = trainer.predict(test_dataset=processed_test_dataset)
+        trainer.log_metrics("test", test_output.metrics)
+
+        if os.path.exists(self.training_path):
+            logger.info(f"Removing {self.training_path} to conserve disk space")
+            shutil.rmtree(self.training_path)
+
+        return test_output
 
     def _compute_metrics(self, eval_preds: EvalPrediction) -> Dict[str, float]:
         if self.problem_type == "multi_class":
@@ -473,6 +528,23 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
             result["labels"] = example_with_labels["labels"]
         return result
 
+    def _preprocess_dataset(
+        self, dataset: Dataset, max_length: int, tokenizer: PretrainedTokenizer, trainer_type: str
+    ):
+        """
+        Preprocess dataset from raw features to input features used by the Trainer or PromptTrainer.
+        """
+        if trainer_type == "PromptTrainer":
+            trans_func = self._preprocess_labels
+        elif trainer_type == "Trainer":
+            trans_func = functools.partial(
+                self._preprocess_fn,
+                tokenizer=tokenizer,
+                max_length=max_length,  # truncate to the max length allowed by the model
+            )
+        processed_dataset = copy.deepcopy(dataset).map(trans_func, lazy=False)
+        return processed_dataset
+
     def to_taskflow(self, trial_id=None, export_path=None, batch_size=1, precision="fp32"):
         """
         Convert the model from a certain `trial_id` to a Taskflow for model inference
@@ -524,9 +596,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
             trainer.export_model(export_path)
             trainer.model.plm.save_pretrained(os.path.join(export_path, "plm"))
             mode = "prompt"
-            max_length = model_config.get(
-                "PreprocessArguments.max_length", trainer.model.plm.config.max_position_embeddings
-            )
+            max_length = model_config.get("max_length", trainer.model.plm.config.max_position_embeddings)
         else:
             if trainer.model.init_config["init_class"] in ["ErnieMForSequenceClassification"]:
                 input_spec = [paddle.static.InputSpec(shape=[None, None], dtype="int64", name="input_ids")]
@@ -537,9 +607,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 ]
             export_model(model=trainer.model, input_spec=input_spec, path=export_path)
             mode = "finetune"
-            max_length = model_config.get(
-                "PreprocessArguments.max_length", trainer.model.config.max_position_embeddings
-            )
+            max_length = model_config.get("max_length", trainer.model.config.max_position_embeddings)
 
         # save tokenizer
         trainer.tokenizer.save_pretrained(export_path)

--- a/paddlenlp/experimental/autonlp/text_classification.py
+++ b/paddlenlp/experimental/autonlp/text_classification.py
@@ -179,7 +179,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "preset": "finetune",
                 "language": "Chinese",
                 "trainer_type": "Trainer",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -190,7 +190,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "preset": "finetune",
                 "language": "English",
                 "trainer_type": "Trainer",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -202,7 +202,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "preset": "finetune",
                 "language": "Chinese",
                 "trainer_type": "Trainer",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -213,7 +213,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "preset": "finetune",
                 "language": "English",
                 "trainer_type": "Trainer",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -226,7 +226,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "language": "Chinese",
                 "trainer_type": "PromptTrainer",
                 "template.prompt": "{'mask'}{'soft'}“{'text': '" + self.text_column + "'}”",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -239,7 +239,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
                 "language": "English",
                 "trainer_type": "PromptTrainer",
                 "template.prompt": "{'mask'}{'soft'}“{'text': '" + self.text_column + "'}”",
-                "EarlyStoppingCallback.early_stopping_patience": 5,
+                "early_stopping_patience": 5,
                 "per_device_train_batch_size": train_batch_size,
                 "per_device_eval_batch_size": train_batch_size * 2,
                 "num_train_epochs": 100,
@@ -253,55 +253,46 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
         """
         Performs different data checks and generate id to label mapping on the datasets.
         """
+        generate_id2label = True
         if self.id2label is None:
             self.id2label, self.label2id = {}, {}
-            if self.problem_type == "multi_class":
-                for dataset in dataset_list:
-                    for example in dataset:
-                        label = example[self.label_column]
-                        if label not in self.label2id:
-                            self.label2id[label] = len(self.label2id)
-                            self.id2label[len(self.id2label)] = label
-            # multi_label
-            else:
-                for dataset in dataset_list:
-                    for example in dataset:
-                        labels = example[self.label_column]
-                        for label in labels:
-                            if label not in self.label2id:
-                                self.label2id[label] = len(self.label2id)
-                                self.id2label[len(self.id2label)] = label
         else:
+            generate_id2label = False
             self.label2id = {}
             for i in self.id2label:
                 self.label2id[self.id2label[i]] = i
 
-            if self.problem_type == "multi_class":
-                for dataset in dataset_list:
-                    for example in dataset:
-                        label = example[self.label_column]
-                        if label not in self.label2id:
+        for dataset in dataset_list:
+            for example in dataset:
+                if self.text_column not in example or self.label_column not in example:
+                    raise ValueError(
+                        f"Text column: {self.text_column} and label columns:{self.label_column} must exist for example: {example}"
+                    )
+                if self.problem_type == "multi_class":
+                    label = example[self.label_column]
+                    if label not in self.label2id:
+                        if generate_id2label:
+                            self.label2id[label] = len(self.label2id)
+                            self.id2label[len(self.id2label)] = label
+                        else:
                             raise ValueError(
                                 f"Label {label} is not found in the user-provided id2label argument: {self.id2label}"
                             )
-            # multi_label
-            else:
-                for dataset in dataset_list:
-                    for example in dataset:
-                        labels = example[self.label_column]
-                        for label in labels:
-                            if label not in self.label2id:
+                else:
+                    labels = example[self.label_column]
+                    for label in labels:
+                        if label not in self.label2id:
+                            if generate_id2label:
+                                self.label2id[label] = len(self.label2id)
+                                self.id2label[len(self.id2label)] = label
+                            else:
                                 raise ValueError(
                                     f"Label {label} is not found in the user-provided id2label argument: {self.id2label}"
                                 )
 
     def _construct_trainer(self, model_config) -> Trainer:
-        if "EarlyStoppingCallback.early_stopping_patience" in model_config:
-            callbacks = [
-                EarlyStoppingCallback(
-                    early_stopping_patience=model_config["EarlyStoppingCallback.early_stopping_patience"]
-                )
-            ]
+        if "early_stopping_patience" in model_config:
+            callbacks = [EarlyStoppingCallback(early_stopping_patience=model_config["early_stopping_patience"])]
         else:
             callbacks = None
 
@@ -443,7 +434,15 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
             test_dataset (Dataset): Custom test dataset and must contains the 'text_column' and 'label_column' fields.
             trial_id (str, optional): Specify the model to be evaluated through the `trial_id`. Defaults to the best model selected by `metric_for_best_model`.
         """
-        self._data_checks_and_inference([test_dataset])
+        is_test = False
+        if self.label_column in test_dataset[0]:
+            self._data_checks_and_inference([test_dataset])
+        else:
+            is_test = True
+            for example in test_dataset:
+                if self.text_column not in example:
+                    raise ValueError(f"Text column: {self.text_column} must exist for example: {example}")
+
         model_result = self._get_model_result(trial_id=trial_id)
         model_config = model_result.metrics["config"]["candidates"]
 
@@ -457,7 +456,7 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
         else:
             max_length = model_config.get("max_length", trainer.model.config.max_position_embeddings)
         processed_test_dataset = self._preprocess_dataset(
-            test_dataset, max_length, trainer.tokenizer, model_config["trainer_type"]
+            test_dataset, max_length, trainer.tokenizer, model_config["trainer_type"], is_test=is_test
         )
         test_output = trainer.predict(test_dataset=processed_test_dataset)
         trainer.log_metrics("test", test_output.metrics)
@@ -524,23 +523,31 @@ class AutoTrainerForTextClassification(AutoTrainerBase):
         """
         result = tokenizer(text=example[self.text_column], max_length=max_length, truncation=True)
         if not is_test:
-            example_with_labels = self._preprocess_labels(example)
-            result["labels"] = example_with_labels["labels"]
+            result["labels"] = self._preprocess_labels(example)["labels"]
         return result
 
     def _preprocess_dataset(
-        self, dataset: Dataset, max_length: int, tokenizer: PretrainedTokenizer, trainer_type: str
+        self,
+        dataset: Dataset,
+        max_length: int,
+        tokenizer: PretrainedTokenizer,
+        trainer_type: str,
+        is_test: bool = False,
     ):
         """
         Preprocess dataset from raw features to input features used by the Trainer or PromptTrainer.
         """
+
         if trainer_type == "PromptTrainer":
+            if is_test:
+                return dataset
             trans_func = self._preprocess_labels
         elif trainer_type == "Trainer":
             trans_func = functools.partial(
                 self._preprocess_fn,
                 tokenizer=tokenizer,
                 max_length=max_length,  # truncate to the max length allowed by the model
+                is_test=is_test,
             )
         processed_dataset = copy.deepcopy(dataset).map(trans_func, lazy=False)
         return processed_dataset

--- a/paddlenlp/prompt/prompt_trainer.py
+++ b/paddlenlp/prompt/prompt_trainer.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle.io import DataLoader, Dataset
 
 from ..data import DataCollator
 from ..datasets import MapDataset
@@ -151,6 +152,11 @@ class PromptTrainer(Trainer):
     def get_test_dataloader(self, test_dataset):
         test_dataset = self._map_dataset(test_dataset)
         return super(PromptTrainer, self).get_test_dataloader(test_dataset)
+
+    def get_eval_dataloader(self, eval_dataset: Optional[Dataset] = None) -> DataLoader:
+        if eval_dataset is not None:
+            eval_dataset = self._map_dataset(eval_dataset)
+        return super(PromptTrainer, self).get_eval_dataloader(eval_dataset)
 
     def create_optimizer(self, lr_scheduler=None):
         """

--- a/tests/experimental/autonlp/test_text_classification.py
+++ b/tests/experimental/autonlp/test_text_classification.py
@@ -269,15 +269,21 @@ class TestAutoTrainerForTextClassification(unittest.TestCase):
             )
 
             # test predict
-            copy_test_ds = copy.deepcopy(self.multi_label_dev_ds)
-            test_output = auto_trainer.predict(test_dataset=copy_test_ds)
+            dev_output = auto_trainer.predict(test_dataset=copy_dev_ds)
             self.assertEqual(
                 eval_metrics1[auto_trainer.metric_for_best_model],
-                test_output.metrics[auto_trainer.metric_for_best_model.replace("eval", "test")],
+                dev_output.metrics[auto_trainer.metric_for_best_model.replace("eval", "test")],
             )
+            self.assertEqual(len(copy_dev_ds), len(dev_output.label_ids))
+            self.assertEqual(len(copy_dev_ds), len(dev_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(dev_output.predictions[0]))
+
+            copy_test_ds = copy.deepcopy(self.test_ds)
+            test_output = auto_trainer.predict(test_dataset=copy_test_ds)
+            self.assertFalse(auto_trainer.metric_for_best_model.replace("eval", "test") in test_output.metrics)
+            self.assertEqual(None, test_output.label_ids)
             self.assertEqual(len(copy_test_ds), len(test_output.predictions))
             self.assertEqual(len(auto_trainer.id2label), len(test_output.predictions[0]))
-            self.assertEqual(len(copy_test_ds), len(test_output.label_ids))
 
             # test taskflow
             taskflow = auto_trainer.to_taskflow()
@@ -371,12 +377,21 @@ class TestAutoTrainerForTextClassification(unittest.TestCase):
             )
 
             # test predict
-            copy_test_ds = copy.deepcopy(self.multi_class_dev_ds)
-            eval_metrics3 = auto_trainer.predict(test_dataset=copy_test_ds).metrics
+            dev_output = auto_trainer.predict(test_dataset=copy_dev_ds)
             self.assertEqual(
                 eval_metrics1[auto_trainer.metric_for_best_model],
-                eval_metrics3[auto_trainer.metric_for_best_model.replace("eval", "test")],
+                dev_output.metrics[auto_trainer.metric_for_best_model.replace("eval", "test")],
             )
+            self.assertEqual(len(copy_dev_ds), len(dev_output.label_ids))
+            self.assertEqual(len(copy_dev_ds), len(dev_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(dev_output.predictions[0]))
+
+            copy_test_ds = copy.deepcopy(self.test_ds)
+            test_output = auto_trainer.predict(test_dataset=copy_test_ds)
+            self.assertFalse(auto_trainer.metric_for_best_model.replace("eval", "test") in test_output.metrics)
+            self.assertEqual(None, test_output.label_ids)
+            self.assertEqual(len(copy_test_ds), len(test_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(test_output.predictions[0]))
 
             # test export
             temp_export_path = os.path.join(temp_dir_path, "test_export")

--- a/tests/experimental/autonlp/test_text_classification.py
+++ b/tests/experimental/autonlp/test_text_classification.py
@@ -44,7 +44,7 @@ prompt_model_candidate = {
 }
 
 
-def read_multi_label_dataset(path):
+def read_dataset(path, is_test=False):
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
             items = line.strip().split("\t")
@@ -55,7 +55,10 @@ def read_multi_label_dataset(path):
                 sentence = "".join(items[:-1])
                 label = items[-1]
                 labels = label.split(",")
-            yield {"sentence": sentence, "labels": labels}
+            if is_test:
+                yield {"sentence": sentence}
+            else:
+                yield {"sentence": sentence, "labels": labels}
 
 
 class TestAutoTrainerForTextClassification(unittest.TestCase):
@@ -72,11 +75,17 @@ class TestAutoTrainerForTextClassification(unittest.TestCase):
             lazy=False,
         )
         cls.multi_label_train_ds = load_dataset(
-            read_multi_label_dataset, path=os.path.join(fixture_path, "divorce", "train.txt"), lazy=False
+            read_dataset, path=os.path.join(fixture_path, "divorce", "train.txt"), lazy=False
         )
         cls.multi_label_dev_ds = load_dataset(
-            read_multi_label_dataset,
+            read_dataset,
             path=os.path.join(fixture_path, "divorce", "dev.txt"),
+            lazy=False,
+        )
+        cls.test_ds = load_dataset(
+            read_dataset,
+            path=os.path.join(fixture_path, "divorce", "dev.txt"),
+            is_test=True,
             lazy=False,
         )
         ray.init(local_mode=True)
@@ -151,12 +160,21 @@ class TestAutoTrainerForTextClassification(unittest.TestCase):
             )
 
             # test predict
-            copy_test_ds = copy.deepcopy(self.multi_class_dev_ds)
-            eval_metrics3 = auto_trainer.predict(test_dataset=copy_test_ds).metrics
+            dev_output = auto_trainer.predict(test_dataset=copy_dev_ds)
             self.assertEqual(
                 eval_metrics1[auto_trainer.metric_for_best_model],
-                eval_metrics3[auto_trainer.metric_for_best_model.replace("eval", "test")],
+                dev_output.metrics[auto_trainer.metric_for_best_model.replace("eval", "test")],
             )
+            self.assertEqual(len(copy_dev_ds), len(dev_output.label_ids))
+            self.assertEqual(len(copy_dev_ds), len(dev_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(dev_output.predictions[0]))
+
+            copy_test_ds = copy.deepcopy(self.test_ds)
+            test_output = auto_trainer.predict(test_dataset=copy_test_ds)
+            self.assertFalse(auto_trainer.metric_for_best_model.replace("eval", "test") in test_output.metrics)
+            self.assertEqual(None, test_output.label_ids)
+            self.assertEqual(len(copy_test_ds), len(test_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(test_output.predictions[0]))
 
             # test export
             temp_export_path = os.path.join(temp_dir_path, "test_export")
@@ -252,11 +270,14 @@ class TestAutoTrainerForTextClassification(unittest.TestCase):
 
             # test predict
             copy_test_ds = copy.deepcopy(self.multi_label_dev_ds)
-            eval_metrics3 = auto_trainer.predict(test_dataset=copy_test_ds).metrics
+            test_output = auto_trainer.predict(test_dataset=copy_test_ds)
             self.assertEqual(
                 eval_metrics1[auto_trainer.metric_for_best_model],
-                eval_metrics3[auto_trainer.metric_for_best_model.replace("eval", "test")],
+                test_output.metrics[auto_trainer.metric_for_best_model.replace("eval", "test")],
             )
+            self.assertEqual(len(copy_test_ds), len(test_output.predictions))
+            self.assertEqual(len(auto_trainer.id2label), len(test_output.predictions[0]))
+            self.assertEqual(len(copy_test_ds), len(test_output.label_ids))
 
             # test taskflow
             taskflow = auto_trainer.to_taskflow()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
 New features
### PR changes
APIs

### Description
新增predict函数
- 重写_override_hp()，这样不再虚假加上TrainingArguments等类似前缀，比如同时有prompt模型和微调模型的话，override_hp就要定义一个"TrainingArguments.max_steps": 5 和 "PromptTuningArguments.max_steps"
- 新增predict函数，修改evaluate函数，与trainer对齐
- prompttrainer evaluate函数未与trainer对齐，重写了get_eval_dataloader
-将数据预处理函数单独抽出来