### PR TITLE
Remove dtype from __init__

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1539,7 +1539,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 **kwargs,
             )
 
-        dtype = kwargs.pop("dtype", config.dtype)
+        dtype = model_kwargs.pop("dtype", config.dtype)
 
         init_contexts = []
         if low_cpu_mem_usage:
@@ -1561,7 +1561,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             config.save_pretrained(cache_dir)
 
         # PretrainedConfig auto contains dtype field
-        dtype = kwargs.pop("dtype", config.get("dtype", None))
+        dtype = model_kwargs.pop("dtype", config.get("dtype", None))
         init_contexts = []
         if low_cpu_mem_usage:
             load_state_as_np = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
- model_kwargs has an unexpected parameter `dtype` when `dtype` is set in `from_pretrained`.