### PR TITLE
[lora] fix warning

### DIFF
--- a/paddlenlp/layers/lora.py
+++ b/paddlenlp/layers/lora.py
@@ -683,9 +683,9 @@ class LoRAModel(nn.Layer):
         trainable_numel = 0
         for _, weight in self.model.state_dict().items():
             if weight.stop_gradient:
-                freeze_numel += weight.numel().numpy()[0]
+                freeze_numel += float(weight.numel())
             else:
-                trainable_numel += weight.numel().numpy()[0]
+                trainable_numel += float(weight.numel())
         logger.info(
             f"Frozen parameters: {freeze_numel:.2e} || Trainable parameters:{trainable_numel:.2e} || Total parameters:{freeze_numel+trainable_numel:.2e}|| Trainable:{trainable_numel / (freeze_numel+trainable_numel):.2%}"
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
 Bug fixes 

### PR changes
 APIs 
### Description
修复 warning
 Warning:: 0D Tensor cannot be used as 'Tensor.numpy()[0]' . In order to avoid this problem, 0D Tensor will be changed to 1D numpy currently, but it's not correct and will be removed in future. For Tensor contain only one element, Please modify  'Tensor.numpy()[0]' to 'float(Tensor)' as soon as possible, otherwise 'Tensor.numpy()[0]' will raise error in future.

