### PR TITLE
add memory efficient attention to gpt3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,11 @@ FETCH_HEAD
 # vscode
 .vscode
 ./ppdiffusers/ppdiffusers/version.py
+
+# data and parameter
+model_zoo/gpt-3/data/
+model_zoo/gpt-3/log_mea_175B/
+model_zoo/gpt-3/log/
+model_zoo/gpt-3/output/
+model_zoo/gpt-3/my-gpt2_text/
+model_zoo/gpt-3/__MACOSX/

--- a/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -38,7 +38,7 @@ Model:
   scale_qk_by_layer_num: True
   sequence_parallel: False
   use_flash_attn: False
-  use_memory_attn: True
+  use_memory_attn: False
   fused_softmax_with_triangular: True
 
 

--- a/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -38,6 +38,7 @@ Model:
   scale_qk_by_layer_num: True
   sequence_parallel: False
   use_flash_attn: False
+  use_memory_attn: True
   fused_softmax_with_triangular: True
 
 

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -25,7 +25,7 @@ import paddle.incubate as incubate
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.tensor as tensor
-import paddle.incubate.nn.attn_bias as ab
+# import paddle.incubate.nn.attn_bias as ab
 from paddle.autograd import PyLayer
 from paddle.common_ops_import import convert_dtype
 from paddle.distributed.fleet.meta_parallel import (
@@ -330,13 +330,13 @@ class MultiHeadAttention(nn.Layer):
             # attn_mask = ab.LowerTriangularMask()
             
         out = memory_efficient_attention(
-            q, 
-            k, 
-            v, 
-            attn_mask, 
-            self.dropout, 
-            -1.0, 
-            self.training
+            query=q, 
+            key=k, 
+            value=v, 
+            attn_bias=attn_mask, 
+            p=self.dropout, 
+            scale=None, 
+            training=self.training,
         )
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
         if self.sequence_parallel:
@@ -793,10 +793,10 @@ class GPTModelHybrid(nn.Layer):
 
         if use_memory_attn:
             if memory_efficient_attention:
-                logger.info("Memory-attntion enabled.")
+                logger.info("Memory-efficient-attention enabled.")
             else:
                 use_memory_attn = False
-                logger.warning("Memory-attntion is not support in this Paddle version.")
+                logger.warning("Memory-efficient-attention is not support in this Paddle version.")
                 
         hcg = env.get_hcg()
         mp_size = hcg.get_model_parallel_world_size()

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -324,7 +324,7 @@ class MultiHeadAttention(nn.Layer):
             v = tensor.transpose(x=v, perm=perm)
             
         if attn_mask is None:
-            mask = paddle.full(shape=[q.shape[0], q.shape[2], q.shape[1], k.shape[1]], fill_value=-np.inf)
+            mask = paddle.full(shape=[q.shape[0], q.shape[2], q.shape[1], k.shape[1]], fill_value=-np.inf, dtype=p.dtype)
             attn_mask = paddle.triu(mask, diagonal=1)
             attn_mask.stop_gradient = False
             # attn_mask = ab.LowerTriangularMask()

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -25,6 +25,7 @@ import paddle.incubate as incubate
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.tensor as tensor
+import paddle.incubate.nn.attn_bias as ab
 from paddle.autograd import PyLayer
 from paddle.common_ops_import import convert_dtype
 from paddle.distributed.fleet.meta_parallel import (
@@ -64,7 +65,15 @@ try:
 except:
     FusedDropoutAdd = None
 FusedDropoutAdd = None
+    
+try:
+    from paddle.incubate.nn.memory_efficient_attention import (
+    memory_efficient_attention,
+)
+except:
+    memory_efficient_attention = None
 
+from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
 
 def get_attr(layer, name):
     if getattr(layer, name, None) is not None:
@@ -124,6 +133,7 @@ class MultiHeadAttention(nn.Layer):
         sequence_parallel=False,
         do_recompute=True,
         use_flash_attn=False,
+        use_memory_attn=False,
     ):
         super(MultiHeadAttention, self).__init__()
         self.embed_dim = embed_dim
@@ -139,6 +149,7 @@ class MultiHeadAttention(nn.Layer):
         self.do_recompute = do_recompute
         self.sequence_parallel = sequence_parallel
         self.use_flash_attn = use_flash_attn if flash_attention else None
+        self.use_memory_attn = use_memory_attn if memory_efficient_attention else None
 
         if sequence_parallel:
             ColumnParallelLinear = ColumnSequenceParallelLinear
@@ -302,18 +313,50 @@ class MultiHeadAttention(nn.Layer):
         if self.sequence_parallel:
             perm = [1, 0, 2]
             out = tensor.transpose(x=out, perm=perm)
-        return (out, weights) if self.need_weights else out
+        return out, weights
+    
+    def _memory_efficient_attention(self, q, k, v, attn_mask=None):
+        perm = [1, 2, 0, 3] if self.sequence_parallel else [0, 2, 1, 3]
+        q_temp = tensor.transpose(x=q, perm=perm)
+        k_temp = tensor.transpose(x=k, perm=perm)
+        product = paddle.matmul(x=q_temp, y=k_temp, transpose_y=True)
+        
+        if self.sequence_parallel:
+            perm = [1, 0, 2, 3]
+            q = tensor.transpose(x=q, perm=perm)
+            k = tensor.transpose(x=k, perm=perm)
+            v = tensor.transpose(x=v, perm=perm)
+            
+        if attn_mask is None:
+            attn_mask = get_triangle_upper_mask(product, attn_mask)
+            attn_mask.stop_gradient = False
+            # attn_mask = ab.LowerTriangularMask()
+            
+        out = memory_efficient_attention(
+            q, 
+            k, 
+            v, 
+            attn_mask, 
+            self.dropout, 
+            -1.0, 
+            self.training
+        )
+        out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+        if self.sequence_parallel:
+            perm = [1, 0, 2]
+            out = tensor.transpose(x=out, perm=perm)
+        return out
 
     def core_attn(self, q, k, v, attn_mask=None):
         perm = [1, 2, 0, 3] if self.sequence_parallel else [0, 2, 1, 3]
         q = tensor.transpose(x=q, perm=perm)
         k = tensor.transpose(x=k, perm=perm)
         v = tensor.transpose(x=v, perm=perm)
-
+        
         # scale dot product attention
         scale_qk_coeff = self.scale_qk_coeff * self.head_dim**0.5
         product = paddle.matmul(x=q.scale(1.0 / scale_qk_coeff), y=k, transpose_y=True)
-
+        
         if self.scale_qk_coeff != 1.0:
             product = product.scale(self.scale_qk_coeff)
 
@@ -356,23 +399,32 @@ class MultiHeadAttention(nn.Layer):
         # no matter sequence_parallel is true or false,
         # after reshape, q, k, v shape should be [b, num_heads/n, s, head_dim]
         # compute q ,k ,v
+                
         if self.fuse_attn_qkv:
             q, k, v, cache = self._fuse_prepare_qkv(query, use_cache, cache)
         else:
             q, k, v, cache = self._prepare_qkv(query, key, value, use_cache, cache)
-
+        
         if self.use_flash_attn and attn_mask is None:
             attn_func = self._flash_attention
+        if self.use_memory_attn and not self.need_weights:
+            attn_func = self._memory_efficient_attention
         else:
             attn_func = self.core_attn
 
         if self.use_recompute and self.recompute_granularity == "core_attn" and self.do_recompute:
-            out = recompute(attn_func, q, k, v, attn_mask)
+            attn_outs = recompute(attn_func, q, k, v, attn_mask)
         else:
-            out = attn_func(q, k, v, attn_mask=attn_mask)
-
+            attn_outs = attn_func(q, k, v, attn_mask=attn_mask)
+        
         if self.need_weights:
-            out, weights = out
+            assert not self.use_memory_attn, "the output of memory attn doesn't have weights"
+            
+        if self.use_memory_attn:
+            out = attn_outs
+        else:
+            out = attn_outs[0]
+            weights = attn_outs[1]
 
         # project to output
         # if sequence_parallel is true, out shape are [s/n, b, h],
@@ -381,6 +433,7 @@ class MultiHeadAttention(nn.Layer):
 
         outs = [out]
         if self.need_weights:
+            assert self.use_memory_attn, "the output of memory attn doesn't have weights"
             outs.append(weights)
         if use_cache:
             outs.append(cache)
@@ -502,6 +555,7 @@ class TransformerDecoderLayer(nn.Layer):
         do_recompute=True,
         skip_quant_tensors=[],
         use_flash_attn=False,
+        use_memory_attn=False,
     ):
         self._config = locals()
         self._config.pop("self")
