### PR TITLE
[Generation] Remove __get_attr__ shortcut that gets attribute from config

### DIFF
--- a/paddlenlp/transformers/bigbird/modeling.py
+++ b/paddlenlp/transformers/bigbird/modeling.py
@@ -547,16 +547,16 @@ class BigBirdForSequenceClassification(BigBirdPretrainedModel):
     Args:
         bigbird (:class:`BigBirdModel`):
             An instance of :class:`BigBirdModel`.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `None`.
     """
 
     def __init__(self, config: BigBirdConfig):
         super(BigBirdForSequenceClassification, self).__init__(config)
-        self.num_classes = config.num_classes
+        self.num_labels = config.num_labels
         self.config = config
         self.bigbird = BigBirdModel(config)
-        self.linear = nn.Linear(config.hidden_size, self.num_classes)
+        self.linear = nn.Linear(config.hidden_size, self.num_labels)
         self.dropout = nn.Dropout(config.hidden_dropout_prob, mode="upscale_in_train")
         self.apply(self.init_weights)
 
@@ -603,7 +603,7 @@ class BigBirdForSequenceClassification(BigBirdPretrainedModel):
 
         Returns:
             Tensor: Returns tensor `output`, a tensor of the input text classification logits.
-            Its data type should be float32 and it has a shape of [batch_size, num_classes].
+            Its data type should be float32 and it has a shape of [batch_size, num_labels].
 
         Examples:
             .. code-block::
@@ -1246,7 +1246,7 @@ class BigBirdForTokenClassification(BigBirdPretrainedModel):
     Args:
         bigbird (:class:`BigBirdModel`):
             An instance of BigBirdModel.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `2`.
         dropout (float, optional):
             The dropout probability for output of BIGBIRD.
@@ -1256,12 +1256,10 @@ class BigBirdForTokenClassification(BigBirdPretrainedModel):
 
     def __init__(self, config: BigBirdConfig):
         super(BigBirdForTokenClassification, self).__init__(config)
-        self.num_classes = config.num_classes
-        self.bigbird = BigBirdModel(config)  # allow bigbird to be config
-        self.dropout = nn.Dropout(
-            self.dropout if self.dropout is not None else self.bigbird.config["hidden_dropout_prob"]
-        )
-        self.classifier = nn.Linear(self.bigbird.config["hidden_size"], self.num_classes)
+        self.num_labels = config.num_labels
+        self.bigbird = BigBirdModel(config)
+        self.dropout = nn.Dropout(config.dropout if config.dropout is not None else config.hidden_dropout_prob)
+        self.classifier = nn.Linear(self.bigbird.config["hidden_size"], self.num_labels)
         self.apply(self.init_weights)
 
     def forward(

--- a/paddlenlp/transformers/blenderbot/modeling.py
+++ b/paddlenlp/transformers/blenderbot/modeling.py
@@ -639,14 +639,8 @@ class BlenderbotForConditionalGeneration(BlenderbotPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class BlenderbotForCausalLM(BlenderbotPretrainedModel):

--- a/paddlenlp/transformers/blenderbot_small/modeling.py
+++ b/paddlenlp/transformers/blenderbot_small/modeling.py
@@ -642,14 +642,8 @@ class BlenderbotSmallForConditionalGeneration(BlenderbotSmallPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class BlenderbotSmallForCausalLM(BlenderbotSmallPretrainedModel):

--- a/paddlenlp/transformers/blip_2/modeling.py
+++ b/paddlenlp/transformers/blip_2/modeling.py
@@ -990,7 +990,7 @@ class Blip2QFormerModel(Blip2PretrainedModel):
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.cast(dtype=self.dtype)  # fp16 compatibility
+        extended_attention_mask = extended_attention_mask.cast(dtype=self.config.dtype)  # fp16 compatibility
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
         return extended_attention_mask
 
@@ -1011,7 +1011,9 @@ class Blip2QFormerModel(Blip2PretrainedModel):
         # /transformer/transformer_layers.py#L270
         # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
         # encoder_extended_attention_mask.transpose(-1, -2))
-        encoder_extended_attention_mask = encoder_extended_attention_mask.cast(dtype=self.dtype)  # fp16 compatibility
+        encoder_extended_attention_mask = encoder_extended_attention_mask.cast(
+            dtype=self.config.dtype
+        )  # fp16 compatibility
         encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e4
 
         return encoder_extended_attention_mask
@@ -1049,7 +1051,7 @@ class Blip2QFormerModel(Blip2PretrainedModel):
         elif head_mask.ndim == 2:
             head_mask = head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)  # We can specify head_mask for each layer
         assert head_mask.ndim == 5, f"head_mask.dim != 5, instead {head_mask.dim()}"
-        head_mask = head_mask.cast(dtype=self.dtype)  # switch to float if need + fp16 compatibility
+        head_mask = head_mask.cast(dtype=self.config.dtype)  # switch to float if need + fp16 compatibility
         return head_mask
 
     def forward(

--- a/paddlenlp/transformers/dallebart/modeling.py
+++ b/paddlenlp/transformers/dallebart/modeling.py
@@ -1203,14 +1203,8 @@ class DalleBartForConditionalGeneration(DalleBartPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config.name
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class ResnetBlock(nn.Layer):

--- a/paddlenlp/transformers/distilbert/modeling.py
+++ b/paddlenlp/transformers/distilbert/modeling.py
@@ -88,7 +88,7 @@ class DistilBertPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )

--- a/paddlenlp/transformers/electra/modeling.py
+++ b/paddlenlp/transformers/electra/modeling.py
@@ -628,7 +628,7 @@ class ElectraClassificationHead(nn.Layer):
             Dimensionality of the embedding layer.
         hidden_dropout_prob (float):
             The dropout probability for all fully connected layers.
-        num_classes (int):
+        num_labels (int):
             The number of classes.
         activation (str):
             The activation function name between layers.
@@ -639,7 +639,7 @@ class ElectraClassificationHead(nn.Layer):
         super(ElectraClassificationHead, self).__init__()
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
-        self.out_proj = nn.Linear(config.hidden_size, config.num_classes)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
         self.act = get_activation(config.hidden_act)
 
     def forward(self, features, **kwargs):
@@ -653,7 +653,7 @@ class ElectraClassificationHead(nn.Layer):
 
         Returns:
             Tensor: Returns a tensor of the input text classification logits.
-            Shape as `[batch_size, num_classes]` and dtype as float32.
+            Shape as `[batch_size, num_labels]` and dtype as float32.
         """
         x = features[:, 0, :]  # take <s> token (equiv. to [CLS])
         x = self.dropout(x)
