### PR TITLE
[Bug fixes] Update labelstudio2doccano.py

### DIFF
--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--doccano_file",
         type=str,
-        default="doccano_ext.json",
+        default="doccano_ext.jsonl",
         help="Saving path in doccano format.",
     )
     parser.add_argument(

--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -41,7 +41,9 @@ def append_attrs(data, item, label_id, relation_id, default_relation_type):
                     "id": relation_id,
                     "from_id": mapp[anno["from_id"]],
                     "to_id": mapp[anno["to_id"]],
-                    "type": anno["labels"][0] if len(anno["labels"]) else default_relation_type,
+                    "type": anno["labels"][0]
+                    if len(anno["labels"])
+                    else default_relation_type,
                 }
             )
 
@@ -58,7 +60,7 @@ def convert(dataset, task_type):
             outer_id += 1
             item = {
                 "id": outer_id,
-                "text": data["data"]["text"],
+                "text": data["data"][args.text_field],
                 "entities": [],
                 "relations": [],
             }
@@ -77,7 +79,7 @@ def convert(dataset, task_type):
             results.append(
                 {
                     "id": outer_id,
-                    "text": data["data"]["text"],
+                    "text": data["data"][args.text_field],
                     "label": data["annotations"][0]["result"][0]["value"]["choices"],
                 }
             )
@@ -124,6 +126,12 @@ if __name__ == "__main__":
         type=str,
         default="relation",
         help="The default relation type for missing relation type, defaults to relation.",
+    )
+    parser.add_argument(
+        "--text_field",
+        type=str,
+        default="text",
+        help="The field name representing the text column of data , defaults to text.",
     )
 
     args = parser.parse_args()

--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -41,9 +41,7 @@ def append_attrs(data, item, label_id, relation_id, default_relation_type):
                     "id": relation_id,
                     "from_id": mapp[anno["from_id"]],
                     "to_id": mapp[anno["to_id"]],
-                    "type": anno["labels"][0]
-                    if len(anno["labels"])
-                    else default_relation_type,
+                    "type": anno["labels"][0] if len(anno["labels"]) else default_relation_type,
                 }
             )
 

--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -41,7 +41,9 @@ def append_attrs(data, item, label_id, relation_id, default_relation_type):
                     "id": relation_id,
                     "from_id": mapp[anno["from_id"]],
                     "to_id": mapp[anno["to_id"]],
-                    "type": anno["labels"][0] if len(anno["labels"]) else default_relation_type,
+                    "type": anno["labels"][0]
+                    if len(anno["labels"])
+                    else default_relation_type,
                 }
             )
 
@@ -56,9 +58,19 @@ def convert(dataset, task_type):
         relation_id = 0
         for data in dataset:
             outer_id += 1
-            item = {"id": outer_id, "text": data["data"]["text"], "entities": [], "relations": []}
-            item, label_id, relation_id = append_attrs(data, item, label_id, relation_id,
-                                                       default_relation_type=args.default_relation_type)
+            item = {
+                "id": outer_id,
+                "text": data["data"]["text"],
+                "entities": [],
+                "relations": [],
+            }
+            item, label_id, relation_id = append_attrs(
+                data,
+                item,
+                label_id,
+                relation_id,
+                default_relation_type=args.default_relation_type,
+            )
             results.append(item)
     # for the classification task
     else:
@@ -92,9 +104,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--labelstudio_file", type=str, help="The export file path of label studio, only support the JSON format."
+        "--labelstudio_file",
+        type=str,
+        help="The export file path of label studio, only support the JSON format.",
     )
-    parser.add_argument("--doccano_file", type=str, default="doccano_ext.json", help="Saving path in doccano format.")
+    parser.add_argument(
+        "--doccano_file",
+        type=str,
+        default="doccano_ext.json",
+        help="Saving path in doccano format.",
+    )
     parser.add_argument(
         "--task_type",
         type=str,
@@ -103,8 +122,10 @@ if __name__ == "__main__":
         help="Select task type, ext for the extraction task and cls for the classification task, defaults to ext.",
     )
     parser.add_argument(
-        '--default_relation_type', type=str, default="relation",
-        help="The default relation type for missing relation type, defaults to relation."
+        "--default_relation_type",
+        type=str,
+        default="relation",
+        help="The default relation type for missing relation type, defaults to relation.",
     )
 
     args = parser.parse_args()

