### PR TITLE
Fix prompt head shape due to tie weights

### DIFF
--- a/paddlenlp/prompt/verbalizer.py
+++ b/paddlenlp/prompt/verbalizer.py
@@ -346,67 +346,47 @@ class SoftVerbalizer(Verbalizer):
         return self.head(outputs).squeeze(1)
 
     def head_parameters(self):
-        return [(n, p) for n, p in self.head.named_parameters() if self.weight_name in n or self.bias_name in n]
+        # possible head parameters: decoder.weight, decoder_bias, bias
+        return [(n, p) for n, p in self.head.named_parameters() if self.head_name[-1] in n or n == "bias"]
 
     def non_head_parameters(self):
-        return [(n, p) for n, p in self.head.named_parameters() if not (self.weight_name in n or self.bias_name in n)]
-
-    def _get_vocab_size(self, model: PretrainedModel):
-        try:
-            vocab_size = model.config.vocab_size
-        except AttributeError:
-            model_name = None
-            for name in model.state_dict():
-                if "layers" in name:
-                    model_name = name.split(".")[0]
-                    break
-            vocab_size = getattr(model, model_name).config["vocab_size"]
-        return vocab_size
+        return [(n, p) for n, p in self.head.named_parameters() if self.head_name[-1] not in n and n != "bias"]
 
     def _extract_head(self, model: PretrainedModel):
-        # Find all parameters shaped with [..., vocab_size].
-        weight_name, bias_name, is_linear = None, None, False
-        vocab_size = self._get_vocab_size(model)
-        for name in model.state_dict():
-            if vocab_size in model.state_dict()[name].shape and "embeddings" not in name:
-                if "bias" in name and (bias_name is None or len(name.split(".")) > len(bias_name)):
-                    bias_name = name.split(".")
-                elif "weight" in name:
-                    weight_name = name.split(".")
-                    if ".weight" in name:
-                        is_linear = True
-        if weight_name is None:
+        # Find the nn.Linear layer with in_features = vocab_size
+        module_name = None
+        for i in model.named_sublayers():
+            if isinstance(i[1], nn.Linear) and i[1].weight.shape[0] == model.config.vocab_size:
+                module_name = i[0]
+                break
+        if module_name is None:
             raise ValueError("Can not find output layer, make sure type of the input model is AutoModelForMaskedLM.")
 
-        # Reconstruct found parameters according to label words.
-        end_index = len(weight_name) - int(is_linear)
-        self.head_name = weight_name[:end_index]
-        self.head = copy.deepcopy(getattr(model, weight_name[0]))
-        module = self.head
-        for name in self.head_name[1:-1]:
-            module = getattr(module, name)
-        self.head = copy.deepcopy(module)
+        # recursively get the parent module to the decoder linear layer
+        parent_module = model
+        attribute_chain = module_name.split(".")
+        for name in attribute_chain[:-1]:
+            parent_module = getattr(parent_module, name)
+        self.head = copy.deepcopy(parent_module)
 
-        self.weight_name = weight_name[end_index - 1]
-        self.bias_name = bias_name[end_index - 1] if bias_name is not None else None
-        if is_linear:
-            module = getattr(self.head, self.weight_name)
-            setattr(self.head, self.weight_name, nn.Linear(len(self.labels), module.weight.shape[1], bias_attr=False))
-            getattr(self.head, self.weight_name).weight.set_value(self._create_init_weight(module.weight).T)
-        else:
-            module = paddle.to_tensor(getattr(self.head, self.weight_name))
-            new_head = nn.Linear(len(self.labels), module.shape[1], bias_attr=False)
-            new_head.weight.set_value(self._create_init_weight(module).T)
-
-            setattr(self.head, self.weight_name, new_head.weight)
-            getattr(self.head, self.weight_name).stop_gradient = False
-            if self.bias_name is not None:
-                setattr(
-                    self.head,
-                    self.bias_name,
-                    self.head.create_parameter(shape=[len(self.labels)], dtype=new_head.weight.dtype, is_bias=True),
-                )
-                getattr(self.head, self.bias_name).stop_gradient = False
+        # replace the decoder linear layer with a linear linear with the trimmed vocab size
+        self.head_name = attribute_chain
+        module_name = attribute_chain[-1]
+        module = getattr(self.head, module_name)
+        module_weight = module.weight
+        module_bias = module.bias
+        selected_weight = self._create_init_weight(module_weight)
+        selected_bias = self._create_init_weight(module_bias, is_bias=True)
+        setattr(self.head, module_name, nn.Linear(len(self.labels), module.weight.shape[1], bias_attr=False))
+        getattr(self.head, module_name).weight.set_value(selected_weight.T)
+        getattr(self.head, module_name).bias = self.head.create_parameter(
+            shape=[len(self.labels)], dtype=selected_bias.dtype, is_bias=True
+        )
+        getattr(self.head, module_name).bias.set_value(selected_bias)
+        if hasattr(self.head, "decoder_bias"):
+            self.head.decoder_bias = getattr(self.head, module_name).bias
+        elif hasattr(self.head, "bias"):
+            self.head.bias = getattr(self.head, module_name).bias
 
     def _create_init_weight(self, weight: Tensor, is_bias: bool = False):
         token_ids = self.token_ids.squeeze(1)

