### PR TITLE
fix static gpt3 generation attention_mask

### DIFF
--- a/examples/language_model/gpt-3/static/modeling.py
+++ b/examples/language_model/gpt-3/static/modeling.py
@@ -1079,7 +1079,7 @@ class GPTForGeneration(GPTPretrainedModel):
             tgt_pos = paddle.sum(attention_mask, axis=-1, keepdim=True).astype("int64")
             if len(attention_mask.shape) == 2:
                 attention_mask = paddle.unsqueeze(attention_mask, axis=[1, 2])
-            encode_mask = attention_mask + causal_mask
+            encode_mask = (1 - attention_mask) * -1e4 + causal_mask
         else:
             encode_mask = causal_mask
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
attention_mask 输入是[1, 1, 1, 0]这样形式的，修复静态图gpt3生成模型中计算encode_mask时attention_mask没有转成[0, 0, 0, -1e4] 的bug。
不过当前写法上三角+被mask部分值会是 -1e4 + -1e4 = -2e4，问题不大就是。可以将causal_mask改成 tril(ones(S, S))下三角， 然后与运算 (1 -  attention_mask & causal_mask) * -1e4 来计算。