### PR TITLE
[Reformer P2] Add inputs_embeds and  past_key_values(cache)

### DIFF
--- a/paddlenlp/transformers/reformer/modeling.py
+++ b/paddlenlp/transformers/reformer/modeling.py
@@ -13,22 +13,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import inspect
 import sys
-from collections import namedtuple
+from dataclasses import dataclass
 from functools import reduce
 from operator import mul
+from typing import List, Optional, Tuple
 
 import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle import Tensor
 from paddle.autograd import PyLayer
 
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
 from ..activations import ACT2FN
+from ..model_outputs import (
+    BaseModelOutputWithPoolingAndCrossAttentions,
+    MaskedLMOutput,
+    ModelOutput,
+    QuestionAnsweringModelOutput,
+    SequenceClassifierOutput,
+)
 from .configuration import (
     REFORMER_PRETRAINED_INIT_CONFIGURATION,
     REFORMER_PRETRAINED_RESOURCE_FILES_MAP,
@@ -49,20 +57,6 @@ REFORMER_PRETRAINED_MODEL_ARCHIVE_LIST = [
     "reformer-crime-and-punishment",
     "reformer-enwik8",
 ]
-
-# Define named tuples for nn.Layers here
-LSHSelfAttentionOutput = namedtuple("LSHSelfAttentionOutput", ["hidden_states", "attention_probs", "buckets"])
-LocalSelfAttentionOutput = namedtuple("LocalSelfAttentionOutput", ["hidden_states", "attention_probs"])
-AttentionOutput = namedtuple("AttentionOutput", ["hidden_states", "attention_probs", "buckets"])
-ReformerOutput = namedtuple("ReformerOutput", ["hidden_states", "attn_output", "attention_probs", "buckets"])
-ReformerBackwardOutput = namedtuple(
-    "ReformerBackwardOutput",
-    ["attn_output", "hidden_states", "grad_attn_output", "grad_hidden_states"],
-)
-ReformerEncoderOutput = namedtuple(
-    "ReformerEncoderOutput",
-    ["hidden_states", "all_hidden_states", "all_attentions", "cache"],
-)
 
 
 def _logsumexp(x, axis=-1, keepdim=False):
@@ -461,13 +455,24 @@ class ReformerEmbeddings(nn.Layer):
             AxialPositionEmbeddings(config) if config.axial_pos_embds else PositionEmbeddings(config)
         )
 
-    def forward(self, input_ids, position_ids=None, start_idx_pos_encodings=0):
-        seq_length = input_ids.shape[1]
-        if position_ids is None:
-            position_ids = paddle.arange(start_idx_pos_encodings, start_idx_pos_encodings + seq_length)
-            position_ids = position_ids.unsqueeze(0).expand_as(input_ids)
+    def forward(
+        self,
+        input_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        start_idx_pos_encodings=0,
+        inputs_embeds: Optional[Tensor] = None,
+    ):
 
-        inputs_embeds = self.word_embeddings(input_ids)
+        if input_ids is not None:
+            inputs_embeds = self.word_embeddings(input_ids)
+
+        input_shape = paddle.shape(inputs_embeds)[:-1]
+
+        if position_ids is None:
+            ones = paddle.ones(input_shape, dtype="int64")
+            seq_length = paddle.cumsum(ones, axis=1)
+            position_ids = start_idx_pos_encodings + seq_length - start_idx_pos_encodings - ones
+            position_ids.stop_gradient = True
 
         if position_ids.shape[-1] > self.max_position_embeddings:
             raise ValueError(
@@ -475,12 +480,11 @@ class ReformerEmbeddings(nn.Layer):
                 f"max_position_embeddings {self.max_position_embeddings}."
             )
 
-        # dropout
-        embeddings = F.dropout(inputs_embeds, p=self.dropout, training=self.training)
-
         # add positional embeddings
         position_embeddings = self.position_embeddings(position_ids)
-        embeddings = embeddings + position_embeddings
+        embeddings = inputs_embeds + position_embeddings
+        # dropout
+        embeddings = F.dropout(embeddings, p=self.dropout, training=self.training)
         return embeddings
 
 
@@ -546,7 +550,6 @@ class EfficientAttentionMixin:
 class LSHSelfAttention(nn.Layer, EfficientAttentionMixin):
     def __init__(self, config: ReformerConfig):
         super().__init__()
-        self.config = config
 
         self.chunk_length = config.lsh_attn_chunk_length
         self.num_hashes = config.num_hashes
@@ -1895,11 +1898,14 @@ class ReformerOnlyLMHead(nn.Layer):
 class ReformerClassificationHead(nn.Layer):
     """Head for sentence-level classification tasks."""
 
-    def __init__(self, hidden_size, classifier_dropout, num_classes):
+    def __init__(self, config):
         super().__init__()
-        self.dense = nn.Linear(2 * hidden_size, hidden_size)
+        self.dense = nn.Linear(2 * config.hidden_size, config.hidden_size)
+        classifier_dropout = (
+            config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
+        )
         self.dropout = nn.Dropout(classifier_dropout)
-        self.out_proj = nn.Linear(hidden_size, num_classes)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_classes)
 
     def forward(self, hidden_states):
         hidden_states = hidden_states[:, 0]  # take <s> token (equiv. to [CLS])
