### PR TITLE
[Function optimization] default target_name is source_name

### DIFF
--- a/paddlenlp/transformers/albert/modeling.py
+++ b/paddlenlp/transformers/albert/modeling.py
@@ -23,7 +23,7 @@ import paddle.nn.functional as F
 from paddle.nn import Layer
 
 from ...layers import Linear as TransposedLinear
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.env import CONFIG_NAME
 from .. import PretrainedModel, register_base_model
 from ..activations import ACT2FN
@@ -362,69 +362,51 @@ class AlbertPretrainedModel(PretrainedModel):
     @classmethod
     def _get_name_mappings(cls, config: AlbertConfig) -> List[StateDictNameMapping]:
         model_mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"],
-            ["embeddings.token_type_embeddings.weight", "embeddings.token_type_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
-            ["encoder.embedding_hidden_mapping_in.weight", "encoder.embedding_hidden_mapping_in.weight", "transpose"],
-            ["encoder.embedding_hidden_mapping_in.bias", "encoder.embedding_hidden_mapping_in.bias"],
+            ["encoder.embedding_hidden_mapping_in.weight", None, "transpose"],
+            "encoder.embedding_hidden_mapping_in.bias",
         ]
 
         if config.add_pooling_layer:
             model_mappings.extend(
                 [
-                    ["pooler.weight", "pooler.weight", "transpose"],
-                    ["pooler.bias", "pooler.bias"],
+                    ["pooler.weight", None, "transpose"],
+                    ["pooler.bias"],
                 ]
             )
 
         for group_index in range(config.num_hidden_groups):
             group_mappings = [
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.weight",
-                ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.weight",
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.full_layer_layer_norm.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.query.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.query.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.query.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.query.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.query.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.key.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.key.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.key.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.key.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.key.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.value.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.value.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.value.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.value.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.value.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.dense.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.dense.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.dense.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.dense.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.dense.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.LayerNorm.weight",
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.attention.layer_norm.weight",
@@ -435,25 +417,20 @@ class AlbertPretrainedModel(PretrainedModel):
                 ],
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn.bias",
                 [
                     f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn_output.weight",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn_output.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn_output.bias",
-                    f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn_output.bias",
-                ],
+                f"encoder.albert_layer_groups.{group_index}.albert_layers.0.ffn_output.bias",
             ]
             model_mappings.extend(group_mappings)
 
+        init_name_mappings(model_mappings)
         # base-model prefix "AlbertModel"
         if "AlbertModel" not in config.architectures:
             for mapping in model_mappings:

--- a/paddlenlp/transformers/bart/modeling.py
+++ b/paddlenlp/transformers/bart/modeling.py
@@ -23,7 +23,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.nn import Embedding, Layer, MultiHeadAttention
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.env import CONFIG_NAME
 from ...utils.log import logger
 from .. import PretrainedModel, register_base_model
@@ -86,7 +86,7 @@ class BartPretrainedModel(PretrainedModel):
     @classmethod
     def _get_name_mappings(cls, config: BartConfig) -> List[StateDictNameMapping]:
         model_mappings = [
-            ["shared.weight", "shared.weight"],
+            "shared.weight",
         ]
 
         num_encoder_layers = config.num_encoder_layers or 0
@@ -305,6 +305,8 @@ class BartPretrainedModel(PretrainedModel):
                 ]
 
                 model_mappings.extend(decoder_mappings)
+
+        init_name_mappings(model_mappings)
 
         # base-model prefix "BartModel"
         if "BartModel" not in config.architectures:

--- a/paddlenlp/transformers/bert/modeling.py
+++ b/paddlenlp/transformers/bert/modeling.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from paddlenlp.transformers.model_utils import PretrainedModel, register_base_model
 
 from ...layers import Linear as TransposedLinear
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.env import CONFIG_NAME
 from ..model_outputs import (
     BaseModelOutputWithPoolingAndCrossAttentions,
@@ -153,13 +153,13 @@ class BertPretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config: BertConfig) -> list[StateDictNameMapping]:
         mappings: list[StateDictNameMapping] = []
         model_mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"],
