### PR TITLE
[GPT3] fix rm api is_compiled_with_npu

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/utils/device.py
+++ b/model_zoo/gpt-3/ppfleetx/utils/device.py
@@ -25,7 +25,7 @@ def get_device_and_mapping():
         "gpu": paddle.is_compiled_with_cuda(),
         "xpu": paddle.is_compiled_with_xpu(),
         "rocm": paddle.is_compiled_with_rocm(),
-        "npu": paddle.is_compiled_with_npu() or paddle.is_compiled_with_custom_device("npu"),
+        "npu": paddle.is_compiled_with_custom_device("npu"),
         "cpu": True,
     }
     for d, v in suppoted_device_map.items():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
`is_compiled_with_npu` API is removed by
https://github.com/PaddlePaddle/Paddle/pull/52385.
