### PR TITLE
[Bug fixes] fix loading numpy ndarray bug

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1395,7 +1395,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             if dtype not in ["float32", "float16"]:
                 raise ValueError(f"the value of `dtype` should be one of [`float32`, `float16`], but received {dtype}")
             for key in state_dict.keys():
-                if isinstance(state_dict[key], np.ndarray) and isinstance(state_dict[key].dtype.type, np.floating):
+                if isinstance(state_dict[key], np.ndarray) and issubclass(state_dict[key].dtype.type, np.floating):
                     state_dict[key] = state_dict[key].astype(dtype=dtype)
                 if isinstance(state_dict[key], paddle.Tensor) and state_dict[key].is_floating_point():
                     state_dict[key] = paddle.cast(state_dict[key], dtype=dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

当state_dict[key] 为 numpy 浮点类型数组时，`isinstance(state_dict[key].dtype.type, np.floating)` 始终为 False，以下为复现测试代码：

```python
import paddle
import numpy as np

tensor = paddle.randn([2,3])

assert isinstance(tensor, paddle.Tensor)
assert tensor.is_floating_point()

np_tensor = tensor.numpy()
assert issubclass(np_tensor.dtype.type, np.floating)
```

原因是由于：`np_tensor.dtype.type` 是一个类，并不是一个是实例对象。
