### PR TITLE
Make FastGPT parallel adapt to the latest code

### DIFF
--- a/paddlenlp/ops/fast_transformer/src/fusion_gptj_op.cu
+++ b/paddlenlp/ops/fast_transformer/src/fusion_gptj_op.cu
@@ -31,7 +31,7 @@ limitations under the License. */
 #ifdef HOST
 #undef HOST
 #endif
-#include "fastertransformer/cuda/cub/cub.cuh"
+#include "fastertransformer/gptj.h"
 #include "fastertransformer/utils/common.h"
 
 #ifdef BUILD_GPT  // consistent with FasterTransformer

--- a/paddlenlp/ops/fast_transformer/src/fusion_gptj_op.h
+++ b/paddlenlp/ops/fast_transformer/src/fusion_gptj_op.h
@@ -17,9 +17,9 @@ limitations under the License. */
 #include <string>
 #include <vector>
 
-#include "fastertransformer/gptj.h"
-#include "fastertransformer/open_decoder.h"
-#include "fastertransformer/utils/common.h"
+// #include "fastertransformer/gptj.h"
+// #include "fastertransformer/open_decoder.h"
+// #include "fastertransformer/utils/common.h"
 
 #ifdef PADDLE_ON_INFERENCE
 #include "paddle/include/experimental/ext_all.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
    Make FastGPT and enable_ft_para adapt to PretrainedConfig and state_dict implement,
    and fix compiling errors when open parallel in gpt-j. By this FastGPT with tensor
    parallel and pipeline parallel can work in the latest.