@@ -1909,6 +1915,50 @@ class ReformerClassificationHead(nn.Layer):
         hidden_states = self.dropout(hidden_states)
         hidden_states = self.out_proj(hidden_states)
         return hidden_states
+
+
+@dataclass
+class LSHSelfAttentionOutput(ModelOutput):
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    attention_probs: Optional[Tuple[paddle.Tensor]] = None
+    buckets: Optional[Tuple[paddle.Tensor]] = None
+
+
+@dataclass
+class LocalSelfAttentionOutput(ModelOutput):
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    attention_probs: Optional[Tuple[paddle.Tensor]] = None
+
+
+@dataclass
+class AttentionOutput(ModelOutput):
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    attention_probs: Optional[Tuple[paddle.Tensor]] = None
+    buckets: Optional[Tuple[paddle.Tensor]] = None
+
+
+@dataclass
+class ReformerOutput(ModelOutput):
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    attn_output: Optional[Tuple[paddle.Tensor]] = None
+    attention_probs: Optional[Tuple[paddle.Tensor]] = None
+    buckets: Optional[Tuple[paddle.Tensor]] = None
+
+
+@dataclass
+class ReformerBackwardOutput(ModelOutput):
+    attn_output: Optional[Tuple[paddle.Tensor]] = None
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    grad_attn_output: Optional[Tuple[paddle.Tensor]] = None
+    grad_hidden_states: Optional[Tuple[paddle.Tensor]] = None
+
+
+@dataclass
+class ReformerEncoderOutput(ModelOutput):
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    all_hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    all_attentions: Optional[Tuple[paddle.Tensor]] = None
+    cache: Optional[Tuple[paddle.Tensor]] = None
 
 
 class ReformerPretrainedModel(PretrainedModel):
@@ -1941,7 +1991,7 @@ class ReformerPretrainedModel(PretrainedModel):
         tie_word_embeddings = (
             self.tie_word_embeddings
             if hasattr(self, "tie_word_embeddings")
-            else self.reformer.config.get("tie_word_embeddings", False)
+            else self.config.get("tie_word_embeddings", False)
         )
         if hasattr(self, "get_output_embeddings") and hasattr(self, "get_input_embeddings") and tie_word_embeddings:
             output_embeddings = self.get_output_embeddings()
@@ -1981,9 +2031,7 @@ class ReformerPretrainedModel(PretrainedModel):
                 weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.axial_norm_std
-                        if hasattr(self, "axial_norm_std")
-                        else self.reformer.config["axial_norm_std"],
+                        std=self.config.axial_norm_std,
                         shape=weight.shape,
                     )
                 )
@@ -1992,9 +2040,7 @@ class ReformerPretrainedModel(PretrainedModel):
             layer.weight.set_value(
                 paddle.tensor.normal(
                     mean=0.0,
-                    std=self.initializer_range
-                    if hasattr(self, "initializer_range")
-                    else self.reformer.config["initializer_range"],
+                    std=self.config.initializer_range,
                     shape=layer.weight.shape,
                 )
             )
@@ -2004,9 +2050,7 @@ class ReformerPretrainedModel(PretrainedModel):
             layer.weight.set_value(
                 paddle.tensor.normal(
                     mean=0.0,
-                    std=self.axial_norm_std
-                    if hasattr(self, "axial_norm_std")
-                    else self.reformer.config["axial_norm_std"],
+                    std=self.config.axial_norm_std,
                     shape=layer.weight.shape,
                 )
             )
@@ -2118,7 +2162,6 @@ class ReformerModel(ReformerPretrainedModel):
 
     def __init__(self, config: ReformerConfig):
         super().__init__(config)
-        self.config = config
         assert (
             self.config.num_hidden_layers > 0
         ), "`config.attn_layers` is empty. Select at least one attn layer form ['lsh', 'local']"
