### PR TITLE
修复windows下加载训练好的Promt静态json文件时，报gbk编码错误问题

### DIFF
--- a/paddlenlp/prompt/template.py
+++ b/paddlenlp/prompt/template.py
@@ -853,7 +853,7 @@ class AutoTemplate(object):
         template_config_file = os.path.join(data_path, TEMPLATE_CONFIG_FILE)
         if not os.path.isfile(template_config_file):
             raise ValueError("{} not found under {}".format(TEMPLATE_CONFIG_FILE, data_path))
-        with open(template_config_file, "r") as fp:
+        with open(template_config_file, "r", encoding="utf-8") as fp:
             config = [x.strip() for x in fp]
             prompt = json.loads(config[0])
             if len(config) > 1:

--- a/paddlenlp/prompt/verbalizer.py
+++ b/paddlenlp/prompt/verbalizer.py
@@ -215,7 +215,7 @@ class Verbalizer(nn.Layer):
         verb_config_file = os.path.join(data_path, VERBALIZER_CONFIG_FILE)
         if not os.path.isfile(verb_config_file):
             raise ValueError("{} not found under {}".format(VERBALIZER_CONFIG_FILE, data_path))
-        with open(verb_config_file, "r") as fp:
+        with open(verb_config_file, "r", encoding="utf-8") as fp:
             label_words = json.load(fp)
 
         verbalizer = cls(label_words, tokenizer)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes
### PR changes
Models
### Description
运行环境：Windows 
使用trainer进行prompt训练并保存后相关静态文件后，再使用AutoTemplate.load_from()/SoftVerbalizer.load_from()/PromptTrainer.load_state_dict_from_checkpoint()都无法加载静态文件。
报错原因是保存时规定了utf-8保存，而加载时未限制。导致windows下的gbk编码报错
修复地方：
PromptTrainer引用的是AutoTemplate和SoftVerbalizer，所以只需要修复这两个文件下load_from方法即可