-            ["embeddings.token_type_embeddings.weight", "embeddings.token_type_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
-            ["pooler.dense.weight", "pooler.dense.weight", "transpose"],
-            ["pooler.dense.bias", "pooler.dense.bias"],
+            ["pooler.dense.weight", None, "transpose"],
+            "pooler.dense.bias",
             # for TokenClassification
         ]
         for layer_index in range(config.num_hidden_layers):
@@ -224,6 +224,8 @@ class BertPretrainedModel(PretrainedModel):
                 [f"encoder.layer.{layer_index}.output.LayerNorm.bias", f"encoder.layers.{layer_index}.norm2.bias"],
             ]
             model_mappings.extend(layer_mappings)
+
+        init_name_mappings(model_mappings)
 
         # base-model prefix "BertModel"
         if "BertModel" not in config.architectures:

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -34,7 +34,7 @@ from paddlenlp.transformers.model_outputs import (
     TokenClassifierOutput,
 )
 from paddlenlp.transformers.model_utils import PretrainedModel
-from paddlenlp.utils.converter import StateDictNameMapping
+from paddlenlp.utils.converter import StateDictNameMapping, init_name_mappings
 from paddlenlp.utils.log import logger
 
 from .configuration import BloomConfig
@@ -757,33 +757,35 @@ class BloomPreTrainedModel(PretrainedModel):
     @classmethod
     def _get_name_mappings(cls, config: BloomConfig) -> list[StateDictNameMapping]:
         hard_mapping = [
-            ["word_embeddings.weight", "word_embeddings.weight"],
-            ["word_embeddings_layernorm.weight", "word_embeddings_layernorm.weight"],
-            ["word_embeddings_layernorm.bias", "word_embeddings_layernorm.bias"],
-            ["ln_f.weight", "ln_f.weight"],
-            ["ln_f.bias", "ln_f.bias"],
+            "word_embeddings.weight",
+            "word_embeddings_layernorm.weight",
+            "word_embeddings_layernorm.bias",
+            "ln_f.weight",
+            "ln_f.bias",
         ]
         for i in range(config.n_layer):
             hard_mapping.extend(
                 [
-                    [f"h.{i}.input_layernorm.weight", f"h.{i}.input_layernorm.weight"],
-                    [f"h.{i}.input_layernorm.bias", f"h.{i}.input_layernorm.bias"],
+                    f"h.{i}.input_layernorm.weight",
+                    f"h.{i}.input_layernorm.bias",
                     [
                         f"h.{i}.self_attention.query_key_value.weight",
-                        f"h.{i}.self_attention.query_key_value.weight",
+                        None,
                         "transpose",
                     ],
-                    [f"h.{i}.self_attention.query_key_value.bias", f"h.{i}.self_attention.query_key_value.bias"],
-                    [f"h.{i}.self_attention.dense.weight", f"h.{i}.self_attention.dense.weight", "transpose"],
-                    [f"h.{i}.self_attention.dense.bias", f"h.{i}.self_attention.dense.bias"],
-                    [f"h.{i}.post_attention_layernorm.weight", f"h.{i}.post_attention_layernorm.weight"],
-                    [f"h.{i}.post_attention_layernorm.bias", f"h.{i}.post_attention_layernorm.bias"],
-                    [f"h.{i}.mlp.dense_h_to_4h.weight", f"h.{i}.mlp.dense_h_to_4h.weight", "transpose"],
-                    [f"h.{i}.mlp.dense_h_to_4h.bias", f"h.{i}.mlp.dense_h_to_4h.bias"],
-                    [f"h.{i}.mlp.dense_4h_to_h.weight", f"h.{i}.mlp.dense_4h_to_h.weight", "transpose"],
-                    [f"h.{i}.mlp.dense_4h_to_h.bias", f"h.{i}.mlp.dense_4h_to_h.bias"],
+                    f"h.{i}.self_attention.query_key_value.bias",
+                    [f"h.{i}.self_attention.dense.weight", None, "transpose"],
+                    f"h.{i}.self_attention.dense.bias",
+                    f"h.{i}.post_attention_layernorm.weight",
+                    f"h.{i}.post_attention_layernorm.bias",
+                    [f"h.{i}.mlp.dense_h_to_4h.weight", None, "transpose"],
+                    [f"h.{i}.mlp.dense_4h_to_h.weight", None, "transpose"],
+                    f"h.{i}.mlp.dense_h_to_4h.bias",
+                    f"h.{i}.mlp.dense_4h_to_h.bias",
                 ]
             )
