### PR TITLE
Fix GPT setup.py

### DIFF
--- a/model_zoo/gpt-3/external_ops/setup.py
+++ b/model_zoo/gpt-3/external_ops/setup.py
@@ -32,7 +32,8 @@ def run(func):
 
 def change_pwd():
     path = os.path.dirname(__file__)
-    os.chdir(path)
+    if path:
+        os.chdir(path)
 
 
 def setup_fast_ln():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Fix bug when `path` is empty in `external_ops/setup.py`.