### PR TITLE
[lora]fix lora unitest

### DIFF
--- a/tests/layers/test_lora.py
+++ b/tests/layers/test_lora.py
@@ -150,8 +150,7 @@ class TestLoraModel(unittest.TestCase):
         self.assertIsNotNone(original_results_1)
         self.assertIsNotNone(original_results_2)
         self.assertIsInstance(restored_model, BertModel)
-        for i, j in zip(original_results_1, original_results_2):
-            self.assertTrue(paddle.allclose(i, j))
+        self.assertTrue(paddle.allclose(original_results_1[0], original_results_2[0]))
 
     @parameterized.expand([(None,), ("all",), ("lora",)])
     def test_lora_model_constructor(self, bias):
@@ -189,8 +188,7 @@ class TestLoraModel(unittest.TestCase):
         lora_model.eval()
         eval_forward_results = lora_model(input_ids)
         self.assertIsNotNone(eval_forward_results)
-        for i, j in zip(train_forward_results, eval_forward_results):
-            self.assertTrue(paddle.allclose(i, j))
+        self.assertTrue(paddle.allclose(train_forward_results[0], eval_forward_results[0]))
 
     @parameterized.expand([(None,), ("all",), ("lora",)])
     def test_lora_model_save_load(self, bias):
@@ -213,8 +211,7 @@ class TestLoraModel(unittest.TestCase):
             loaded_lora_model = LoRAModel.from_pretrained(new_model, tempdir)
             loaded_lora_model.eval()
             loaded_results = loaded_lora_model(input_ids)
-            for i, j in zip(original_results, loaded_results):
-                self.assertTrue(paddle.allclose(i, j))
+            self.assertTrue(paddle.allclose(original_results[0], loaded_results[0]))
 
 
 class TestLoRAConfig(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes 

### PR changes
Others

### Description
修复lora单测, allclose不支持比较tuple，只比较第0维的sequence_output也满足单测需求了
(InvalidArgument) allclose(): argument 'x' (position 0) must be Tensor, but got tuple (at /paddle/paddle/fluid/pybind/eager_utils.cc:894)