+
+        init_name_mappings(hard_mapping)
 
         mappings = [StateDictNameMapping(*mapping, index=index) for index, mapping in enumerate(hard_mapping)]
         model_class_name = config.architectures[0]
@@ -794,10 +796,10 @@ class BloomPreTrainedModel(PretrainedModel):
                 mapping.target_name = "bloom." + mapping.target_name
 
         if model_class_name == "BloomForSequenceClassification":
-            mappings.append(StateDictNameMapping("score.weight", "score.weight", "transpose"))
+            mappings.append(StateDictNameMapping("score.weight", None, "transpose"))
         if model_class_name == "BloomForTokenClassification":
-            mappings.append(StateDictNameMapping("classifier.weight", "classifier.weight", "transpose"))
-            mappings.append(StateDictNameMapping("classifier.bias", "classifier.bias"))
+            mappings.append(StateDictNameMapping("classifier.weight", None, "transpose"))
+            mappings.append(StateDictNameMapping("classifier.bias"))
 
         return mappings
 

--- a/paddlenlp/transformers/conversion_utils.py
+++ b/paddlenlp/transformers/conversion_utils.py
@@ -121,6 +121,24 @@ def state_dict_contains_prefix(state_dict: Dict[str, ndarray], prefix: str) -> b
     return prefix_count > 0
 
 
+def init_name_mappings(mappings: list[StateDictNameMapping]) -> list[StateDictNameMapping]:
+    """init name mapping which are simple mappings"""
+    for index in range(len(mappings)):
+        sub_mapping = mappings[index]
+
+        # if sub_mapping is `str`, so repeat it. eg: [ "word_embedding.weight", ["layer_norm", "LayerNorm"] ]
+        if isinstance(sub_mapping, str):
+            sub_mapping = [sub_mapping]
+
+        if len(sub_mapping) == 1:
+            sub_mapping = sub_mapping * 2
+
+        elif sub_mapping[1] is None:
+            sub_mapping[1] = sub_mapping[0]
+
+        mappings[index] = sub_mapping
+
+
 class StateDictKeysChecker:
     """State Dict Keys Checker"""
 

--- a/paddlenlp/transformers/conversion_utils.py
+++ b/paddlenlp/transformers/conversion_utils.py
@@ -400,6 +400,9 @@ class StateDictNameMapping:
 
     slots: list[str] = None
 
+    def __post_init__(self):
+        self.target_name = self.target_name or self.source_name
+
     def should_transpose(self) -> bool:
         return self.action == "transpose"
 

--- a/paddlenlp/transformers/conversion_utils.py
+++ b/paddlenlp/transformers/conversion_utils.py
@@ -393,7 +393,7 @@ class StateDictNameMapping:
     """NameMapping of StateDict between two models"""
 
     source_name: str
-    target_name: str
+    target_name: str = None
 
     action: Optional[str] = None  # the value can be: transpose, merge_last_two_dim
     index: Optional[int] = None

--- a/paddlenlp/transformers/distilbert/modeling.py
+++ b/paddlenlp/transformers/distilbert/modeling.py
@@ -20,7 +20,7 @@ import paddle.nn as nn
 
 from paddlenlp.utils.env import CONFIG_NAME
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from .. import PretrainedModel, register_base_model
 from .configuration import (
     DISTILBERT_PRETRAINED_INIT_CONFIGURATION,
@@ -86,8 +86,8 @@ class DistilBertPretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config: DistilBertConfig) -> List[StateDictNameMapping]:
         mappings: list[StateDictNameMapping] = []
         model_mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
         ]
