### PR TITLE
[Dy2St] Decorated Monkey Patch Function With @not_to_static

### DIFF
--- a/paddlenlp/transformers/model_outputs.py
+++ b/paddlenlp/transformers/model_outputs.py
@@ -71,6 +71,7 @@ def layer_init_wrapper(func):
     return _impl
 
 
+@paddle.jit.not_to_static
 def _transformer_encoder_layer_fwd(self, src, src_mask=None, cache=None, output_attentions=False):
     self.self_attn.need_weights = output_attentions
     src_mask = _convert_attention_mask(src_mask, src.dtype)
@@ -102,6 +103,7 @@ def _transformer_encoder_layer_fwd(self, src, src_mask=None, cache=None, output_
     return src if outputs is None else ((src,) + outputs[::-1])  # hidden_states, cache, attentions
 
 
+@paddle.jit.not_to_static
 def _transformer_decoder_layer_fwd(
     self,
     tgt,
@@ -179,6 +181,7 @@ def _transformer_decoder_layer_fwd(
         return outputs
 
 
+@paddle.jit.not_to_static
 def _transformer_decoder_fwd(
     self,
     tgt,
@@ -263,6 +266,7 @@ def _transformer_decoder_fwd(
     )
 
 
+@paddle.jit.not_to_static
 def _transformer_encoder_fwd(
     self, src, src_mask=None, cache=None, output_attentions=False, output_hidden_states=False, return_dict=False
 ):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

此文件中的部分函数是通过 monkey patch 的机制动态修改了paddle内部API函数的指向，导致会误触发动转静的AST转写，与之前「Paddle内部API源码默认不做AST转写」这一假设违背，因为手动在函数定义处加上 `@paddle.jit.not_to_static`。

此PR后，支持对模型的subLayer单独进行to_static.