@@ -2135,14 +2178,16 @@ class ReformerModel(ReformerPretrainedModel):
 
     def forward(
         self,
-        input_ids=None,
-        attention_mask=None,
-        position_ids=None,
-        num_hashes=None,
-        cache=None,
-        use_cache=False,
-        output_hidden_states=False,
-        output_attentions=False,
+        input_ids: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        num_hashes: Optional[int] = None,
+        cache: Optional[List[Tuple[Tensor]]] = None,
+        use_cache: Optional[bool] = False,
+        inputs_embeds: Optional[Tensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ):
         r"""
         The ReformerModel forward method, overrides the `__call__()` special method.
@@ -2181,40 +2226,24 @@ class ReformerModel(ReformerPretrainedModel):
                 Whether or not to use cache. If set to `True`, `cache` states are returned
                 and can be used to speed up decoding.
                 Defaults to `False`.
+            inputs_embeds (Tensor, optional):
+                If you want to control how to convert `inputs_ids` indices into associated vectors, you can
+                pass an embedded representation directly instead of passing `inputs_ids`.
             output_attentions (bool, optional):
                 Whether or not to return the attentions tensors of all attention layers.
                 Defaults to `False`.
             output_hidden_states (bool, optional):
                 Whether or not to return the output of all hidden layers.
                 Defaults to `False`.
+            return_dict (bool, optional):
+                Whether to return a :class:`~paddlenlp.transformers.model_outputs.ModelOutput` object. If `False`, the output
+                will be a tuple of tensors. Defaults to `False`.
 
         Returns:
-            tuple: Returns tuple (`last_hidden_state`, `cache`, `hidden_states`, `attentions`)
-
-            With the fields:
-
-            - `last_hidden_state` (Tensor):
-                Sequence of hidden-states at the last layer of the model.
-                It's data type should be float32 and
-                its shape is [batch_size, sequence_length, hidden_size].
-
-            - `cache` (List[tuple(Tensor, Tensor)], optional):
-                returned when `use_cache=True` is passed.
-                List of `tuple(Tensor, Tensor)` of length `config["num_hidden_layers"]`,
-                with the first element being the previous `buckets` of shape
-                `[batch_size, num_heads, num_hashes, sequence_length]` and the second
-                being the previous `hidden_states` of shape `[batch_size, sequence_length, hidden_size]`.
-
-            - `hidden_states` (tuple(Tensor), optional):
-                returned when `output_hidden_states=True` is passed.
-                tuple of `Tensor` (one for the output of the embeddings + one for the
-                output of each layer). Each Tensor has a data type of float32
-                and its shape is [batch_size, sequence_length, hidden_size].
-
-            - `attentions` (tuple(Tensor), optional):
-                returned when `output_attentions=True` is passed.
-                tuple of `Tensor` (one for each layer) of shape. Each Tensor has a data
-                type of float32 and its shape is [batch_size, num_heads, sequence_length, sequence_length].
+            An instance of :class:`~paddlenlp.transformers.model_outputs.BaseModelOutputWithPoolingAndCrossAttentions` if
+            `return_dict=True`. Otherwise it returns a tuple of tensors corresponding
+            to ordered and not None (depending on the input arguments) fields of
+            :class:`~paddlenlp.transformers.model_outputs.BaseModelOutputWithPoolingAndCrossAttentions`.
 
         Example:
             .. code-block::
@@ -2226,15 +2255,25 @@ class ReformerModel(ReformerPretrainedModel):
                 model = ReformerModel.from_pretrained('reformer-crime-and-punishment')
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
 
                 outputs = model(**inputs)
                 last_hidden_state = outputs[0]
 
         """
+        output_attentions = output_attentions if output_attentions is not None else False
+        output_hidden_states = output_hidden_states if output_hidden_states is not None else False
+        return_dict = return_dict if return_dict is not None else False
 
-        input_shape = input_ids.shape
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        elif input_ids is not None:
+            input_shape = input_ids.shape  # noqa: F841
+        elif inputs_embeds is not None:
+            input_shape = inputs_embeds.shape[:-1]  # noqa: F841
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
 
         assert (
             len(input_shape) == 2
@@ -2271,8 +2310,9 @@ class ReformerModel(ReformerPretrainedModel):
                 )
 
             # pad input
-            (input_ids, attention_mask, position_ids, input_shape,) = self._pad_to_mult_of_chunk_length(
+            input_ids, inputs_embeds, attention_mask, position_ids, input_shape = self._pad_to_mult_of_chunk_length(
                 input_ids,
+                inputs_embeds=inputs_embeds,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
                 input_shape=input_shape,
@@ -2290,6 +2330,7 @@ class ReformerModel(ReformerPretrainedModel):
             input_ids=input_ids,
             position_ids=position_ids,
             start_idx_pos_encodings=start_idx_pos_encodings,
+            inputs_embeds=inputs_embeds,
         )
 
         encoder_outputs = self.encoder(
@@ -2312,34 +2353,44 @@ class ReformerModel(ReformerPretrainedModel):
         hidden_states = encoder_outputs.all_hidden_states if output_hidden_states else None
         attentions = encoder_outputs.all_attentions if output_attentions else None
 
-        return tuple(
-            v
-            for v in [
-                sequence_output,
-                cache,
-                hidden_states,
-                attentions,
-            ]
-            if v is not None
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    sequence_output,
+                    cache,
+                    hidden_states,
+                    attentions,
+                ]
+                if v is not None
+            )
+
+        return BaseModelOutputWithPoolingAndCrossAttentions(
+            last_hidden_state=sequence_output,
+            past_key_values=cache,
+            hidden_states=hidden_states,
+            attentions=attentions,
         )
 
     def _pad_to_mult_of_chunk_length(
         self,
         input_ids,
+        inputs_embeds=None,
         attention_mask=None,
         position_ids=None,
         input_shape=None,
         padding_length=None,
         padded_seq_length=None,
+        device=None,
     ):
         logger.info(
             f"Input ids are automatically padded from {input_shape[-1]} to {input_shape[-1] + padding_length} to be a "
-            f"multiple of `chunk_length`: {padded_seq_length}"
+            f"multiple of `config.chunk_length`: {padded_seq_length}"
         )
 
         padded_input_ids = paddle.full(
             (input_shape[0], padding_length),
-            self.pad_token_id,
+            self.config.pad_token_id,
             dtype=paddle.int64,
         )
 
@@ -2352,21 +2403,28 @@ class ReformerModel(ReformerPretrainedModel):
             attention_mask = paddle.concat(
                 [
                     paddle.ones(input_shape, dtype=paddle.int64),
-                    paddle.zeros(shape=(input_shape[0], padding_length), dtype=paddle.int64),
+                    paddle.zeros((input_shape[0], padding_length), dtype=paddle.int64),
                 ],
                 axis=-1,
             )
 
-        input_ids = paddle.concat([paddle.cast(input_ids, dtype="int64"), padded_input_ids], axis=-1)
-        input_shape = input_ids.shape
+        # Extend `input_ids` with padding to match least common multiple chunk_length
+        if input_ids is not None:
+            input_ids = paddle.concat([paddle.cast(input_ids, dtype="int64"), padded_input_ids], axis=-1)
+            input_shape = input_ids.shape
 
-        # Pad position ids if given
-        if position_ids is not None:
-            padded_position_ids = paddle.arange(input_shape[-1], padded_seq_length)
-            padded_position_ids = position_ids.unsqueeze(0).expand(shape=[input_shape[0], padding_length])
-            position_ids = paddle.concat([position_ids, padded_position_ids], axis=-1)
+            # Pad position ids if given
+            if position_ids is not None:
+                padded_position_ids = paddle.arange(input_shape[-1], padded_seq_length, dtype=paddle.int64)
+                padded_position_ids = position_ids.unsqueeze(0).expand(input_shape[0], padding_length)
+                position_ids = paddle.concat([position_ids, padded_position_ids], axis=-1)
 
-        return input_ids, attention_mask, position_ids, input_shape
+        # Extend `inputs_embeds` with padding to match least common multiple chunk_length
+        if inputs_embeds is not None:
+            padded_inputs_embeds = self.embeddings(padded_input_ids, position_ids)
+            inputs_embeds = paddle.concat([inputs_embeds, padded_inputs_embeds], axis=-2)
+            input_shape = inputs_embeds.shape
+        return input_ids, inputs_embeds, attention_mask, position_ids, input_shape
 
 
 class ReformerModelWithLMHead(ReformerPretrainedModel):
@@ -2382,22 +2440,22 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
     def __init__(self, config: ReformerConfig):
         super().__init__(config)
         self.reformer = ReformerModel(config)
-        local_num_chunks_after = self.reformer.config["local_num_chunks_after"]
-        lsh_num_chunks_after = self.reformer.config["lsh_num_chunks_after"]
-        assert self.reformer.config[
+        local_num_chunks_after = self.config.local_num_chunks_after
+        lsh_num_chunks_after = self.config.lsh_num_chunks_after
+        assert self.config[
             "is_decoder"
         ], "If you want to use `ReformerModelWithLMHead` make sure that `is_decoder=True`."
         assert (
-            "local" not in self.reformer.config["attn_layers"] or local_num_chunks_after == 0
+            "local" not in self.config.attn_layers or local_num_chunks_after == 0
         ), f"If causal mask is enabled, make sure that `local_num_chunks_after` is set to 0 and not {local_num_chunks_after}."
         assert (
-            "lsh" not in self.reformer.config["attn_layers"] or lsh_num_chunks_after == 0
+            "lsh" not in self.config.attn_layers or lsh_num_chunks_after == 0
         ), f"If causal mask is enabled, make sure that `lsh_num_chunks_after` is set to 1 and not {lsh_num_chunks_after}."
 
         """self.lm_head = ReformerOnlyLMHead(
-            chunk_size_lm_head=self.reformer.config["chunk_size_lm_head"],
-            hidden_size=self.reformer.config["hidden_size"],
-            vocab_size=self.reformer.config["vocab_size"],
+            chunk_size_lm_head=self.config.chunk_size_lm_head,
+            hidden_size=self.config.hidden_size,
+            vocab_size=self.config.vocab_size,
         )"""
         self.lm_head = ReformerOnlyLMHead(config)
 
@@ -2411,15 +2469,16 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
 
     def forward(
         self,
-        input_ids=None,
-        position_ids=None,
-        attention_mask=None,
-        num_hashes=None,
-        cache=None,
-        use_cache=False,
-        labels=None,
-        output_hidden_states=False,
-        output_attentions=False,
+        input_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        num_hashes: Optional[int] = None,
+        cache: Optional[List[Tuple[Tensor]]] = None,
+        use_cache: Optional[bool] = False,
+        inputs_embeds: Optional[Tensor] = None,
+        labels: Optional[Tensor] = None,
+        output_hidden_states: Optional[Tensor] = None,
+        output_attentions: Optional[Tensor] = None,
     ):
         r"""
 
@@ -2436,6 +2495,8 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
                 See :class:`ReformerModel`.
             use_cache (bool, optional):
                 See :class:`ReformerModel`.
+            inputs_embeds (Tensor, optional):
+                See :class:`NeZhaModel`.
             labels (Tensor, optional):
                 Labels for language modeling. Note that the labels **are shifted**
                 inside the model, i.e. you can set `labels = input_ids` Indices are
@@ -2482,7 +2543,7 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
                 model = ReformerModelWithLMHead.from_pretrained('reformer-crime-and-punishment')
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=inputs["input_ids"])
 
@@ -2498,6 +2559,7 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
             num_hashes=num_hashes,
             cache=cache,
             use_cache=use_cache,
+            inputs_embeds=inputs_embeds,
             output_hidden_states=output_hidden_states,
             output_attentions=output_attentions,
         )
@@ -2513,7 +2575,7 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
 
             loss_fct = nn.CrossEntropyLoss()
             loss = loss_fct(
-                shift_logits.reshape(shape=[-1, self.reformer.config["vocab_size"]]),
+                shift_logits.reshape(shape=[-1, self.config.vocab_size]),
                 shift_labels.flatten(),
             )
 
@@ -2548,7 +2610,7 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
     def __init__(self, config: ReformerConfig):
         super().__init__(config)
         self.reformer = ReformerModel(config)
-        assert not self.reformer.config[
+        assert not self.config[
             "is_decoder"
         ], "If you want to use `ReformerForMaskedLM` make sure `is_decoder=False` for bi-directional self-attention."
         self.lm_head = ReformerOnlyLMHead(config)
@@ -2562,13 +2624,15 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
 
     def forward(
         self,
-        input_ids=None,
-        position_ids=None,
-        attention_mask=None,
-        num_hashes=None,
-        labels=None,
-        output_hidden_states=False,
-        output_attentions=False,
+        input_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        num_hashes: Optional[int] = None,
+        inputs_embeds: Optional[Tensor] = None,
+        labels: Optional[Tensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ):
         r"""
 
@@ -2581,6 +2645,8 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
                 See :class:`ReformerModel`.
             num_hashes (int, optional):
                 See :class:`ReformerModel`.
+            inputs_embeds (Tensor, optional):
+                See :class:`NeZhaModel`.
             labels (Tensor, optional):
                 Labels for computing the masked language modeling loss.
                 Indices should be in ``[-100, 0, ..., vocab_size]``
@@ -2592,6 +2658,9 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
                 See :class:`ReformerModel`.
             output_hidden_states (bool, optional):
                 See :class:`ReformerModel`.
+            return_dict (bool, optional):
+                Whether to return a :class:`~paddlenlp.transformers.model_outputs.MaskedLMOutput` object. If
+                `False`, the output will be a tuple of tensors. Defaults to `False`.
 
         Returns:
             tuple: Returns tuple `(loss, logits, hidden_states, attentions)`.
@@ -2625,7 +2694,7 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
                 model = ReformerForMaskedLM.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=inputs["input_ids"])
 
@@ -2633,6 +2702,7 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
                 logits = output[1]
 
         """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         reformer_outputs = self.reformer(
             input_ids,
@@ -2640,8 +2710,10 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
             attention_mask=attention_mask,
             num_hashes=num_hashes,
             use_cache=False,  # no causal mask
+            inputs_embeds=inputs_embeds,
             output_hidden_states=output_hidden_states,
             output_attentions=output_attentions,
+            return_dict=return_dict,
         )
 
         sequence_output = reformer_outputs[0]
@@ -2651,12 +2723,20 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
         if labels is not None:
             loss_fct = nn.CrossEntropyLoss()  # -100 index = padding token
             masked_lm_loss = loss_fct(
-                logits.reshape(shape=[-1, self.reformer.config["vocab_size"]]),
+                logits.reshape(shape=[-1, self.config.vocab_size]),
                 labels.flatten(),
             )
 
-        output = (logits,) + reformer_outputs[1:]
-        return ((masked_lm_loss,) + output) if masked_lm_loss is not None else output
+        if not return_dict:
+            output = (logits,) + reformer_outputs[1:]
+            return ((masked_lm_loss,) + output) if masked_lm_loss is not None else output
+
+        return MaskedLMOutput(
+            loss=masked_lm_loss,
+            logits=logits,
+            hidden_states=reformer_outputs.hidden_states,
+            attentions=reformer_outputs.attentions,
+        )
 
 
 class ReformerForSequenceClassification(ReformerPretrainedModel):
@@ -2679,27 +2759,23 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
         super().__init__(config)
         self.reformer = ReformerModel(config)
         self.num_classes = config.num_classes
-        dropout = None
-        classifier_dropout = dropout if dropout is not None else self.reformer.config["hidden_dropout_prob"]
-        self.classifier = ReformerClassificationHead(
-            hidden_size=self.reformer.config["hidden_size"],
-            classifier_dropout=classifier_dropout,
-            num_classes=config.num_classes,
-        )
-        if self.reformer.config["is_decoder"] is True:
+        self.classifier = ReformerClassificationHead(config)
+        if self.config.is_decoder:
             logger.warning("You might want to disable causal masking for sequence classification")
 
         self.init_weights()
 
     def forward(
         self,
-        input_ids=None,
-        position_ids=None,
-        attention_mask=None,
-        num_hashes=None,
-        labels=None,
-        output_hidden_states=False,
-        output_attentions=False,
+        input_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        num_hashes: Optional[int] = None,
+        inputs_embeds: Optional[Tensor] = None,
+        labels: Optional[Tensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ):
         r"""
 
@@ -2712,6 +2788,8 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 See :class:`ReformerModel`.
             num_hashes (int, optional):
                 See :class:`ReformerModel`.
+            inputs_embeds (Tensor, optional):
+                See :class:`NeZhaModel`.
             labels (Tensor, optional):
                 Labels for computing the sequence classification/regression loss. Indices
                 should be in `[0, ...,num_classes - 1]`. If `num_classes == 1` a regression
@@ -2722,6 +2800,9 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 See :class:`ReformerModel`.
             output_hidden_states (bool, optional):
                 See :class:`ReformerModel`.
+            return_dict (bool, optional):
+                Whether to return a :class:`~paddlenlp.transformers.model_outputs.SequenceClassifierOutput` object. If
+                `False`, the output will be a tuple of tensors. Defaults to `False`.
 
         Returns:
             tuple: Returns tuple `(loss, logits, hidden_states, attentions)`.
@@ -2753,7 +2834,7 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 model = ReformerForSequenceClassification.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=paddle.to_tensor([0]))
 
@@ -2761,14 +2842,17 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 logits = output[1]
 
         """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.reformer(
             input_ids,
             position_ids=position_ids,
             attention_mask=attention_mask,
             num_hashes=num_hashes,
+            inputs_embeds=inputs_embeds,
             output_hidden_states=output_hidden_states,
             output_attentions=output_attentions,
+            return_dict=return_dict,
         )
 
         sequence_output = outputs[0]
@@ -2784,8 +2868,16 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 loss_fct = nn.CrossEntropyLoss()
                 loss = loss_fct(logits.reshape([-1, self.num_classes]), labels.flatten())
 
-        output = (logits,) + outputs[1:]
-        return ((loss,) + output) if loss is not None else output
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
 
 
 class ReformerForQuestionAnswering(ReformerPretrainedModel):
@@ -2805,25 +2897,25 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
 
     def __init__(self, config: ReformerConfig):
         super().__init__(config)
-        dropout = (None,)
         self.reformer = ReformerModel(config)
-        self.dropout = nn.Dropout(dropout if dropout is not None else self.reformer.config["hidden_dropout_prob"])
         # 2 * hidden_size because we use reversible residual layers
-        self.qa_outputs = nn.Linear(2 * self.reformer.config["hidden_size"], 2)
-        if self.reformer.config["is_decoder"] is True:
+        self.qa_outputs = nn.Linear(2 * self.config.hidden_size, 2)
+        if self.config.is_decoder:
             logger.warning("You might want to disable causal masking for question answering task.")
         self.init_weights()
 
     def forward(
         self,
-        input_ids=None,
-        position_ids=None,
-        attention_mask=None,
-        num_hashes=None,
-        start_positions=None,
-        end_positions=None,
-        output_hidden_states=False,
-        output_attentions=False,
+        input_ids: Optional[Tensor] = None,
+        position_ids: Optional[Tensor] = None,
+        attention_mask: Optional[Tensor] = None,
+        num_hashes: Optional[int] = None,
+        start_positions: Optional[Tensor] = None,
+        end_positions: Optional[Tensor] = None,
+        inputs_embeds: Optional[Tensor] = None,
+        output_hidden_states: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
     ):
         r"""
 
@@ -2850,10 +2942,16 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
                 (`sequence_length`). Position outside of the sequence
                 are not taken into account for computing the loss.
                 Shape is [batch_size,] and dtype is int64.
+            inputs_embeds (Tensor, optional):
+                See :class:`NeZhaModel`.
             output_attentions (bool, optional):
                 See :class:`ReformerModel`.
             output_hidden_states (bool, optional):
                 See :class:`ReformerModel`.
+            return_dict (bool, optional):
+                Whether to return a :class:`~paddlenlp.transformers.model_outputs.QuestionAnsweringModelOutput` object. If
+                `False`, the output will be a tuple of tensors. Defaults to `False`.
+
 
         Returns:
             tuple: Returns tuple `(loss, logits, hidden_states, attentions)`.
@@ -2891,7 +2989,7 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
                 model = ReformerForQuestionAnswering.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs)
 