@@ -166,6 +166,7 @@ class DistilBertPretrainedModel(PretrainedModel):
             ]
             model_mappings.extend(layer_mappings)
 
+        init_name_mappings(model_mappings)
         # base-model prefix "DistilBertModel"
         if "DistilBertModel" not in config.architectures:
             for mapping in model_mappings:
@@ -176,18 +177,18 @@ class DistilBertPretrainedModel(PretrainedModel):
         if "DistilBertForSequenceClassification" in config.architectures:
             model_mappings.extend(
                 [
-                    ["pre_classifier.weight", "pre_classifier.weight", "transpose"],
-                    ["pre_classifier.bias", "pre_classifier.bias"],
-                    ["classifier.weight", "classifier.weight", "transpose"],
-                    ["classifier.bias", "classifier.bias"],
+                    ["pre_classifier.weight", None, "transpose"],
+                    "pre_classifier.bias",
+                    ["classifier.weight", None, "transpose"],
+                    "classifier.bias",
                 ]
             )
 
         if "DistilBertForTokenClassification" in config.architectures:
             model_mappings.extend(
                 [
-                    ["classifier.weight", "classifier.weight", "transpose"],
-                    ["classifier.bias", "classifier.bias"],
+                    ["classifier.weight", None, "transpose"],
+                    "classifier.bias",
                 ]
             )
 
@@ -196,6 +197,7 @@ class DistilBertPretrainedModel(PretrainedModel):
                 [["qa_outputs.weight", "classifier.weight", "transpose"], ["qa_outputs.bias", "classifier.bias"]]
             )
 
+        init_name_mappings(model_mappings)
         mappings = [StateDictNameMapping(*mapping, index=index) for index, mapping in enumerate(model_mappings)]
         return mappings
 

--- a/paddlenlp/transformers/electra/modeling.py
+++ b/paddlenlp/transformers/electra/modeling.py
@@ -22,7 +22,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.nn import TransformerEncoder, TransformerEncoderLayer
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from .. import PretrainedModel, register_base_model
 from ..activations import get_activation
 from ..model_outputs import (
@@ -164,13 +164,13 @@ class ElectraPretrainedModel(PretrainedModel):
     @classmethod
     def _get_name_mappings(cls, config: ElectraConfig) -> List[StateDictNameMapping]:
         model_mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"],
-            ["embeddings.token_type_embeddings.weight", "embeddings.token_type_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
-            ["embeddings_project.weight", "embeddings_project.weight", "transpose"],
-            ["embeddings_project.bias", "embeddings_project.bias"],
+            ["embeddings_project.weight", None, "transpose"],
+            "embeddings_project.bias",
         ]
 
         for layer_index in range(config.num_hidden_layers):
@@ -236,6 +236,7 @@ class ElectraPretrainedModel(PretrainedModel):
             ]
             model_mappings.extend(layer_mappings)
 
+        init_name_mappings(model_mappings)
         # base-model prefix "ElectraModel"
         if "ElectraModel" not in config.architectures:
             for mapping in model_mappings:
@@ -272,7 +273,7 @@ class ElectraPretrainedModel(PretrainedModel):
             model_mappings.extend(
                 [
                     ["classifier.weight", "classifier.weight", "transpose"],
-                    ["classifier.bias", "classifier.bias"],
+                    "classifier.bias",
                 ]
             )
 
@@ -282,12 +283,13 @@ class ElectraPretrainedModel(PretrainedModel):
                 [
                     ["generator_predictions.LayerNorm.weight", "generator_predictions.layer_norm.weight", "transpose"],
                     ["generator_predictions.LayerNorm.bias", "generator_predictions.layer_norm.bias"],
-                    ["generator_predictions.dense.weight", "generator_predictions.dense.weight", "transpose"],
-                    ["generator_predictions.dense.bias", "generator_predictions.dense.bias"],
+                    ["generator_predictions.dense.weight", None, "transpose"],
+                    "generator_predictions.dense.bias",
                     ["generator_lm_head.bias", "generator_lm_head_bias"],
                 ]
             )
 