--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -17,8 +17,7 @@ import os
 import json
 
 
-def append_attrs(data, item, label_id, relation_id):
-
+def append_attrs(data, item, label_id, relation_id, default_relation_type):
     mapp = {}
 
     for anno in data["annotations"][0]["result"]:
@@ -42,7 +41,7 @@ def append_attrs(data, item, label_id, relation_id):
                     "id": relation_id,
                     "from_id": mapp[anno["from_id"]],
                     "to_id": mapp[anno["to_id"]],
-                    "type": anno["labels"][0],
+                    "type": anno["labels"][0] if len(anno["labels"]) else default_relation_type,
                 }
             )
 
@@ -58,7 +57,8 @@ def convert(dataset, task_type):
         for data in dataset:
             outer_id += 1
             item = {"id": outer_id, "text": data["data"]["text"], "entities": [], "relations": []}
-            item, label_id, relation_id = append_attrs(data, item, label_id, relation_id)
+            item, label_id, relation_id = append_attrs(data, item, label_id, relation_id,
+                                                       default_relation_type=args.default_relation_type)
             results.append(item)
     # for the classification task
     else:
@@ -75,13 +75,11 @@ def convert(dataset, task_type):
 
 
 def do_convert(args):
-
     if not os.path.exists(args.labelstudio_file):
         raise ValueError("Please input the correct path of label studio file.")
 
     with open(args.labelstudio_file, "r", encoding="utf-8") as infile:
-        for content in infile:
-            dataset = json.loads(content)
+        dataset = json.load(infile)
         results = convert(dataset, args.task_type)
 
     with open(args.doccano_file, "w", encoding="utf-8") as outfile:
@@ -91,19 +89,22 @@ def do_convert(args):
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
         "--labelstudio_file", type=str, help="The export file path of label studio, only support the JSON format."
     )
-    parser.add_argument("--doccano_file", type=str, default="doccano_ext.jsonl", help="Saving path in doccano format.")
+    parser.add_argument("--doccano_file", type=str, default="doccano_ext.json", help="Saving path in doccano format.")
     parser.add_argument(
         "--task_type",
         type=str,
         choices=["ext", "cls"],
         default="ext",
         help="Select task type, ext for the extraction task and cls for the classification task, defaults to ext.",
+    )
+    parser.add_argument(
+        '--default_relation_type', type=str, default="relation",
+        help="The default relation type for missing relation type, defaults to relation."
     )
 
     args = parser.parse_args()

--- a/model_zoo/uie/labelstudio2doccano.py
+++ b/model_zoo/uie/labelstudio2doccano.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import argparse
-import os
 import json
+import os
 
 
 def append_attrs(data, item, label_id, relation_id, default_relation_type):
@@ -41,9 +41,7 @@ def append_attrs(data, item, label_id, relation_id, default_relation_type):
                     "id": relation_id,
                     "from_id": mapp[anno["from_id"]],
                     "to_id": mapp[anno["to_id"]],
-                    "type": anno["labels"][0]
-                    if len(anno["labels"])
-                    else default_relation_type,
+                    "type": anno["labels"][0] if len(anno["labels"]) else default_relation_type,
                 }
             )
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others. Helper function for convering the format of label-studio to doccano.

### Description

Fix json file reading error.
- Only json line format was accpted, which is not the default export option in labelstudio, making error for directly output json or formatted json file. The reading procedure was fixed to adapt both the json line format and detended format.

Add support for setting default value for missing relation type, which is allowed in label-studio but not the case in doccano.
- Some relation type could be emply list imported from label-studio. Add default relation type.