### PR TITLE
[Neural Search] change output_emb_size to self.ptm.config.hidden_size

### DIFF
--- a/applications/neural_search/recall/in_batch_negative/base_model.py
+++ b/applications/neural_search/recall/in_batch_negative/base_model.py
@@ -33,7 +33,7 @@ class SemanticIndexBase(nn.Layer):
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
             self.emb_reduce_linear = paddle.nn.Linear(
-                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
             )
 
     def get_pooled_embedding(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
@@ -98,7 +98,7 @@ class SemanticIndexBaseStatic(nn.Layer):
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
             self.emb_reduce_linear = paddle.nn.Linear(
-                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
             )
 
     @paddle.jit.to_static(

--- a/applications/neural_search/recall/in_batch_negative/base_model.py
+++ b/applications/neural_search/recall/in_batch_negative/base_model.py
@@ -32,7 +32,9 @@ class SemanticIndexBase(nn.Layer):
         self.output_emb_size = output_emb_size
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
-            self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
+            self.emb_reduce_linear = paddle.nn.Linear(
+                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+            )
 
     def get_pooled_embedding(self, input_ids, token_type_ids=None, position_ids=None, attention_mask=None):
         _, cls_embedding = self.ptm(input_ids, token_type_ids, position_ids, attention_mask)
@@ -95,7 +97,9 @@ class SemanticIndexBaseStatic(nn.Layer):
         self.output_emb_size = output_emb_size
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
-            self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
+            self.emb_reduce_linear = paddle.nn.Linear(
+                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+            )
 
     @paddle.jit.to_static(
         input_spec=[

--- a/applications/neural_search/recall/milvus/base_model.py
+++ b/applications/neural_search/recall/milvus/base_model.py
@@ -106,7 +106,7 @@ class SemanticIndexBaseStatic(nn.Layer):
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
             self.emb_reduce_linear = paddle.nn.Linear(
-                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
             )
 
     @paddle.jit.to_static(

--- a/applications/neural_search/recall/milvus/base_model.py
+++ b/applications/neural_search/recall/milvus/base_model.py
@@ -33,7 +33,7 @@ class SemanticIndexBase(nn.Layer):
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
             self.emb_reduce_linear = paddle.nn.Linear(
-                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
             )
 
     @paddle.jit.to_static(

--- a/applications/neural_search/recall/milvus/base_model.py
+++ b/applications/neural_search/recall/milvus/base_model.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import abc
-import sys
-
-import numpy as np
 
 import paddle
 import paddle.nn as nn
@@ -35,7 +32,9 @@ class SemanticIndexBase(nn.Layer):
         self.output_emb_size = output_emb_size
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
-            self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
+            self.emb_reduce_linear = paddle.nn.Linear(
+                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+            )
 
     @paddle.jit.to_static(
         input_spec=[
@@ -106,7 +105,9 @@ class SemanticIndexBaseStatic(nn.Layer):
         self.output_emb_size = output_emb_size
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
-            self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
+            self.emb_reduce_linear = paddle.nn.Linear(
+                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+            )
 
     @paddle.jit.to_static(
         input_spec=[

--- a/applications/neural_search/recall/simcse/model.py
+++ b/applications/neural_search/recall/simcse/model.py
@@ -33,7 +33,7 @@ class SimCSE(nn.Layer):
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
             self.emb_reduce_linear = paddle.nn.Linear(
-                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
             )
 
         self.margin = margin

--- a/applications/neural_search/recall/simcse/model.py
+++ b/applications/neural_search/recall/simcse/model.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import abc
-import sys
-
-import numpy as np
 
 import paddle
 import paddle.nn as nn
@@ -36,7 +32,9 @@ class SimCSE(nn.Layer):
         self.output_emb_size = output_emb_size
         if output_emb_size > 0:
             weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.TruncatedNormal(std=0.02))
-            self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
+            self.emb_reduce_linear = paddle.nn.Linear(
+                self.ptm.config["hidden_size"], output_emb_size, weight_attr=weight_attr
+            )
 
         self.margin = margin
         # Used scaling cosine similarity to ease converge
@@ -55,7 +53,7 @@ class SimCSE(nn.Layer):
         # Note: cls_embedding is poolerd embedding with act tanh
         sequence_output, cls_embedding = self.ptm(input_ids, token_type_ids, position_ids, attention_mask)
 
-        if with_pooler == False:
+        if with_pooler is False:
             cls_embedding = sequence_output[:, 0, :]
 
         if self.output_emb_size > 0:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

+ Function optimization 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

+ APIs

### Description
<!-- Describe what this PR does -->

```
self.emb_reduce_linear = paddle.nn.Linear(768, output_emb_size, weight_attr=weight_attr)
```
Change to:

```
self.emb_reduce_linear = paddle.nn.Linear(
                self.ptm.config.hidden_size, output_emb_size, weight_attr=weight_attr
            )

```