--- a/paddlenlp/transformers/albert/modeling.py
+++ b/paddlenlp/transformers/albert/modeling.py
@@ -759,14 +759,7 @@ class AlbertMLMHead(Layer):
             [config.vocab_size], is_bias=True, default_initializer=nn.initializer.Constant(value=0)
         )
         self.dense = nn.Linear(config.hidden_size, config.embedding_size)
-
-        self.tie_status = config.get("tie_word_embeddings", False)
-        # tie_weights() will tie decoder weight with input embeddings
-        if self.tie_status:
-            self.decoder = nn.Linear(config.vocab_size, config.embedding_size)
-        # use legacy decoder shape in order to load pretrained weights
-        else:
-            self.decoder = nn.Linear(config.embedding_size, config.vocab_size)
+        self.decoder = nn.Linear(config.vocab_size, config.embedding_size)
 
         self.activation = ACT2FN[config.hidden_act]
 
@@ -777,12 +770,7 @@ class AlbertMLMHead(Layer):
         hidden_states = self.dense(hidden_states)
         hidden_states = self.activation(hidden_states)
         hidden_states = self.layer_norm(hidden_states)
-
-        if self.tie_status:
-            hidden_states = paddle.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.bias
-        else:
-            hidden_states = self.decoder(hidden_states)
-
+        hidden_states = paddle.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.bias
         prediction_scores = hidden_states
         return prediction_scores
 

--- a/paddlenlp/transformers/ernie/configuration.py
+++ b/paddlenlp/transformers/ernie/configuration.py
@@ -1268,7 +1268,7 @@ class ErnieConfig(PretrainedConfig):
         fuse: bool = False,
         layer_norm_eps=1e-12,
         use_cache=False,
-        use_task_id=True,
+        use_task_id=False,
         enable_recompute=False,
         **kwargs
     ):

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -757,8 +757,6 @@ class ErnieLMPredictionHead(nn.Layer):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.activation(hidden_states)
         hidden_states = self.layer_norm(hidden_states)
-        # print(paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True).shape)
-        # print(self.decoder_bias)
         hidden_states = paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.decoder_bias
         return hidden_states
 

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -737,7 +737,6 @@ class ErnieLMPredictionHead(nn.Layer):
     def __init__(
         self,
         config: ErnieConfig,
-        embedding_weights=None,
         weight_attr=None,
     ):
         super(ErnieLMPredictionHead, self).__init__()
@@ -745,19 +744,12 @@ class ErnieLMPredictionHead(nn.Layer):
         self.transform = nn.Linear(config.hidden_size, config.hidden_size, weight_attr=weight_attr)
         self.activation = getattr(nn.functional, config.hidden_act)
         self.layer_norm = nn.LayerNorm(config.hidden_size)
-        self.decoder_weight = (
-            self.create_parameter(
-                shape=[config.vocab_size, config.hidden_size],
-                dtype=self.transform.weight.dtype,
-                attr=weight_attr,
-                is_bias=False,
-            )
-            if embedding_weights is None
-            else embedding_weights
+        self.bias = self.create_parameter(
+            [config.vocab_size], is_bias=True, default_initializer=nn.initializer.Constant(value=0)
         )
-        self.decoder_bias = self.create_parameter(
-            shape=[config.vocab_size], dtype=self.decoder_weight.dtype, is_bias=True
-        )
+        self.decoder = nn.Linear(config.vocab_size, config.hidden_size)
+        # link bias
+        self.decoder.bias = self.bias
 
     def forward(self, hidden_states, masked_positions=None):
         if masked_positions is not None:
@@ -767,8 +759,7 @@ class ErnieLMPredictionHead(nn.Layer):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.activation(hidden_states)
         hidden_states = self.layer_norm(hidden_states)
-        decoder_weight = paddle.transpose(self.decoder_weight, perm=[1, 0])
-        hidden_states = paddle.tensor.matmul(hidden_states, decoder_weight, transpose_y=False) + self.decoder_bias
+        hidden_states = paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.bias
         return hidden_states
 
 
@@ -776,11 +767,10 @@ class ErniePretrainingHeads(nn.Layer):
     def __init__(
         self,
         config: ErnieConfig,
-        embedding_weights=None,
         weight_attr=None,
     ):
         super(ErniePretrainingHeads, self).__init__()
-        self.predictions = ErnieLMPredictionHead(config, embedding_weights, weight_attr)
+        self.predictions = ErnieLMPredictionHead(config, weight_attr)
         self.seq_relationship = nn.Linear(config.hidden_size, 2, weight_attr=weight_attr)
 
     def forward(self, sequence_output, pooled_output, masked_positions=None):
@@ -835,11 +825,14 @@ class ErnieForPretraining(ErniePretrainedModel):
         )
         self.cls = ErniePretrainingHeads(
             config=config,
-            embedding_weights=self.ernie.embeddings.word_embeddings.weight,
             weight_attr=weight_attr,
         )
 
         self.apply(self.init_weights)