+        init_name_mappings(model_mappings)
         return [StateDictNameMapping(*mapping) for mapping in model_mappings]
 
     def init_weights(self):

--- a/paddlenlp/transformers/glm/modeling.py
+++ b/paddlenlp/transformers/glm/modeling.py
@@ -25,7 +25,7 @@ from paddle import Tensor
 from paddle.distributed import fleet
 from paddle.distributed.fleet.utils import recompute
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.env import CONFIG_NAME
 from ...utils.initializer import normal_, ones_, zeros_
 from ...utils.log import logger
@@ -461,11 +461,11 @@ class GLMPretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config):
         mappings: list[StateDictNameMapping] = []
         model_mappings = [
-            ["word_embeddings.weight", "word_embeddings.weight"],
-            ["transformer.position_embeddings.weight", "transformer.position_embeddings.weight"],
-            ["transformer.block_position_embeddings.weight", "transformer.block_position_embeddings.weight"],
-            ["transformer.final_layernorm.weight", "transformer.final_layernorm.weight"],
-            ["transformer.final_layernorm.bias", "transformer.final_layernorm.bias"],
+            "word_embeddings.weight",
+            "transformer.position_embeddings.weight",
+            "transformer.block_position_embeddings.weight",
+            "transformer.final_layernorm.weight",
+            "transformer.final_layernorm.bias",
         ]
         for layer_index in range(config.num_hidden_layers):
             layer_mappings = []
@@ -499,6 +499,7 @@ class GLMPretrainedModel(PretrainedModel):
                 )
 
             model_mappings.extend(layer_mappings)
+        init_name_mappings(model_mappings)
 
         import numpy as np
 

--- a/paddlenlp/transformers/mt5/modeling.py
+++ b/paddlenlp/transformers/mt5/modeling.py
@@ -25,7 +25,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 from paddle.distributed.fleet.utils import recompute
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.log import logger
 from ..activations import ACT2FN
 from ..model_outputs import (
@@ -577,19 +577,13 @@ class MT5PretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config: MT5Config) -> list[StateDictNameMapping]:
         mappings: list[StateDictNameMapping] = []
         model_mappings = [
-            ["shared.weight", "shared.weight"],
-            ["encoder.embed_tokens.weight", "encoder.embed_tokens.weight"],
-            ["encoder.final_layer_norm.weight", "encoder.final_layer_norm.weight"],
-            ["decoder.embed_tokens.weight", "decoder.embed_tokens.weight"],
-            ["decoder.final_layer_norm.weight", "decoder.final_layer_norm.weight"],
-            [
-                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-            ],
-            [
-                "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-                "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-            ],
+            "shared.weight",
+            "encoder.embed_tokens.weight",
+            "encoder.final_layer_norm.weight",
+            "decoder.embed_tokens.weight",
+            "decoder.final_layer_norm.weight",
+            "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
+            "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
         ]
         for layer_index in range(config.num_hidden_layers):
             for att_head in ["q", "k", "v", "o"]:
@@ -597,17 +591,17 @@ class MT5PretrainedModel(PretrainedModel):
                     [
                         [
                             f"encoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
-                            f"encoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
-                            f"decoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.1.EncDecAttention.{att_head}.weight",
-                            f"decoder.block.{layer_index}.layer.1.EncDecAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                     ]
@@ -616,34 +610,19 @@ class MT5PretrainedModel(PretrainedModel):
             layer_mappings = [
                 [
                     f"encoder.block.{layer_index}.layer.1.DenseReluDense.wo.weight",
-                    f"encoder.block.{layer_index}.layer.1.DenseReluDense.wo.weight",
+                    None,
                     "transpose",
                 ],
                 [
                     f"decoder.block.{layer_index}.layer.2.DenseReluDense.wo.weight",
-                    f"decoder.block.{layer_index}.layer.2.DenseReluDense.wo.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
-                    f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
-                ],
-                [
-                    f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
-                    f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
-                ],
+                f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
+                f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
             ]
 
             if config.feed_forward_proj == "relu":
@@ -651,12 +630,12 @@ class MT5PretrainedModel(PretrainedModel):
                     [
                         [
                             f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi.weight",
-                            f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi.weight",
-                            f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi.weight",
+                            None,
                             "transpose",
                         ],
                     ]
@@ -667,18 +646,20 @@ class MT5PretrainedModel(PretrainedModel):
                         [
                             [
                                 f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi_{i}.weight",
-                                f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi_{i}.weight",
+                                None,
                                 "transpose",
                             ],
                             [
                                 f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi_{i}.weight",
-                                f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi_{i}.weight",
+                                None,
                                 "transpose",
                             ],
                         ]
                     )
 
             model_mappings.extend(layer_mappings)
+
+        init_name_mappings(model_mappings)
 
         if cls.__name__ != "MT5Model":
             for mapping in model_mappings:

--- a/paddlenlp/transformers/roberta/modeling.py
+++ b/paddlenlp/transformers/roberta/modeling.py
@@ -23,7 +23,7 @@ import paddle.nn.functional as F
 from paddle import Tensor
 
 from ...layers import Linear as TransposedLinear
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from .. import PretrainedModel, register_base_model
 from ..model_outputs import (
     BaseModelOutputWithPoolingAndCrossAttentions,
@@ -169,9 +169,9 @@ class RobertaPretrainedModel(PretrainedModel):
     @classmethod
     def _get_name_mappings(cls, config: RobertaConfig) -> list[StateDictNameMapping]:
         mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.position_embeddings.weight", "embeddings.position_embeddings.weight"],
-            ["embeddings.token_type_embeddings.weight", "embeddings.token_type_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
         ]
@@ -239,6 +239,7 @@ class RobertaPretrainedModel(PretrainedModel):
             ]
             mappings.extend(layer_mappings)
 
+        init_name_mappings(mappings)
         # Other than RobertaModel, other architectures will prepend model prefix
         if config.architectures is not None and "RobertaModel" not in config.architectures:
             for mapping in mappings:
@@ -259,20 +260,19 @@ class RobertaPretrainedModel(PretrainedModel):
             if "RobertaForSequenceClassification" in config.architectures:
                 mappings.extend(
                     [
-                        ["classifier.out_proj.weight", "classifier.out_proj.weight", "transpose"],
-                        ["classifier.out_proj.bias", "classifier.out_proj.bias"],
-                        ["classifier.dense.weight", "classifier.dense.weight", "transpose"],
-                        ["classifier.dense.bias", "classifier.dense.bias"],
+                        ["classifier.out_proj.weight", None, "transpose"],
+                        "classifier.out_proj.bias"["classifier.dense.weight", "transpose"],
+                        "classifier.dense.bias",
                     ]
                 )
             if "RobertaForMaskedLM" in config.architectures:
                 mappings.extend(
                     [
-                        ["lm_head.bias", "lm_head.bias"],
-                        ["lm_head.dense.weight", "lm_head.dense.weight"],
-                        ["lm_head.dense.bias", "lm_head.dense.bias"],
-                        ["lm_head.layer_norm.weight", "lm_head.layer_norm.weight"],
-                        ["lm_head.layer_norm.bias", "lm_head.layer_norm.bias"],
+                        "lm_head.bias",
+                        "lm_head.dense.weight",
+                        "lm_head.dense.bias",
+                        "lm_head.layer_norm.weight",
+                        "lm_head.layer_norm.bias",
                     ]
                 )
             if (
@@ -281,8 +281,8 @@ class RobertaPretrainedModel(PretrainedModel):
             ):
                 mappings.extend(
                     [
-                        ["classifier.weight", "classifier.weight", "transpose"],
-                        ["classifier.bias", "classifier.bias"],
+                        ["classifier.weight", None, "transpose"],
+                        "classifier.bias",
                     ]
                 )
             if "RobertaForQuestionAnswering" in config.architectures:
@@ -292,7 +292,7 @@ class RobertaPretrainedModel(PretrainedModel):
                         ["qa_outputs.bias", "classifier.bias"],
                     ]
                 )