@@ -543,6 +597,7 @@ class TransformerDecoderLayer(nn.Layer):
             sequence_parallel=sequence_parallel,
             do_recompute=do_recompute,
             use_flash_attn=use_flash_attn,
+            use_memory_attn=use_memory_attn,
         )
 
         self.linear1 = ColumnParallelLinear(
@@ -719,6 +774,7 @@ class GPTModelHybrid(nn.Layer):
         skip_tensor_map={},
         freeze_embedding=False,
         use_flash_attn=False,
+        use_memory_attn=False,
         fused_softmax_with_triangular=False,
     ):
 
@@ -738,6 +794,13 @@ class GPTModelHybrid(nn.Layer):
                 use_flash_attn = False
                 logger.warning("Flash-attention is not support in this Paddle version.")
 
+        if use_memory_attn:
+            if memory_efficient_attention:
+                logger.info("Memory-attntion enabled.")
+            else:
+                use_memory_attn = False
+                logger.warning("Memory-attntion is not support in this Paddle version.")
+                
         hcg = env.get_hcg()
         mp_size = hcg.get_model_parallel_world_size()
         if mp_size <= 1:
@@ -786,6 +849,7 @@ class GPTModelHybrid(nn.Layer):
                     do_recompute=i not in no_recompute_layers,
                     skip_quant_tensors=skip_tensor_map.get("block_{}".format(i), []),
                     use_flash_attn=use_flash_attn,