+        self.tie_weights()
+
+    def get_output_embeddings(self):
+        return self.cls.predictions.decoder
 
     def forward(
         self,
@@ -979,9 +972,9 @@ class ErniePretrainingCriterion(paddle.nn.Layer):
 
 
 class ErnieOnlyMLMHead(nn.Layer):
-    def __init__(self, config: ErnieConfig, embedding_weights):
+    def __init__(self, config: ErnieConfig):
         super().__init__()
-        self.predictions = ErnieLMPredictionHead(config=config, embedding_weights=embedding_weights)
+        self.predictions = ErnieLMPredictionHead(config=config)
 
     def forward(self, sequence_output, masked_positions=None):
         prediction_scores = self.predictions(sequence_output, masked_positions)
@@ -1001,12 +994,13 @@ class ErnieForMaskedLM(ErniePretrainedModel):
     def __init__(self, config: ErnieConfig):
         super(ErnieForMaskedLM, self).__init__(config)
         self.ernie = ErnieModel(config)
-        self.cls = ErnieOnlyMLMHead(
-            config=config,
-            embedding_weights=self.ernie.embeddings.word_embeddings.weight,
-        )
+        self.cls = ErnieOnlyMLMHead(config=config)
 
         self.apply(self.init_weights)
+        self.tie_weights()
+
+    def get_output_embeddings(self):
+        return self.cls.predictions.decoder
 
     def forward(
         self,

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -745,11 +745,9 @@ class ErnieLMPredictionHead(nn.Layer):
         self.activation = getattr(nn.functional, config.hidden_act)
         self.layer_norm = nn.LayerNorm(config.hidden_size)
         self.decoder = nn.Linear(config.vocab_size, config.hidden_size)
-        self.decoder.bias = self.create_parameter(
+        self.decoder_bias = self.create_parameter(
             [config.vocab_size], is_bias=True, default_initializer=nn.initializer.Constant(value=0)
         )
-        # link bias for loading pretrained weights
-        self.decoder_bias = self.decoder.bias
 
     def forward(self, hidden_states, masked_positions=None):
         if masked_positions is not None:

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -759,7 +759,10 @@ class ErnieLMPredictionHead(nn.Layer):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.activation(hidden_states)
         hidden_states = self.layer_norm(hidden_states)
+        print(hidden_states)
+        print(paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True))
         hidden_states = paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.bias
+        print(self.bias)
         return hidden_states
 
 

--- a/paddlenlp/transformers/ernie/modeling.py
+++ b/paddlenlp/transformers/ernie/modeling.py
@@ -748,7 +748,7 @@ class ErnieLMPredictionHead(nn.Layer):
         self.decoder.bias = self.create_parameter(
             [config.vocab_size], is_bias=True, default_initializer=nn.initializer.Constant(value=0)
         )
-        # link bias
+        # link bias for loading pretrained weights
         self.decoder_bias = self.decoder.bias
 
     def forward(self, hidden_states, masked_positions=None):
@@ -759,6 +759,8 @@ class ErnieLMPredictionHead(nn.Layer):
         hidden_states = self.transform(hidden_states)
         hidden_states = self.activation(hidden_states)
         hidden_states = self.layer_norm(hidden_states)
+        # print(paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True).shape)
+        # print(self.decoder_bias)
         hidden_states = paddle.tensor.matmul(hidden_states, self.decoder.weight, transpose_y=True) + self.decoder_bias
         return hidden_states
 

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -595,13 +595,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
         """
         Tie the weights between the input embeddings and the output embeddings.
         """
-        tie_word_embeddings = (
-            self.tie_word_embeddings
-            if hasattr(self, "tie_word_embeddings")
-            else self.config.get("tie_word_embeddings", False)
-        )
-
-        if tie_word_embeddings:
+        if self.config.tie_word_embeddings:
             output_embeddings = self.get_output_embeddings()
             input_embeddings = self.get_input_embeddings()
             if output_embeddings is not None and input_embeddings is not None:

--- a/tests/prompt/test_verbalizer.py
+++ b/tests/prompt/test_verbalizer.py
@@ -189,17 +189,17 @@ class VerbalizerTest(unittest.TestCase):
         [
             (
                 "__internal_testing__/tiny-random-ernie",
-                ["cls", "predictions", "decoder_weight"],
+                ["cls", "predictions", "decoder"],
                 ErnieLMPredictionHead,
-                ["decoder_weight", "decoder_bias"],
+                ["decoder_bias", "decoder.weight"],
                 ["transform.weight", "transform.bias", "layer_norm.weight", "layer_norm.bias"],
             ),
             (
                 "albert-chinese-tiny",
                 ["predictions", "decoder"],
                 AlbertMLMHead,
-                ["decoder.weight"],
-                ["bias", "layer_norm.weight", "layer_norm.bias", "dense.weight", "dense.bias"],
+                ["bias", "decoder.weight"],
+                ["layer_norm.weight", "layer_norm.bias", "dense.weight", "dense.bias"],
             ),
         ]
     )
@@ -207,14 +207,12 @@ class VerbalizerTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model = AutoModelForMaskedLM.from_pretrained(model_name)
         verb = SoftVerbalizer(self.default_label_words, tokenizer, model)
-
         self.assertEqual(verb.head_name, head_name)
         self.assertTrue(isinstance(verb.head, head_class))
         self.assertTrue(isinstance(getattr(model, head_name[0]), MaskedLMIdentity))
         module = getattr(verb.head, verb.head_name[-1])
         module = module.weight if isinstance(module, paddle.nn.Linear) else module
         self.assertTrue(len(self.default_label_words) in module.shape)
-
         self.assertEqual([x[0] for x in verb.head_parameters()], head_params)
         self.assertEqual([x[0] for x in verb.non_head_parameters()], non_head_params)
 

--- a/tests/prompt/test_verbalizer.py
+++ b/tests/prompt/test_verbalizer.py
@@ -193,15 +193,14 @@ class VerbalizerTest(unittest.TestCase):
                 ErnieLMPredictionHead,
                 ["decoder_weight", "decoder_bias"],
                 ["transform.weight", "transform.bias", "layer_norm.weight", "layer_norm.bias"],
-            )
-            # ,
-            # (
-            #     "albert-chinese-tiny",
-            #     ["predictions", "decoder"],
-            #     AlbertMLMHead,
-            #     ["decoder.weight"],
-            #     ["bias", "layer_norm.weight", "layer_norm.bias", "dense.weight", "dense.bias"],
-            # ),
+            ),
+            (
+                "albert-chinese-tiny",
+                ["predictions", "decoder"],
+                AlbertMLMHead,
+                ["decoder.weight"],
+                ["bias", "layer_norm.weight", "layer_norm.bias", "dense.weight", "dense.bias"],
+            ),
         ]
     )
     def test_soft_initialization(self, model_name, head_name, head_class, head_params, non_head_params):