-
+        init_name_mappings(mappings)
         return [StateDictNameMapping(*mapping) for mapping in mappings]
 
     def init_weights(self, layer):

--- a/paddlenlp/transformers/roberta/modeling.py
+++ b/paddlenlp/transformers/roberta/modeling.py
@@ -261,7 +261,8 @@ class RobertaPretrainedModel(PretrainedModel):
                 mappings.extend(
                     [
                         ["classifier.out_proj.weight", None, "transpose"],
-                        "classifier.out_proj.bias"["classifier.dense.weight", "transpose"],
+                        "classifier.out_proj.bias",
+                        ["classifier.dense.weight", None, "transpose"],
                         "classifier.dense.bias",
                     ]
                 )

--- a/paddlenlp/transformers/roformer/modeling.py
+++ b/paddlenlp/transformers/roformer/modeling.py
@@ -20,7 +20,7 @@ import paddle.nn as nn
 from paddle import Tensor
 from paddle.common_ops_import import convert_dtype
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from .. import PretrainedModel, register_base_model
 from ..activations import get_activation
 from ..model_outputs import (
@@ -259,12 +259,12 @@ class RoFormerPretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config: RoFormerConfig) -> List[StateDictNameMapping]:
         mappings: List[StateDictNameMapping] = []
         model_mappings = [
-            ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
-            ["embeddings.token_type_embeddings.weight", "embeddings.token_type_embeddings.weight"],
+            "embeddings.word_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
             ["embeddings.LayerNorm.weight", "embeddings.layer_norm.weight"],
             ["embeddings.LayerNorm.bias", "embeddings.layer_norm.bias"],
-            ["pooler.dense.weight", "pooler.dense.weight", "transpose"],
-            ["pooler.dense.bias", "pooler.dense.bias"],
+            ["pooler.dense.weight", None, "transpose"],
+            "pooler.dense.bias",
             # for TokenClassification
         ]
         for layer_index in range(config.num_hidden_layers):
@@ -330,6 +330,8 @@ class RoFormerPretrainedModel(PretrainedModel):
             ]
             model_mappings.extend(layer_mappings)
 
+        init_name_mappings(model_mappings)
+
         # base-model prefix "RoFormerModel"
         if "RoFormerModel" not in config.architectures:
             for mapping in model_mappings:
@@ -356,8 +358,9 @@ class RoFormerPretrainedModel(PretrainedModel):
             or "RoFormerForSequenceClassification" in config.architectures
             or "RoFormerForTokenClassification" in config.architectures
         ):
-            model_mappings.extend([["classifier.weight", "classifier.weight", "transpose"]])
+            model_mappings.extend([["classifier.weight", None, "transpose"]])
 
+        init_name_mappings(model_mappings)
         mappings = [StateDictNameMapping(*mapping, index=index) for index, mapping in enumerate(model_mappings)]
         return mappings
 

--- a/paddlenlp/transformers/t5/modeling.py
+++ b/paddlenlp/transformers/t5/modeling.py
@@ -30,7 +30,7 @@ except ImportError:
     from paddle.fluid.dygraph.amp.auto_cast import amp_state
 from paddle.distributed.fleet.utils import recompute
 