@@ -746,7 +746,7 @@ class ElectraForSequenceClassification(ElectraPretrainedModel):
     Args:
         electra (:class:`ElectraModel`):
             An instance of ElectraModel.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `2`.
         dropout (float, optional):
             The dropout probability for output of Electra.
@@ -802,7 +802,7 @@ class ElectraForSequenceClassification(ElectraPretrainedModel):
 
         Returns:
             Tensor: Returns tensor `logits`, a tensor of the input text classification logits.
-            Shape as `[batch_size, num_classes]` and dtype as float32.
+            Shape as `[batch_size, num_labels]` and dtype as float32.
 
         Example:
             .. code-block::
@@ -837,12 +837,12 @@ class ElectraForSequenceClassification(ElectraPretrainedModel):
 
         loss = None
         if labels is not None:
-            if self.num_classes == 1:
+            if self.num_labels == 1:
                 loss_fct = paddle.nn.MSELoss()
                 loss = loss_fct(logits, labels)
             elif labels.dtype == paddle.int64 or labels.dtype == paddle.int32:
                 loss_fct = paddle.nn.CrossEntropyLoss()
-                loss = loss_fct(logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+                loss = loss_fct(logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
             else:
                 loss_fct = paddle.nn.BCEWithLogitsLoss()
                 loss = loss_fct(logits, labels)
@@ -867,7 +867,7 @@ class ElectraForTokenClassification(ElectraPretrainedModel):
     Args:
         electra (:class:`ElectraModel`):
             An instance of ElectraModel.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `2`.
         dropout (float, optional):
             The dropout probability for output of Electra.
@@ -925,7 +925,7 @@ class ElectraForTokenClassification(ElectraPretrainedModel):
 
         Returns:
             Tensor: Returns tensor `logits`, a tensor of the input token classification logits.
-            Shape as `[batch_size, sequence_length, num_classes]` and dtype as `float32`.
+            Shape as `[batch_size, sequence_length, num_labels]` and dtype as `float32`.
 
         Example:
             .. code-block::
@@ -961,7 +961,7 @@ class ElectraForTokenClassification(ElectraPretrainedModel):
         loss = None
         if labels is not None:
             loss_fct = nn.CrossEntropyLoss()
-            loss = loss_fct(logits.reshape([-1, self.num_classes]), labels.reshape([-1]))
+            loss = loss_fct(logits.reshape([-1, self.num_labels]), labels.reshape([-1]))
 
         if not return_dict:
             output = (logits,) + sequence_output[1:]

--- a/paddlenlp/transformers/electra/modeling.py
+++ b/paddlenlp/transformers/electra/modeling.py
@@ -232,44 +232,8 @@ class ElectraModel(ElectraPretrainedModel):
     and refer to the Paddle documentation for all matter related to general usage and behavior.
 
     Args:
-        vocab_size (int):
-            Vocabulary size of `inputs_ids` in `ElectraModel`. Also is the vocab size of token embedding matrix.
-            Defines the number of different tokens that can be represented by the `inputs_ids` passed when calling `ElectraModel`.
-        embedding_size (int, optional):
-            Dimensionality of the embedding layer.
-        hidden_size (int, optional):
-            Dimensionality of the encoder layer and pooler layer.
-        num_hidden_layers (int, optional):
-            Number of hidden layers in the Transformer encoder.
-        num_attention_heads (int, optional):
-            Number of attention heads for each attention layer in the Transformer encoder.
-        intermediate_size (int, optional):
-            Dimensionality of the feed-forward (ff) layer in the encoder. Input tensors
-            to ff layers are firstly projected from `hidden_size` to `intermediate_size`,
-            and then projected back to `hidden_size`. Typically `intermediate_size` is larger than `hidden_size`.
-        hidden_act (str, optional):
-            The non-linear activation function in the feed-forward layer.
-            ``"gelu"``, ``"relu"`` and any other paddle supported activation functions
-            are supported.
-        hidden_dropout_prob (float, optional):
-            The dropout probability for all fully connected layers in the embeddings and encoder.
-        attention_probs_dropout_prob (float, optional):
-            The dropout probability used in MultiHeadAttention in all encoder layers to drop some attention target.
-        max_position_embeddings (int, optional):
-            The maximum value of the dimensionality of position encoding, which dictates the maximum supported length of an input
-            sequence.
-        type_vocab_size (int, optional):
-            The vocabulary size of `token_type_ids`.
-
-        initializer_range (float, optional):
-            The standard deviation of the normal initializer.
-
-            .. note::
-                A normal_initializer initializes weight matrices as normal distributions.
-                See :meth:`ElectraPretrainedModel.init_weights()` for how weights are initialized in `ElectraModel`.
-
-        pad_token_id (int, optional):
-            The index of padding token in the token vocabulary.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
     """
 
     def __init__(self, config: ElectraConfig):
@@ -434,8 +398,8 @@ class ElectraDiscriminator(ElectraPretrainedModel):
     The Electra Discriminator can detect the tokens that are replaced by the Electra Generator.
 
     Args:
-         electra (:class:`ElectraModel`):
-             An instance of :class:`ElectraModel`.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
 
     """
 
@@ -505,8 +469,8 @@ class ElectraGenerator(ElectraPretrainedModel):
     a masked language model.
 
     Args:
-         electra (:class:`ElectraModel`):
-             An instance of :class:`ElectraModel`.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
     """
 
     def __init__(self, config: ElectraConfig):
@@ -624,14 +588,8 @@ class ElectraClassificationHead(nn.Layer):
     Perform sentence-level classification tasks.
 
     Args:
-        hidden_size (int):
-            Dimensionality of the embedding layer.
-        hidden_dropout_prob (float):
-            The dropout probability for all fully connected layers.
-        num_labels (int):
-            The number of classes.
-        activation (str):
-            The activation function name between layers.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
 
     """
 
@@ -672,8 +630,8 @@ class ErnieHealthDiscriminator(ElectraPretrainedModel):
         - sequence-level Contrastive Sequence Prediction (CSP) task.
 
     Args:
-         electra (:class:`ElectraModel`):
-             An instance of :class:`ElectraModel`.
+         config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ErnieHealthDiscriminator
 
     """
 
@@ -744,24 +702,13 @@ class ElectraForSequenceClassification(ElectraPretrainedModel):
     designed for sequence classification/regression tasks like GLUE tasks.
 
     Args:
-        electra (:class:`ElectraModel`):
-            An instance of ElectraModel.
-        num_labels (int, optional):
-            The number of classes. Defaults to `2`.
-        dropout (float, optional):
-            The dropout probability for output of Electra.
-            If None, use the same value as `hidden_dropout_prob` of `ElectraModel`
-            instance `electra`. Defaults to None.
-        activation (str, optional):
-            The activation function name for classifier.
-            Defaults to "gelu".
-        layer_norm_eps (float, optional):
-            The epsilon to initialize nn.LayerNorm layers.
-            Defaults to 1e-12.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ElectraForSequenceClassification
     """
 
     def __init__(self, config: ElectraConfig):
         super(ElectraForSequenceClassification, self).__init__(config)
+        self.num_labels = config.num_labels
         self.electra = ElectraModel(config)
         self.classifier = ElectraClassificationHead(config)
         self.init_weights()
@@ -865,23 +812,17 @@ class ElectraForTokenClassification(ElectraPretrainedModel):
     designed for token classification tasks like NER tasks.
 
     Args:
-        electra (:class:`ElectraModel`):
-            An instance of ElectraModel.
-        num_labels (int, optional):
-            The number of classes. Defaults to `2`.
-        dropout (float, optional):
-            The dropout probability for output of Electra.
-            If None, use the same value as `hidden_dropout_prob` of `ElectraModel`
-            instance `electra`. Defaults to None.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ElectraForTokenClassification
     """
 
     def __init__(self, config: ElectraConfig):
         super(ElectraForTokenClassification, self).__init__(config)
         self.electra = ElectraModel(config)
-
-        dropout_p = config.hidden_dropout_prob if config.classifier_dropout is None else config.classifier_dropout
-        self.dropout = nn.Dropout(dropout_p)
-
+        self.num_labels = config.num_labels
+        self.dropout = nn.Dropout(
+            config.hidden_dropout_prob if config.classifier_dropout is None else config.classifier_dropout
+        )
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
         self.init_weights()
 
@@ -980,10 +921,8 @@ class ElectraForTotalPretraining(ElectraPretrainedModel):
     Electra Model for pretraining tasks.
 
     Args:
-        generator (:class:`ElectraGenerator`):
-            An instance of :class:`ElectraGenerator`.
-        discriminator (:class:`ElectraDiscriminator`):
-            An instance of :class:`ElectraDiscriminator`.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ElectraForTotalPretraining
 
     """
 
@@ -1154,10 +1093,8 @@ class ErnieHealthForTotalPretraining(ElectraForTotalPretraining):
     ERNIE-Health Model for pretraining task.
 
     Args:
-        generator (:class:`ElectraGenerator`):
-            An instance of :class:`ElectraGenerator`.
-        discriminator (:class:`ErnieHealthDiscriminator):
-            An instance of :class:`ErnieHealthDiscriminator`.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ElectraForMultipleChoice
     """
 
     def __init__(self, config: ElectraConfig):
@@ -1269,14 +1206,8 @@ class ElectraForMultipleChoice(ElectraPretrainedModel):
     designed for multiple choice tasks like RocStories/SWAG tasks.
 
     Args:
-        electra (:class:`ElectraModel`):
-            An instance of ElectraModel.
-        num_choices (int, optional):
-            The number of choices. Defaults to `2`.
-        dropout (float, optional):
-            The dropout probability for output of Electra.
-            If None, use the same value as `hidden_dropout_prob` of `ElectraModel`
-            instance `electra`. Defaults to None.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig to construct ElectraForMultipleChoice
     """
 
     def __init__(self, config: ElectraConfig):
@@ -1434,13 +1365,8 @@ class ElectraPretrainingCriterion(paddle.nn.Layer):
     """
 
     Args:
-        vocab_size(int):
-            Vocabulary size of `inputs_ids` in `ElectraModel`. Defines the number of different tokens that can
-            be represented by the `inputs_ids` passed when calling `ElectraModel`.
-        gen_weight(float):
-            The weight of the Electra Generator.
-        disc_weight(float):
-            The weight of the Electra Discriminator.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
 
     """
 
@@ -1520,13 +1446,8 @@ class ErnieHealthPretrainingCriterion(paddle.nn.Layer):
     """
 
     Args:
-        vocab_size(int):
-            Vocabulary size of `inputs_ids` in `ElectraModel`. Defines the number of different tokens that can
-            be represented by the `inputs_ids` passed when calling `ElectraModel`.
-        gen_weight(float):
-            The weight of the Electra Generator.
-        disc_weight(float):
-            The weight of the Electra Discriminator.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig
 
     """
 
@@ -1662,8 +1583,8 @@ class ElectraForQuestionAnswering(ElectraPretrainedModel):
     and `span_end_logits`, designed for question-answering tasks like SQuAD.
 
     Args:
-        electra (:class:`ElectraModel`):
-            An instance of ElectraModel.
+        config (:class:`ElectraConfig`):
+            An instance of ElectraConfig used to construct ElectraForQuestionAnswering.
 
     """
 

--- a/paddlenlp/transformers/ernie_doc/modeling.py
+++ b/paddlenlp/transformers/ernie_doc/modeling.py
@@ -300,7 +300,7 @@ class ErnieDocPretrainedModel(PretrainedModel):
                 layer.weight.set_value(
                     paddle.tensor.normal(
                         mean=0.0,
-                        std=self.initializer_range,
+                        std=self.config.initializer_range,
                         shape=layer.weight.shape,
                     )
                 )
@@ -667,7 +667,7 @@ class ErnieDocForTokenClassification(ErnieDocPretrainedModel):
 
             - `logits` (Tensor):
                 A tensor containing the hidden-states of the model at the output of last layer.
-                Each Tensor has a data type of `float32` and has a shape of [batch_size, sequence_length, num_classes].
+                Each Tensor has a data type of `float32` and has a shape of [batch_size, sequence_length, num_labels].
 
             - `mem` (List[Tensor]):
                 A list of pre-computed hidden-states. The length of the list is `n_layers`.
@@ -689,7 +689,7 @@ class ErnieDocForTokenClassification(ErnieDocPretrainedModel):
                     return np.array(r_position).astype('int64').reshape([len(insts), beg, 1])
 
                 tokenizer = ErnieDocTokenizer.from_pretrained('ernie-doc-base-zh')
-                model = ErnieDocForTokenClassification.from_pretrained('ernie-doc-base-zh', num_classes=2)
+                model = ErnieDocForTokenClassification.from_pretrained('ernie-doc-base-zh', num_labels=2)
 
                 inputs = tokenizer("欢迎使用百度飞桨！")
                 inputs = {k:paddle.to_tensor([v + [0] * (128-len(v))]).unsqueeze(-1) for (k, v) in inputs.items()}
@@ -727,7 +727,7 @@ class ErnieDocForQuestionAnswering(ErnieDocPretrainedModel):
 
     def __init__(self, config: ErnieDocConfig):
         super(ErnieDocForQuestionAnswering, self).__init__(config)
-        self.ernie_doc = ErnieDocModel(config)  # allow ernie_doc to be config
+        self.ernie_doc = ErnieDocModel(config)
         self.dropout = nn.Dropout(
             config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob,
             mode="upscale_in_train",

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -471,9 +471,7 @@ class GenerationMixin(object):
 
     def prepare_decoder_input_ids_for_generation(self, input_ids, decoder_start_token_id=None, bos_token_id=None):
         decoder_start_token_id = (
-            decoder_start_token_id
-            if decoder_start_token_id is not None
-            else getattr(self, "decoder_start_token_id", None)
+            decoder_start_token_id if decoder_start_token_id is not None else self.config.decoder_start_token_id
         )
         decoder_start_token_id = decoder_start_token_id if decoder_start_token_id is not None else bos_token_id
 
@@ -483,22 +481,18 @@ class GenerationMixin(object):
 
     def get_decoder_start_token_id(self, decoder_start_token_id=None, bos_token_id=None):
         decoder_start_token_id = (
-            decoder_start_token_id
-            if decoder_start_token_id is not None
-            else getattr(self, self.base_model_prefix).config.get("decoder_start_token_id", None)
+            decoder_start_token_id if decoder_start_token_id is not None else self.config.decoder_start_token_id
         )
-        bos_token_id = (
-            bos_token_id if bos_token_id is not None else getattr(self, self.base_model_prefix).config["bos_token_id"]
-        )
+        bos_token_id = bos_token_id if bos_token_id is not None else self.config.bos_token_id
 
         if decoder_start_token_id is not None:
             return decoder_start_token_id
-        elif getattr(self, self.base_model_prefix).config.get("decoder_start_token_id", None) is not None:
-            return getattr(self, self.base_model_prefix).config["decoder_start_token_id"]
+        elif self.config.decoder_start_token_id is not None:
+            return self.config.decoder_start_token_id
         elif bos_token_id is not None:
             return bos_token_id
-        elif getattr(self, self.base_model_prefix).config["bos_token_id"] is not None:
-            return getattr(self, self.base_model_prefix).config["bos_token_id"]
+        elif self.config.bos_token_id is not None:
+            return self.config.bos_token_id
         raise ValueError(
             "`decoder_start_token_id` or `bos_token_id` has to be defined for encoder-decoder generation."
         )
@@ -761,23 +755,20 @@ class GenerationMixin(object):
                 logger.warning("`use_faster` will be deprecated in near future. Please use `use_fast` instead. ")
                 self.deprecated_warnings["use_faster"] = True
 
-        # TODO: change from model.attribute to model.config.attribute when all models are integrated with PretrainedConfig
-        bos_token_id = bos_token_id if bos_token_id is not None else getattr(self, "bos_token_id", None)
-        eos_token_id = eos_token_id if eos_token_id is not None else getattr(self, "eos_token_id", None)
-        pad_token_id = pad_token_id if pad_token_id is not None else getattr(self, "pad_token_id", None)
+        bos_token_id = bos_token_id if bos_token_id is not None else self.config.bos_token_id
+        eos_token_id = eos_token_id if eos_token_id is not None else self.config.eos_token_id
+        pad_token_id = pad_token_id if pad_token_id is not None else self.config.pad_token_id
         forced_bos_token_id = (
-            forced_bos_token_id if forced_bos_token_id is not None else getattr(self, "forced_bos_token_id", None)
+            forced_bos_token_id if forced_bos_token_id is not None else self.config.forced_bos_token_id
         )
         forced_eos_token_id = (
-            forced_eos_token_id if forced_eos_token_id is not None else getattr(self, "forced_eos_token_id", None)
+            forced_eos_token_id if forced_eos_token_id is not None else self.config.forced_eos_token_id
         )
         decoder_start_token_id = (
-            decoder_start_token_id
-            if decoder_start_token_id is not None
-            else getattr(self, "decoder_start_token_id", None)
+            decoder_start_token_id if decoder_start_token_id is not None else self.config.decoder_start_token_id
         )
         no_repeat_ngram_size = (
-            no_repeat_ngram_size if no_repeat_ngram_size is not None else getattr(self, "no_repeat_ngram_size", None)
+            no_repeat_ngram_size if no_repeat_ngram_size is not None else self.config.no_repeat_ngram_size
         )
 
         if is_tracing:

--- a/paddlenlp/transformers/gpt/modeling.py
+++ b/paddlenlp/transformers/gpt/modeling.py
@@ -1200,7 +1200,7 @@ class GPTForTokenClassification(GPTPretrainedModel):
     Args:
         gpt (:class:`GPTModel`):
             An instance of GPTModel.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `2`.
         dropout (float, optional):
             The dropout probability for output of GPT.
@@ -1210,7 +1210,7 @@ class GPTForTokenClassification(GPTPretrainedModel):
 
     def __init__(self, config: GPTConfig):
         super(GPTForTokenClassification, self).__init__(config)
-        self.num_classes = config.num_labels
+        self.num_labels = config.num_labels
 
         self.gpt = GPTModel(config)  # allow gpt to be config
         dropout_p = config.hidden_dropout_prob if config.classifier_dropout is None else config.classifier_dropout
@@ -1261,7 +1261,7 @@ class GPTForTokenClassification(GPTPretrainedModel):
 
             Especialy, when `return_dict=output_attentions=output_hidden_states=False`,
             returns tensor `logits`, a tensor of the input token classification logits.
-            Shape as `[batch_size, sequence_length, num_classes]` and dtype as `float32`.
+            Shape as `[batch_size, sequence_length, num_labels]` and dtype as `float32`.
 
         Example:
             .. code-block::
@@ -1297,7 +1297,7 @@ class GPTForTokenClassification(GPTPretrainedModel):
         loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+            loss = loss_fct(logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
 
         if not return_dict:
             if isinstance(sequence_output, input_type):
@@ -1322,7 +1322,7 @@ class GPTForSequenceClassification(GPTPretrainedModel):
     Args:
         gpt (:class:`GPTModel`):
             An instance of GPTModel.
-        num_classes (int, optional):
+        num_labels (int, optional):
             The number of classes. Defaults to `2`.
 
     """
@@ -1379,7 +1379,7 @@ class GPTForSequenceClassification(GPTPretrainedModel):
 
             Especialy, when `return_dict=output_attentions=output_hidden_states=False`,
             returns tensor `logits`, a tensor of the input text classification logits.
-            Shape as `[batch_size, num_classes]` and dtype as float32.
+            Shape as `[batch_size, num_labels]` and dtype as float32.
 
         Example:
             .. code-block::
@@ -1432,12 +1432,12 @@ class GPTForSequenceClassification(GPTPretrainedModel):
 
         loss = None
         if labels is not None:
-            if self.num_classes == 1:
+            if self.num_labels == 1:
                 loss_fct = MSELoss()
                 loss = loss_fct(pooled_logits, labels)
             elif labels.dtype == paddle.int64 or labels.dtype == paddle.int32:
                 loss_fct = CrossEntropyLoss()
-                loss = loss_fct(pooled_logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+                loss = loss_fct(pooled_logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
             else:
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(pooled_logits, labels)

--- a/paddlenlp/transformers/gpt/modeling.py
+++ b/paddlenlp/transformers/gpt/modeling.py
@@ -1189,10 +1189,7 @@ class GPTLMHeadModel(GPTPretrainedModel):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                return getattr(self, self.base_model_prefix).config[name]
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class GPTForTokenClassification(GPTPretrainedModel):

--- a/paddlenlp/transformers/gpt/modeling.py
+++ b/paddlenlp/transformers/gpt/modeling.py
@@ -1329,8 +1329,8 @@ class GPTForSequenceClassification(GPTPretrainedModel):
 
     def __init__(self, config: GPTConfig):
         super(GPTForSequenceClassification, self).__init__(config)
-
-        self.gpt = GPTModel(config)  # allow gpt to be config
+        self.num_labels = config.num_labels
+        self.gpt = GPTModel(config)
         self.score = nn.Linear(config.hidden_size, config.num_labels, bias_attr=False)
         self.apply(self.init_weights)
 

--- a/paddlenlp/transformers/gptj/modeling.py
+++ b/paddlenlp/transformers/gptj/modeling.py
@@ -620,14 +620,8 @@ class GPTJForCausalLM(GPTJPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class GPTJForSequenceClassification(GPTJPretrainedModel):

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -508,32 +508,6 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             init_dict = fn_args_to_dict(original_init, *((self,) + args), **kwargs)
             self.config = init_dict
 
-    def __getattr__(self, name):
-        """
-        called when the attribute name is missed in the model
-
-        Args:
-            name: the name of attribute
-
-        Returns: the value of attribute
-
-        """
-        try:
-            return super(PretrainedModel, self).__getattr__(name)
-        except AttributeError:
-            result = getattr(self.config, name)
-            if getattr(self, "deprecated_warnings", None) is None:
-                self.deprecated_warnings = {}
-
-            if not self.deprecated_warnings.get(name, False):
-                logger.warning(
-                    f"Accessing `{name}` through `model.{name}` will be deprecated after v2.6.0. "
-                    f"Instead, do `model.config.{name}`"
-                )
-                self.deprecated_warnings[name] = True
-
-            return result
-
     @property
     def base_model(self):
         """

--- a/paddlenlp/transformers/mt5/modeling.py
+++ b/paddlenlp/transformers/mt5/modeling.py
@@ -1713,14 +1713,8 @@ class MT5ForConditionalGeneration(MT5PretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class MT5EncoderModel(MT5PretrainedModel):

--- a/paddlenlp/transformers/opt/modeling.py
+++ b/paddlenlp/transformers/opt/modeling.py
@@ -661,11 +661,5 @@ class OPTForCausalLM(OPTPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)

--- a/paddlenlp/transformers/pegasus/modeling.py
+++ b/paddlenlp/transformers/pegasus/modeling.py
@@ -666,11 +666,5 @@ class PegasusForConditionalGeneration(PegasusPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)

--- a/paddlenlp/transformers/prophetnet/modeling.py
+++ b/paddlenlp/transformers/prophetnet/modeling.py
@@ -1256,11 +1256,5 @@ class ProphetNetForConditionalGeneration(ProphetNetPretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)

--- a/paddlenlp/transformers/reformer/modeling.py
+++ b/paddlenlp/transformers/reformer/modeling.py
@@ -2288,10 +2288,10 @@ class ReformerModel(ReformerPretrainedModel):
 
         # if needs padding
         least_common_mult_chunk_length = _get_least_common_mult_chunk_len(
-            self.attn_layers, self.lsh_attn_chunk_length, self.local_attn_chunk_length
+            self.config.attn_layers, self.config.lsh_attn_chunk_length, self.config.local_attn_chunk_length
         )
         min_chunk_length = _get_min_chunk_len(
-            self.attn_layers, self.lsh_attn_chunk_length, self.local_attn_chunk_length
+            self.config.attn_layers, self.config.lsh_attn_chunk_length, self.config.local_attn_chunk_length
         )
 
         must_pad_to_match_chunk_length = (

--- a/paddlenlp/transformers/roformer/modeling.py
+++ b/paddlenlp/transformers/roformer/modeling.py
@@ -750,8 +750,8 @@ class RoFormerForSequenceClassification(RoFormerPretrainedModel):
                 See :class:`RoFormerModel`.
             labels (Tensor of shape `(batch_size,)`, optional):
                 Labels for computing the sequence classification/regression loss.
-                Indices should be in `[0, ..., num_classes - 1]`. If `num_classes == 1`
-                a regression loss is computed (Mean-Square loss), If `num_classes > 1`
+                Indices should be in `[0, ..., num_labels - 1]`. If `num_labels == 1`
+                a regression loss is computed (Mean-Square loss), If `num_labels > 1`
                 a classification loss is computed (Cross-Entropy).
             output_hidden_states (bool, optional):
                 Whether to return the hidden states of all layers.
@@ -797,12 +797,12 @@ class RoFormerForSequenceClassification(RoFormerPretrainedModel):
 
         loss = None
         if labels is not None:
-            if self.num_classes == 1:
+            if self.num_labels == 1:
                 loss_fct = paddle.nn.MSELoss()
                 loss = loss_fct(logits, labels)
             elif labels.dtype == paddle.int64 or labels.dtype == paddle.int32:
                 loss_fct = paddle.nn.CrossEntropyLoss()
-                loss = loss_fct(logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+                loss = loss_fct(logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
             else:
                 loss_fct = paddle.nn.BCEWithLogitsLoss()
                 loss = loss_fct(logits, labels)
@@ -863,7 +863,7 @@ class RoFormerForTokenClassification(RoFormerPretrainedModel):
             inputs_embeds(Tensor, optional):
                 See :class:`RoFormerModel`.
             labels (Tensor of shape `(batch_size, sequence_length)`, optional):
-                Labels for computing the token classification loss. Indices should be in `[0, ..., num_classes - 1]`.
+                Labels for computing the token classification loss. Indices should be in `[0, ..., num_labels - 1]`.
             output_hidden_states (bool, optional):
                 Whether to return the hidden states of all layers.
                 Defaults to `False`.
@@ -910,7 +910,7 @@ class RoFormerForTokenClassification(RoFormerPretrainedModel):
         loss = None
         if labels is not None:
             loss_fct = paddle.nn.CrossEntropyLoss()
-            loss = loss_fct(logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+            loss = loss_fct(logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
 
         if not return_dict:
             output = (logits,) + outputs[2:]

--- a/paddlenlp/transformers/t5/modeling.py
+++ b/paddlenlp/transformers/t5/modeling.py
@@ -1736,14 +1736,8 @@ class T5ForConditionalGeneration(T5PretrainedModel):
     def __getattr__(self, name):
         try:
             return super().__getattr__(name)
-        except AttributeError as e:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                try:
-                    return getattr(self, self.base_model_prefix).config[name]
-                except KeyError:
-                    raise e
+        except AttributeError:
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 class T5EncoderModel(T5PretrainedModel):

--- a/paddlenlp/transformers/tinybert/modeling.py
+++ b/paddlenlp/transformers/tinybert/modeling.py
@@ -430,8 +430,8 @@ class TinyBertForSequenceClassification(TinyBertPretrainedModel):
                 See :class:`TinyBertModel`.
             labels (Tensor of shape `(batch_size,)`, optional):
                 Labels for computing the sequence classification/regression loss.
-                Indices should be in `[0, ..., num_classes - 1]`. If `num_classes == 1`
-                a regression loss is computed (Mean-Square loss), If `num_classes > 1`
+                Indices should be in `[0, ..., num_labels - 1]`. If `num_labels == 1`
+                a regression loss is computed (Mean-Square loss), If `num_labels > 1`
                 a classification loss is computed (Cross-Entropy).
             output_hidden_states (bool, optional):
                 Whether to return the hidden states of all layers.
@@ -480,12 +480,12 @@ class TinyBertForSequenceClassification(TinyBertPretrainedModel):
 
         loss = None
         if labels is not None:
-            if self.num_classes == 1:
+            if self.num_labels == 1:
                 loss_fct = paddle.nn.MSELoss()
                 loss = loss_fct(logits, labels)
             elif labels.dtype == paddle.int64 or labels.dtype == paddle.int32:
                 loss_fct = paddle.nn.CrossEntropyLoss()
-                loss = loss_fct(logits.reshape((-1, self.num_classes)), labels.reshape((-1,)))
+                loss = loss_fct(logits.reshape((-1, self.num_labels)), labels.reshape((-1,)))
             else:
                 loss_fct = paddle.nn.BCEWithLogitsLoss()
                 loss = loss_fct(logits, labels)

--- a/paddlenlp/transformers/unified_transformer/modeling.py
+++ b/paddlenlp/transformers/unified_transformer/modeling.py
@@ -576,10 +576,7 @@ class UnifiedTransformerLMHeadModel(UnifiedTransformerPretrainedModel):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(getattr(self, self.base_model_prefix), name)
-            except AttributeError:
-                return getattr(getattr(self, self.base_model_prefix).config, name)
+            return getattr(getattr(self, self.base_model_prefix), name)
 
 
 UnifiedTransformerForMaskedLM = UnifiedTransformerLMHeadModel

--- a/tests/transformers/test_modeling_common.py
+++ b/tests/transformers/test_modeling_common.py
@@ -711,8 +711,8 @@ class ModelTesterMixin:
             all_maps: dict = copy.deepcopy(model_class.config_class.attribute_map)
 
             for old_attribute, new_attribute in all_maps.items():
-                old_value = getattr(model, old_attribute)
-                new_value = getattr(model, new_attribute)
+                old_value = getattr(model.config, old_attribute)
+                new_value = getattr(model.config, new_attribute)
 
                 # eg: dropout can be an instance of nn.Dropout, so we should check it attribute
                 if type(new_value) != type(old_value):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
- Remove __get_attr__ shortcut that gets attribute from config when calling `model.attribute`
- standardize `generation_utils` to get attribute from config
- fix #5295
<!-- Describe what this PR does -->