@@ -2899,6 +2997,7 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
                 end_logits = outputs[1]
 
         """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         reformer_outputs = self.reformer(
             input_ids,
@@ -2906,8 +3005,10 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
             attention_mask=attention_mask,
             num_hashes=num_hashes,
             use_cache=False,  # no causal mask
+            inputs_embeds=inputs_embeds,
             output_hidden_states=output_hidden_states,
             output_attentions=output_attentions,
+            return_dict=return_dict,
         )
 
         sequence_output = reformer_outputs[0]
@@ -2929,5 +3030,14 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
             end_loss = loss_fct(end_logits, end_positions)
             total_loss = (start_loss + end_loss) / 2
 
-        output = (start_logits, end_logits) + reformer_outputs[1:]
-        return ((total_loss,) + output) if total_loss is not None else output
+        if not return_dict:
+            output = (start_logits, end_logits) + reformer_outputs[1:]
+            return ((total_loss,) + output) if total_loss is not None else output
+
+        return QuestionAnsweringModelOutput(
+            loss=total_loss,
+            start_logits=start_logits,
+            end_logits=end_logits,
+            hidden_states=reformer_outputs.hidden_states,
+            attentions=reformer_outputs.attentions,
+        )

--- a/tests/transformers/reformer/test_modeling.py
+++ b/tests/transformers/reformer/test_modeling.py
@@ -17,6 +17,7 @@ import unittest
 
 import paddle
 import paddle.nn as nn
+from parameterized import parameterized_class
 
 from paddlenlp.transformers import (
     ReformerForMaskedLM,
@@ -199,6 +200,8 @@ class ReformerModelTester:
         model.eval()
         result = model(input_ids, attention_mask=input_mask)
         result = model(input_ids)
+        result = model(input_ids, attention_mask=input_mask, return_dict=self.parent.return_dict)
+        result = model(input_ids, return_dict=self.parent.return_dict)
 
         # 2 * hidden_size because we use reversible resnet layers
         self.parent.assertEqual(result[0].shape, [self.batch_size, self.seq_length, 2 * self.hidden_size])
@@ -213,7 +216,7 @@ class ReformerModelTester:
         config.lsh_num_chunks_after = 1
         model = ReformerForMaskedLM(config=config)
         model.train()
-        loss = model(input_ids, attention_mask=input_mask, labels=input_ids)[0]
+        loss = model(input_ids, attention_mask=input_mask, labels=input_ids, return_dict=self.parent.return_dict)[0]
         loss.backward()
 
     def create_and_check_reformer_with_lm(self, config: ReformerConfig, input_ids, input_mask, choice_labels):
@@ -228,7 +231,7 @@ class ReformerModelTester:
         config.is_decoder = False
         model = ReformerForMaskedLM(config=config)
         model.eval()
-        result = model(input_ids, attention_mask=input_mask, labels=input_ids)
+        result = model(input_ids, attention_mask=input_mask, labels=input_ids, return_dict=self.parent.return_dict)
         self.parent.assertEqual(result[1].shape, [self.batch_size, self.seq_length, self.vocab_size])
 
     def create_and_check_reformer_model_with_attn_mask(
@@ -275,10 +278,14 @@ class ReformerModelTester:
         input_ids_roll = paddle.roll(input_ids_roll, roll, axis=-1)
         attn_mask_roll = paddle.roll(attn_mask, roll, axis=-1)
 
-        output_padded = model(input_ids_padded, attention_mask=attn_mask)[0][:, :half_seq_len]
-        output_padded_rolled = model(input_ids_roll, attention_mask=attn_mask_roll)[0][:, roll : half_seq_len + roll]
+        output_padded = model(input_ids_padded, attention_mask=attn_mask, return_dict=self.parent.return_dict)[0][
+            :, :half_seq_len
+        ]
+        output_padded_rolled = model(
+            input_ids_roll, attention_mask=attn_mask_roll, return_dict=self.parent.return_dict
+        )[0][:, roll : half_seq_len + roll]
 
-        self.parent.assertTrue(paddle.allclose(output_padded, output_padded_rolled, atol=1e-3))
+        self.parent.assertTrue(paddle.allclose(output_padded, output_padded_rolled, atol=1e-4))
 
     def create_and_check_reformer_layer_dropout_seed(
         self, config: ReformerConfig, input_ids, input_mask, choice_labels, is_decoder=False
@@ -309,7 +316,7 @@ class ReformerModelTester:
             paddle.allclose(
                 prev_attn_output + attn_outputs.hidden_states,
                 next_attn_output,
-                atol=1e-3,
+                atol=1e-4,
             )
         )
 
@@ -319,7 +326,7 @@ class ReformerModelTester:
             paddle.allclose(
                 next_hidden_states,
                 hidden_states + feed_forward_hidden_states,
-                atol=1e-3,
+                atol=1e-4,
             )
         )
 
@@ -339,7 +346,9 @@ class ReformerModelTester:
         paddle.seed(0)
         model = ReformerForMaskedLM(config=config)
         model.train()
-        loss_no_chunk, output_no_chunk = model(input_ids, labels=input_ids, attention_mask=input_mask)[:2]
+        loss_no_chunk, output_no_chunk = model(
+            input_ids, labels=input_ids, attention_mask=input_mask, return_dict=self.parent.return_dict
+        )[:2]
         loss_no_chunk.backward()
         grad_slice_word_no_chunk = model.reformer.embeddings.word_embeddings.weight.grad[0, :5]
         grad_slice_position_factor_1_no_chunk = model.reformer.embeddings.position_embeddings.weights[0][1, 0, -5:]
@@ -351,18 +360,20 @@ class ReformerModelTester:
         paddle.seed(0)
         model = ReformerForMaskedLM(config=config)
         model.train()
-        loss_chunk, output_chunk = model(input_ids, labels=input_ids, attention_mask=input_mask)[:2]
+        loss_chunk, output_chunk = model(
+            input_ids, labels=input_ids, attention_mask=input_mask, return_dict=self.parent.return_dict
+        )[:2]
         loss_chunk.backward()
         grad_slice_word_chunk = model.reformer.embeddings.word_embeddings.weight.grad[0, :5]
         grad_slice_position_factor_1_chunk = model.reformer.embeddings.position_embeddings.weights[0][1, 0, -5:]
         grad_slice_position_factor_2_chunk = model.reformer.embeddings.position_embeddings.weights[1][0, 1, :5]
-        self.parent.assertTrue(paddle.allclose(loss_chunk, loss_no_chunk, atol=1e-3))
-        self.parent.assertTrue(paddle.allclose(grad_slice_word_no_chunk, grad_slice_word_chunk, atol=1e-3))
+        self.parent.assertTrue(paddle.allclose(loss_chunk, loss_no_chunk, atol=1e-4))
+        self.parent.assertTrue(paddle.allclose(grad_slice_word_no_chunk, grad_slice_word_chunk, atol=1e-4))
         self.parent.assertTrue(
-            paddle.allclose(grad_slice_position_factor_1_chunk, grad_slice_position_factor_1_no_chunk, atol=1e-3)
+            paddle.allclose(grad_slice_position_factor_1_chunk, grad_slice_position_factor_1_no_chunk, atol=1e-4)
         )
         self.parent.assertTrue(
-            paddle.allclose(grad_slice_position_factor_2_chunk, grad_slice_position_factor_2_no_chunk, atol=1e-3)
+            paddle.allclose(grad_slice_position_factor_2_chunk, grad_slice_position_factor_2_no_chunk, atol=1e-4)
         )
 
     def create_and_check_reformer_model_generate(self, config: ReformerConfig, input_ids, input_mask, choice_labels):
@@ -385,11 +396,13 @@ class ReformerModelTester:
         config.is_decoder = False
         model = ReformerForMaskedLM(config=config)
         model.eval()
-        output_logits = model(input_ids, attention_mask=input_mask)  # (loss, logits, hidden_states, attentions)
+        output_logits = model(
+            input_ids, attention_mask=input_mask, return_dict=self.parent.return_dict
+        )  # (loss, logits, hidden_states, attentions)
         self.parent.assertTrue(output_logits[0].shape[1] == input_ids.shape[-1])
 
     def create_and_check_reformer_for_question_answering(
-        self, config: ReformerConfig, input_ids, input_mask, choice_labels
+        self, config: ReformerConfig, input_ids, input_mask, choice_labels, sequence_labels
     ):
         model = ReformerForQuestionAnswering(config=config)
         model.eval()
@@ -398,9 +411,14 @@ class ReformerModelTester:
             attention_mask=input_mask,
             start_positions=choice_labels,
             end_positions=choice_labels,
+            return_dict=self.parent.return_dict,
         )
-        self.parent.assertEqual(result[1].shape, [self.batch_size, self.seq_length])
-        self.parent.assertEqual(result[2].shape, [self.batch_size, self.seq_length])
+        if sequence_labels is not None:
+            start_logits, end_logits = result[1], result[2]
+        else:
+            start_logits, end_logits = result[0], result[1]
+        self.parent.assertEqual(start_logits.shape, [self.batch_size, self.seq_length])
+        self.parent.assertEqual(end_logits.shape, [self.batch_size, self.seq_length])
 
     def create_and_check_cache(self, config: ReformerConfig, input_ids, input_mask, choice_labels):
         config.is_decoder = True
@@ -441,10 +459,25 @@ class ReformerModelTester:
         sequence_labels = ids_tensor([self.batch_size], config.num_labels)
         model = ReformerForSequenceClassification(config)
         model.eval()
-        result = model(input_ids, attention_mask=input_mask, labels=sequence_labels)
-        self.parent.assertEqual(result[1].shape, [self.batch_size, self.num_labels])
+        result = model(
+            input_ids, attention_mask=input_mask, labels=sequence_labels, return_dict=self.parent.return_dict
+        )
+        if sequence_labels is not None:
+            result = result[1:]
+        elif paddle.is_tensor(result):
+            result = [result]
+        self.parent.assertEqual(result[0].shape, [self.batch_size, self.num_labels])
 
 
+@parameterized_class(
+    ("return_dict", "use_labels"),
+    [
+        [False, False],
+        [False, True],
+        [True, False],
+        [True, True],
+    ],
+)
 class ReformerTesterMixin:
     """
     Reformer Local and Reformer LSH run essentially the same tests