+                    use_memory_attn=use_memory_attn,
                 )
             )
 
@@ -1022,6 +1086,7 @@ class GPTForPretrainingPipe(PipelineLayer):
         no_recompute_layers=None,
         pp_recompute_interval=1,
         use_flash_attn=False,
+        use_memory_attn=False,
         fused_softmax_with_triangular=False,
     ):
 
@@ -1041,6 +1106,13 @@ class GPTForPretrainingPipe(PipelineLayer):
                 use_flash_attn = False
                 logger.warning("Flash-attention is not support in this Paddle version.")
 
+        if use_memory_attn:
+            if memory_efficient_attention:
+                logger.info("Memory-efficient-attention enabled.")
+            else:
+                use_memory_attn = False
+                logger.warning("Memory-efficient-attention is not support in this Paddle version.")
+                
         hcg = env.get_hcg()
         mp_size = hcg.get_model_parallel_world_size()
         if mp_size <= 1:
@@ -1091,6 +1163,7 @@ class GPTForPretrainingPipe(PipelineLayer):
                     sequence_parallel=sequence_parallel,
                     do_recompute=i not in no_recompute_layers,
                     use_flash_attn=use_flash_attn,
+                    use_memory_attn=use_memory_attn,
                 )
             )
 
@@ -1569,7 +1642,6 @@ def get_triangle_upper_mask(x, mask):
     mask = paddle.triu(mask, diagonal=1)
     mask.stop_gradient = True
     return mask
-
 
 class ConcatSoftmaxInput(PyLayer):
     @staticmethod

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -430,7 +430,7 @@ class MultiHeadAttention(nn.Layer):
 
         outs = [out]
         if self.need_weights:
-            assert self.use_memory_attn, "the output of memory attn doesn't have weights"
+            assert not self.use_memory_attn, "the output of memory attn doesn't have weights"
             outs.append(weights)
         if use_cache:
             outs.append(cache)

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -260,6 +260,10 @@ class MultiHeadAttention(nn.Layer):
             q, k, v, cache = self._fuse_prepare_qkv(query, use_cache, cache)
         else:
             q, k, v, cache = self._prepare_qkv(query, key, value, use_cache, cache)
+            
+        if self.need_weights:
+            assert not self.use_memory_attn, "the output of memory attn doesn't have weights"
+            
         if self.use_recompute and self.recompute_granularity == "core_attn" and self.do_recompute:
             attn_outs = recompute(self.core_attn, q, k, v, attn_mask)
         elif self.use_flash_attn and attn_mask is None:
@@ -269,9 +273,6 @@ class MultiHeadAttention(nn.Layer):
         else:
             attn_outs = self.core_attn(q, k, v, attn_mask=attn_mask)
 
-        if self.need_weights:
-            assert not self.use_memory_attn, "the output of memory attn doesn't have weights"
-            
         if self.use_memory_attn:
             out = attn_outs
         else:

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -43,6 +43,12 @@ try:
 except:
     flash_attention = None
 
+try:
+    from paddle.incubate.nn.memory_efficient_attention import (
+    memory_efficient_attention,
+)
+except:
+    memory_efficient_attention = None
 
 def get_attr(layer, name):
     if getattr(layer, name, None) is not None:
@@ -80,6 +86,7 @@ class MultiHeadAttention(nn.Layer):
         recompute_granularity="full",
         do_recompute=True,
         use_flash_attn=False,
+        use_memory_attn=False,
     ):
         super(MultiHeadAttention, self).__init__()
         self.embed_dim = embed_dim
@@ -94,6 +101,7 @@ class MultiHeadAttention(nn.Layer):
         self.recompute_granularity = recompute_granularity
         self.do_recompute = do_recompute
         self.use_flash_attn = use_flash_attn if flash_attention else None
+        self.use_memory_attn = use_memory_attn if memory_efficient_attention else None
 
         self.head_dim = embed_dim // num_heads
         assert self.head_dim * num_heads == self.embed_dim, "embed_dim must be divisible by num_heads"
@@ -195,6 +203,20 @@ class MultiHeadAttention(nn.Layer):
         out, weights = flash_attention(q, k, v, self.dropout, causal=True, return_softmax=self.need_weights)
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
         return out, weights
+    
+    def _memory_efficient_attention(self, q, k, v, attn_mask=None):
+        scale_qk_coeff = self.scale_qk_coeff * self.head_dim**0.5
+        out = memory_efficient_attention(
+            q, 
+            k, 
+            v, 
+            attn_mask, 
+            self.dropout, 
+            1.0 / scale_qk_coeff, 
+            self.training
+        )
+        out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+        return out 
 
     def core_attn(self, q, k, v, attn_mask=None):
         perm = [0, 2, 1, 3]
@@ -234,18 +256,29 @@ class MultiHeadAttention(nn.Layer):
         key = query if key is None else key
         value = query if value is None else value
         # compute q ,k ,v
+        
         if self.fuse_attn_qkv:
             q, k, v, cache = self._fuse_prepare_qkv(query, use_cache, cache)
         else:
             q, k, v, cache = self._prepare_qkv(query, key, value, use_cache, cache)
-
         if self.use_recompute and self.recompute_granularity == "core_attn" and self.do_recompute:
-            out, weights = recompute(self.core_attn, q, k, v, attn_mask)
+            attn_outs = recompute(self.core_attn, q, k, v, attn_mask)
         elif self.use_flash_attn and attn_mask is None:
-            out, weights = self._flash_attention(q, k, v)
+            attn_outs = self._flash_attention(q, k, v)
+        elif self.use_memory_attn and not self.need_weights:
+            attn_outs = self._memory_efficient_attention(q, k, v, attn_mask)
         else:
-            out, weights = self.core_attn(q, k, v, attn_mask=attn_mask)
+            attn_outs = self.core_attn(q, k, v, attn_mask=attn_mask)
 
+        if self.need_weights:
+            assert not self.use_memory_attn, "the output of memory attn doesn't have weights"
+            
+        if self.use_memory_attn:
+            out = attn_outs
+        else:
+            out = attn_outs[0]
+            weights = attn_outs[1]
+            
         # project to output
         out = self.out_proj(out)
 
@@ -362,6 +395,7 @@ class TransformerDecoderLayer(nn.Layer):
         do_recompute=True,
         skip_quant_tensors=[],
         use_flash_attn=False,
+        use_memory_attn=False,
     ):
         self._config = locals()
         self._config.pop("self")
@@ -395,6 +429,7 @@ class TransformerDecoderLayer(nn.Layer):
             recompute_granularity=recompute_granularity,
             do_recompute=do_recompute,
             use_flash_attn=use_flash_attn,
+            use_memory_attn=use_memory_attn,
         )
 
         self.linear1 = Linear(d_model, dim_feedforward, weight_attrs[2], bias_attr=bias_attrs[2])
@@ -522,6 +557,7 @@ class GPTModel(nn.Layer):
         skip_tensor_map={},
         freeze_embedding=False,
         use_flash_attn=False,
+        use_memory_attn=False,
         fused_softmax_with_triangular=False,
     ):
 
@@ -541,6 +577,13 @@ class GPTModel(nn.Layer):
                 use_flash_attn = False
                 logger.warning("Flash-attention is not support in this Paddle version.")
 
+        if use_memory_attn:
+            if memory_efficient_attention:
+                logger.info("Memory-attntion enabled.")
+            else:
+                use_memory_attn = False
+                logger.warning("Memory-attntion is not support in this Paddle version.")
+            
         self.embeddings = GPTEmbeddings(
             vocab_size,
             hidden_size,
@@ -580,6 +623,7 @@ class GPTModel(nn.Layer):
                     do_recompute=i not in no_recompute_layers,
                     skip_quant_tensors=skip_tensor_map.get("block_{}".format(i), []),
                     use_flash_attn=use_flash_attn,
+                    use_memory_attn=use_memory_attn,
                 )
             )
 

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -206,13 +206,13 @@ class MultiHeadAttention(nn.Layer):
     
     def _memory_efficient_attention(self, q, k, v, attn_mask=None):
         out = memory_efficient_attention(
-            q, 
-            k, 
-            v, 
-            attn_mask, 
-            self.dropout, 
-            None, 
-            self.training
+            query=q, 
+            key=k, 
+            value=v, 
+            attn_bias=attn_mask, 
+            p=self.dropout, 
+            scale=None, 
+            training=self.training,
         )
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
         return out 
@@ -578,10 +578,10 @@ class GPTModel(nn.Layer):
 
         if use_memory_attn:
             if memory_efficient_attention:
-                logger.info("Memory-attntion enabled.")
+                logger.info("Memory-efficient-attention enabled.")
             else:
                 use_memory_attn = False
-                logger.warning("Memory-attntion is not support in this Paddle version.")
+                logger.warning("Memory-efficient-attention is not support in this Paddle version.")
             
         self.embeddings = GPTEmbeddings(
             vocab_size,

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -205,14 +205,13 @@ class MultiHeadAttention(nn.Layer):
         return out, weights
     
     def _memory_efficient_attention(self, q, k, v, attn_mask=None):
-        scale_qk_coeff = self.scale_qk_coeff * self.head_dim**0.5
         out = memory_efficient_attention(
             q, 
             k, 
             v, 
             attn_mask, 
             self.dropout, 
-            1.0 / scale_qk_coeff, 
+            None, 
             self.training
         )
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
New features

### PR changes
Others

### Description
Add memory efficient attention in GPT-3. It can be set by changing 'use_memory_attn' in "pretrain_gpt_base.yaml".