-from ...utils.converter import StateDictNameMapping
+from ...utils.converter import StateDictNameMapping, init_name_mappings
 from ...utils.log import logger
 from ..activations import ACT2FN
 from ..model_outputs import (
@@ -581,19 +581,13 @@ class T5PretrainedModel(PretrainedModel):
     def _get_name_mappings(cls, config: T5Config) -> list[StateDictNameMapping]:
         mappings: list[StateDictNameMapping] = []
         model_mappings = [
-            ["shared.weight", "shared.weight"],
-            ["encoder.embed_tokens.weight", "encoder.embed_tokens.weight"],
-            ["encoder.final_layer_norm.weight", "encoder.final_layer_norm.weight"],
-            ["decoder.embed_tokens.weight", "decoder.embed_tokens.weight"],
-            ["decoder.final_layer_norm.weight", "decoder.final_layer_norm.weight"],
-            [
-                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-            ],
-            [
-                "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-                "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
-            ],
+            "shared.weight",
+            "encoder.embed_tokens.weight",
+            "encoder.final_layer_norm.weight",
+            "decoder.embed_tokens.weight",
+            "decoder.final_layer_norm.weight",
+            "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
+            "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
         ]
         for layer_index in range(config.num_hidden_layers):
             for att_head in ["q", "k", "v", "o"]:
@@ -601,17 +595,17 @@ class T5PretrainedModel(PretrainedModel):
                     [
                         [
                             f"encoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
-                            f"encoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
-                            f"decoder.block.{layer_index}.layer.0.SelfAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.1.EncDecAttention.{att_head}.weight",
-                            f"decoder.block.{layer_index}.layer.1.EncDecAttention.{att_head}.weight",
+                            None,
                             "transpose",
                         ],
                     ]
@@ -620,34 +614,19 @@ class T5PretrainedModel(PretrainedModel):
             layer_mappings = [
                 [
                     f"encoder.block.{layer_index}.layer.1.DenseReluDense.wo.weight",
-                    f"encoder.block.{layer_index}.layer.1.DenseReluDense.wo.weight",
+                    None,
                     "transpose",
                 ],
                 [
                     f"decoder.block.{layer_index}.layer.2.DenseReluDense.wo.weight",
-                    f"decoder.block.{layer_index}.layer.2.DenseReluDense.wo.weight",
+                    None,
                     "transpose",
                 ],
-                [
-                    f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
-                    f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
-                ],
-                [
-                    f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
-                    f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
-                ],
-                [
-                    f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
-                    f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
-                ],
+                f"encoder.block.{layer_index}.layer.0.layer_norm.weight",
+                f"encoder.block.{layer_index}.layer.1.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.0.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.1.layer_norm.weight",
+                f"decoder.block.{layer_index}.layer.2.layer_norm.weight",
             ]
 
             if config.feed_forward_proj == "relu":
@@ -655,12 +634,12 @@ class T5PretrainedModel(PretrainedModel):
                     [
                         [
                             f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi.weight",
-                            f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi.weight",
+                            None,
                             "transpose",
                         ],
                         [
                             f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi.weight",
-                            f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi.weight",
+                            None,
                             "transpose",
                         ],
                     ]
@@ -671,18 +650,20 @@ class T5PretrainedModel(PretrainedModel):
                         [
                             [
                                 f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi_{i}.weight",
-                                f"encoder.block.{layer_index}.layer.1.DenseReluDense.wi_{i}.weight",
+                                None,
                                 "transpose",
                             ],
                             [
                                 f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi_{i}.weight",
-                                f"decoder.block.{layer_index}.layer.2.DenseReluDense.wi_{i}.weight",
+                                None,
                                 "transpose",
                             ],
                         ]
                     )
 
             model_mappings.extend(layer_mappings)
+
+        init_name_mappings(model_mappings)
 
         if cls.__name__ != "T5Model":
             for mapping in model_mappings:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->

心在很多模型接入的时候，已经和 transformers 中的网络结构一致，所以在做 name mapping 映射的时候，target-name 和 source-name 一致，此时不应该写两遍。

示例配置如下所示：
```diff
        model_mappings = [
-           ["embeddings.word_embeddings.weight", "embeddings.word_embeddings.weight"],
+           ["embeddings.word_embeddings.weight"],

-             [f"encoder.layer.{layer_index}.attention.self.key.weight",
-              f"encoder.layer.{layer_index}.attention.self.key.weight",
-               "transpose"]

+             [f"encoder.layer.{layer_index}.attention.self.key.weight", None, "transpose"]
        ]
```
