### PR TITLE
[Reformer P2] Add inputs_embeds and past_key_values(cache)

### DIFF
--- a/paddlenlp/transformers/reformer/modeling.py
+++ b/paddlenlp/transformers/reformer/modeling.py
@@ -2496,7 +2496,7 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
             use_cache (bool, optional):
                 See :class:`ReformerModel`.
             inputs_embeds (Tensor, optional):
-                See :class:`NeZhaModel`.
+                See :class:`ReformerModel`.
             labels (Tensor, optional):
                 Labels for language modeling. Note that the labels **are shifted**
                 inside the model, i.e. you can set `labels = input_ids` Indices are
@@ -2646,7 +2646,7 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
             num_hashes (int, optional):
                 See :class:`ReformerModel`.
             inputs_embeds (Tensor, optional):
-                See :class:`NeZhaModel`.
+                See :class:`ReformerModel`.
             labels (Tensor, optional):
                 Labels for computing the masked language modeling loss.
                 Indices should be in ``[-100, 0, ..., vocab_size]``
@@ -2789,7 +2789,7 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
             num_hashes (int, optional):
                 See :class:`ReformerModel`.
             inputs_embeds (Tensor, optional):
-                See :class:`NeZhaModel`.
+                See :class:`ReformerModel`.
             labels (Tensor, optional):
                 Labels for computing the sequence classification/regression loss. Indices
                 should be in `[0, ...,num_classes - 1]`. If `num_classes == 1` a regression
@@ -2943,7 +2943,7 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
                 are not taken into account for computing the loss.
                 Shape is [batch_size,] and dtype is int64.
             inputs_embeds (Tensor, optional):
-                See :class:`NeZhaModel`.
+                See :class:`ReformerModel`.
             output_attentions (bool, optional):
                 See :class:`ReformerModel`.
             output_hidden_states (bool, optional):

--- a/paddlenlp/transformers/reformer/modeling.py
+++ b/paddlenlp/transformers/reformer/modeling.py
@@ -464,9 +464,10 @@ class ReformerEmbeddings(nn.Layer):
     ):
 
         if input_ids is not None:
+            input_shape = paddle.shape(input_ids)
             inputs_embeds = self.word_embeddings(input_ids)
-
-        input_shape = paddle.shape(inputs_embeds)[:-1]
+        else:
+            input_shape = paddle.shape(inputs_embeds)[:-1]
 
         if position_ids is None:
             ones = paddle.ones(input_shape, dtype="int64")
@@ -2255,7 +2256,7 @@ class ReformerModel(ReformerPretrainedModel):
                 model = ReformerModel.from_pretrained('reformer-crime-and-punishment')
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
 
                 outputs = model(**inputs)
@@ -2381,7 +2382,6 @@ class ReformerModel(ReformerPretrainedModel):
         input_shape=None,
         padding_length=None,
         padded_seq_length=None,
-        device=None,
     ):
         logger.info(
             f"Input ids are automatically padded from {input_shape[-1]} to {input_shape[-1] + padding_length} to be a "
@@ -2543,7 +2543,7 @@ class ReformerModelWithLMHead(ReformerPretrainedModel):
                 model = ReformerModelWithLMHead.from_pretrained('reformer-crime-and-punishment')
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=inputs["input_ids"])
 
@@ -2694,7 +2694,7 @@ class ReformerForMaskedLM(ReformerPretrainedModel):
                 model = ReformerForMaskedLM.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=inputs["input_ids"])
 
@@ -2834,7 +2834,7 @@ class ReformerForSequenceClassification(ReformerPretrainedModel):
                 model = ReformerForSequenceClassification.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs, labels=paddle.to_tensor([0]))
 
@@ -2989,7 +2989,7 @@ class ReformerForQuestionAnswering(ReformerPretrainedModel):
                 model = ReformerForQuestionAnswering.from_pretrained('reformer-crime-and-punishment', is_decoder=False)
                 model.eval()
 
-                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!", return_tensors='pt')
+                inputs = tokenizer("Welcome to use PaddlePaddle and PaddleNLP!")
                 inputs = {k:paddle.to_tensor([v]) for (k, v) in inputs.items()}
                 output = model(**inputs)
 

--- a/tests/transformers/reformer/test_modeling.py
+++ b/tests/transformers/reformer/test_modeling.py
@@ -524,10 +524,9 @@ class ReformerTesterMixin:
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_reformer_for_question_answering(*config_and_inputs)
 
-    """todo:
-        def test_reformer_cached_inference(self):
+    def test_reformer_cached_inference(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_cache(*config_and_inputs)"""
+        self.model_tester.create_and_check_cache(*config_and_inputs)
 
     def test_reformer_cached_generate(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
@@ -553,6 +552,7 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, ModelTesterMixin, unittest
     base_model_class = ReformerModel
     return_dict: bool = False
     use_labels: bool = False
+    use_test_inputs_embeds: bool = True
 
     def setUp(self):
         self.model_tester = ReformerModelTester(self)
@@ -642,6 +642,7 @@ class ReformerLSHAttnModelTest(ReformerTesterMixin, ModelTesterMixin, unittest.T
     base_model_class = ReformerModel
     return_dict: bool = False
     use_labels: bool = False
+    use_test_inputs_embeds: bool = True
 
     def setUp(self):
         self.model_tester = ReformerModelTester(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

- Added inputs_embeds and past_key_values(cache)

- Reformer defines its own attention, encoder and encoder layer, adding past_key_values(cache) is non-trivial.