### PR TITLE
[benchmark] fix bertqa and PPMiniLM tests bug

### DIFF
--- a/paddlenlp/transformers/ppminilm/modeling.py
+++ b/paddlenlp/transformers/ppminilm/modeling.py
@@ -134,6 +134,7 @@ class PPMiniLMModel(PPMiniLMPretrainedModel):
 
     def __init__(self, config: PPMiniLMConfig):
         super(PPMiniLMModel, self).__init__(config)
+        self.pad_token_id = config.pad_token_id
         self.embeddings = PPMiniLMEmbeddings(config)
 
         encoder_layer = nn.TransformerEncoderLayer(

--- a/paddlenlp/transformers/reformer/modeling.py
+++ b/paddlenlp/transformers/reformer/modeling.py
@@ -1985,46 +1985,6 @@ class ReformerPretrainedModel(PretrainedModel):
         # Tie weights if needed
         self.tie_weights()
 
-    def tie_weights(self):
-        """
-        Tie the weights between the input embeddings and the output embeddings.
-        """
-        tie_word_embeddings = (
-            self.tie_word_embeddings
-            if hasattr(self, "tie_word_embeddings")
-            else self.reformer.config.get("tie_word_embeddings", False)
-        )
-        if hasattr(self, "get_output_embeddings") and hasattr(self, "get_input_embeddings") and tie_word_embeddings:
-            output_embeddings = self.get_output_embeddings()
-            if output_embeddings is not None:
-                self._tie_or_clone_weights(output_embeddings, self.get_input_embeddings())
-
-    def _tie_or_clone_weights(self, output_embeddings, input_embeddings):
-        """Tie or clone layer weights"""
-        if output_embeddings.weight.shape == input_embeddings.weight.shape:
-            output_embeddings.weight = input_embeddings.weight
-        elif output_embeddings.weight.shape == input_embeddings.weight.t().shape:
-            output_embeddings.weight.set_value(input_embeddings.weight.t())
-        else:
-            raise ValueError(
-                "when tie input/output embeddings, the shape of output embeddings: {}"
-                "should be equal to shape of input embeddings: {}"
-                "or should be equal to the shape of transpose input embeddings: {}".format(
-                    output_embeddings.weight.shape,
-                    input_embeddings.weight.shape,
-                    input_embeddings.weight.t().shape,
-                )
-            )
-        if getattr(output_embeddings, "bias", None) is not None:
-            if output_embeddings.weight.shape[-1] != output_embeddings.bias.shape[0]:
-                raise ValueError(
-                    "the weight lase shape: {} of output_embeddings is not equal to the bias shape: {}"
-                    "please check output_embeddings configuration".format(
-                        output_embeddings.weight.shape[-1],
-                        output_embeddings.bias.shape[0],
-                    )
-                )
-
     def _init_weights(self, layer):
         """Initialize the weights"""
         if isinstance(layer, AxialPositionEmbeddings):

--- a/ppdiffusers/ppdiffusers/ppnlp_patch_utils.py
+++ b/ppdiffusers/ppdiffusers/ppnlp_patch_utils.py
@@ -592,10 +592,9 @@ if is_paddle_available() and is_paddlenlp_available():
     # patch BertModel forward
     from paddlenlp.transformers import BertModel
 
-    raw_forward = BertModel.forward
+    BertModel.raw_forward = BertModel.forward
 
-    @patch_to(BertModel)
-    def forward(
+    def forward_new(
         self,
         input_ids: paddle.Tensor,
         token_type_ids: Optional[paddle.Tensor] = None,
@@ -609,18 +608,19 @@ if is_paddle_available() and is_paddlenlp_available():
     ):
         if attention_mask is None:
             attention_mask = paddle.ones_like(input_ids)
-        return raw_forward(
-            self,
-            input_ids,
-            token_type_ids,
-            position_ids,
-            attention_mask,
-            past_key_values,
-            use_cache,
-            output_hidden_states,
-            output_attentions,
-            return_dict,
+        return self.raw_forward(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            output_attentions=output_attentions,
+            return_dict=return_dict,
         )
+
+    BertModel.forward = forward_new
 
     TRANSFORMERS_SAFE_WEIGHTS_NAME = "model.safetensors"
     TRANSFORMERS_WEIGHTS_NAME = "pytorch_model.bin"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
当前paddle动转静不支持patch_to(xxxx), 会报错，离谱。
修复PPMiniLM 的self.pad_token_id = config.pad_token_id