@@ -491,10 +524,9 @@ class ReformerTesterMixin:
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_reformer_for_question_answering(*config_and_inputs)
 
-    """todo:
-        def test_reformer_cached_inference(self):
+    def test_reformer_cached_inference(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_cache(*config_and_inputs)"""
+        self.model_tester.create_and_check_cache(*config_and_inputs)
 
     def test_reformer_cached_generate(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
@@ -518,6 +550,9 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, ModelTesterMixin, unittest
     test_torchscript = False
     test_sequence_classification_problem_types = True
     base_model_class = ReformerModel
+    return_dict: bool = False
+    use_labels: bool = False
+    use_test_inputs_embeds: bool = True
 
     def setUp(self):
         self.model_tester = ReformerModelTester(self)
@@ -605,6 +640,9 @@ class ReformerLSHAttnModelTest(ReformerTesterMixin, ModelTesterMixin, unittest.T
     test_headmasking = False
     test_torchscript = False
     base_model_class = ReformerModel
+    return_dict: bool = False
+    use_labels: bool = False
+    use_test_inputs_embeds: bool = True
 
     def setUp(self):
         self.model_tester = ReformerModelTester(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

- Added inputs_embeds and past_key_values(cache)

- Reformer defines its own attention, encoder and encoder layer, adding past_key_values(cache) is non-trivial.