### PR TITLE
remove with_data_parallel in static graph training

### DIFF
--- a/examples/machine_translation/transformer/static/train.py
+++ b/examples/machine_translation/transformer/static/train.py
@@ -228,8 +228,9 @@ def do_train(args):
         build_strategy = paddle.static.BuildStrategy()
         exec_strategy = paddle.static.ExecutionStrategy()
 
-        compiled_train_program = paddle.static.CompiledProgram(train_program).with_data_parallel(
-            loss_name=avg_cost.name, build_strategy=build_strategy, exec_strategy=exec_strategy
+        compiled_train_program = paddle.static.CompiledProgram(
+            train_program,
+            build_strategy=build_strategy
         )
     exe.run(startup_program)
 

--- a/examples/machine_translation/transformer/static/train.py
+++ b/examples/machine_translation/transformer/static/train.py
@@ -228,10 +228,7 @@ def do_train(args):
         build_strategy = paddle.static.BuildStrategy()
         exec_strategy = paddle.static.ExecutionStrategy()
 
-        compiled_train_program = paddle.static.CompiledProgram(
-            train_program,
-            build_strategy=build_strategy
-        )
+        compiled_train_program = paddle.static.CompiledProgram(train_program, build_strategy=build_strategy)
     exe.run(startup_program)
 
     if args.use_amp:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
API `with_data_parallel` 已经从Paddle develop分支删除，本PR相应更新了transformer静态图训练代码。

#### Related PR
https://github.com/PaddlePaddle/Paddle/pull/50425