### PR TITLE
change paddle.fluid.layers.utils to paddle.utils

### DIFF
--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.common_ops_import import convert_dtype
+
 try:
     from paddle.utils import map_structure
 except ImportError:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -21,7 +21,10 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.common_ops_import import convert_dtype
-from paddle.utils import map_structure
+try:
+    from paddle.utils import map_structure
+except ImportError:
+    from paddle.fluid.layers.utils import map_structure
 
 from paddlenlp.utils.log import logger
 

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -21,7 +21,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.common_ops_import import convert_dtype
-from paddle.fluid.layers.utils import map_structure
+from paddle.utils import map_structure
 
 from paddlenlp.utils.log import logger
 

--- a/paddlenlp/transformers/transformer/modeling.py
+++ b/paddlenlp/transformers/transformer/modeling.py
@@ -16,7 +16,10 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.utils import map_structure
+try:
+    from paddle.utils import map_structure
+except ImportError:
+    from paddle.fluid.layers.utils import map_structure
 from paddle.nn import (
     TransformerDecoder,
     TransformerDecoderLayer,

--- a/paddlenlp/transformers/transformer/modeling.py
+++ b/paddlenlp/transformers/transformer/modeling.py
@@ -16,7 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.fluid.layers.utils import map_structure
+from paddle.utils import map_structure
 from paddle.nn import (
     TransformerDecoder,
     TransformerDecoderLayer,

--- a/paddlenlp/transformers/transformer/modeling.py
+++ b/paddlenlp/transformers/transformer/modeling.py
@@ -16,6 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+
 try:
     from paddle.utils import map_structure
 except ImportError:

--- a/tests/test_tipc/transformer/modeling.py
+++ b/tests/test_tipc/transformer/modeling.py
@@ -16,7 +16,10 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.utils import map_structure
+try:
+    from paddle.utils import map_structure
+except ImportError:
+    from paddle.fluid.layers.utils import map_structure
 
 __all__ = [
     "position_encoding_init",

--- a/tests/test_tipc/transformer/modeling.py
+++ b/tests/test_tipc/transformer/modeling.py
@@ -16,7 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.fluid.layers.utils import map_structure
+from paddle.utils import map_structure
 
 __all__ = [
     "position_encoding_init",

--- a/tests/test_tipc/transformer/modeling.py
+++ b/tests/test_tipc/transformer/modeling.py
@@ -16,6 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+
 try:
     from paddle.utils import map_structure
 except ImportError:

--- a/tests/transformer/modeling.py
+++ b/tests/transformer/modeling.py
@@ -16,7 +16,10 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.utils import map_structure
+try:
+    from paddle.utils import map_structure
+except ImportError:
+    from paddle.fluid.layers.utils import map_structure
 
 __all__ = [
     "position_encoding_init",

--- a/tests/transformer/modeling.py
+++ b/tests/transformer/modeling.py
@@ -16,7 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.fluid.layers.utils import map_structure
+from paddle.utils import map_structure
 
 __all__ = [
     "position_encoding_init",

--- a/tests/transformer/modeling.py
+++ b/tests/transformer/modeling.py
@@ -16,6 +16,7 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+
 try:
     from paddle.utils import map_structure
 except ImportError:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Because of we are cleaning the code in paddle.fluid, the paddle.fluid.layers.utils now move to paddle.utils