--- a/tests/transformers/ernie/test_modeling.py
+++ b/tests/transformers/ernie/test_modeling.py
@@ -456,7 +456,6 @@ class ErnieModelIntegrationTest(unittest.TestCase, ModelTesterPretrainedMixin):
         expected_slice = paddle.to_tensor(
             [[[-0.0664, -1.3266, -0.3922], [-0.2440, -1.3631, -1.0745], [-0.0986, -0.7947, -0.1932]]]
         )
-        print(output[:, 1:4, 1:4])
         self.assertTrue(paddle.allclose(output[:, 1:4, 1:4], expected_slice, atol=1e-4))
 
     @slow

--- a/tests/transformers/ernie/test_modeling.py
+++ b/tests/transformers/ernie/test_modeling.py
@@ -456,6 +456,7 @@ class ErnieModelIntegrationTest(unittest.TestCase, ModelTesterPretrainedMixin):
         expected_slice = paddle.to_tensor(
             [[[-0.0664, -1.3266, -0.3922], [-0.2440, -1.3631, -1.0745], [-0.0986, -0.7947, -0.1932]]]
         )
+        print(output[:, 1:4, 1:4])
         self.assertTrue(paddle.allclose(output[:, 1:4, 1:4], expected_slice, atol=1e-4))
 
     @slow


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
- Fix prompt tuning head extraction, now that nn.linear also have a shape of `[vocab, hidden]`
- upgrade ernie to use the new tie weights method. Confirmed that the new and the old tie weights gives the same results for ernie 1.0 MLM model
<!-- Describe what this PR does -->
