### PR TITLE
[New features] add multi stop tokens features

### DIFF
--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -54,7 +54,7 @@ def get_unfinished_flag(
         Tensor: the unfinished flag tensor
     """
     if isinstance(eos_token_id, int):
-        unfinished_flag = paddle.logical_and(unfinished_flag, input_ids[:, -1] != eos_token_id)
+        unfinished_flag = paddle.logical_and(unfinished_flag, input_ids[:, -1:] != eos_token_id)
     elif isinstance(eos_token_id[0], int):
         eos_token_id_tensor = paddle.to_tensor([eos_token_id])
         is_last_tokens_equal = paddle.all(
@@ -1025,6 +1025,7 @@ class GenerationMixin(object):
         unfinished_flag = paddle.full([batch_size, 1], True, dtype="bool")
         scores = paddle.full([batch_size, 1], 0.0, dtype=paddle.get_default_dtype())
         while cur_len < max_length:
+
             # prepare model inputs & get model output
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
@@ -1055,6 +1056,7 @@ class GenerationMixin(object):
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
             cur_len += 1
+
             input_ids = paddle.concat([input_ids, next_tokens], axis=1)
 
             if eos_token_id is not None:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -59,7 +59,7 @@ def get_unfinished_flag(
         eos_token_id_tensor = paddle.to_tensor([eos_token_id])
         is_last_tokens_equal = paddle.all(
             paddle.equal(input_ids[:, -len(eos_token_id) :], eos_token_id_tensor), axis=-1
-        )
+        ).unsqueeze(-1)
         unfinished_flag = paddle.logical_and(unfinished_flag, ~is_last_tokens_equal)
     else:
         batch_unfinish_flag = None

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1017,6 +1017,7 @@ class GenerationMixin(object):
                 )
 
     def greedy_search(self, input_ids, logits_processors, max_length, pad_token_id, eos_token_id, **model_kwargs):
+        model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
         batch_size, cur_len = input_ids.shape
@@ -1082,6 +1083,7 @@ class GenerationMixin(object):
         min_tokens_to_keep=1,
         **model_kwargs
     ):
+        model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
 
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
@@ -1277,6 +1279,8 @@ class GenerationMixin(object):
         eos_token_id,
         **model_kwargs
     ):
+        model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
+
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
         batch_size = len(beam_scorer._beam_hyps)

--- a/tests/transformers/test_generation_utils.py
+++ b/tests/transformers/test_generation_utils.py
@@ -1104,7 +1104,7 @@ class GenerationUtilsTestCase(unittest.TestCase):
         )[0].tolist()[0]
         self.assertEqual(decoded_ids, [520, 8, 9, 59, 124])
 
-    def test_gpt_generation_to_static(self):
+    def test_gpt_generation(self):
         # init the tiny-random-gpt
         model = GPTLMHeadModel.from_pretrained("__internal_testing__/tiny-random-gpt")
         model.eval()
@@ -1112,10 +1112,7 @@ class GenerationUtilsTestCase(unittest.TestCase):
         input_ids = np.array([list(range(200, 300)), list(range(100, 200))])
 
         # 1. get the dygraph decoded_ids
-        expected_output_ids = [
-            [15426, 15426, 15426, 15426, 15426, 15426, 15426, 15426, 15426, 15426, 15426],
-            [18966, 18000, 18000, 23410, 23410, 23410, 23410, 23410, 23410, 23410, 23410],
-        ]
+        expected_output_ids = [[15426, 15426, 15426, 15426, 15426, 15426], [18966, 18000, 23410, 23410, 23410, 23410]]
 
         decoded_ids = model.generate(paddle.to_tensor(input_ids), max_length=6)[0].tolist()
 

--- a/tests/transformers/test_generation_utils.py
+++ b/tests/transformers/test_generation_utils.py
@@ -1026,41 +1026,51 @@ class GenerationUtilsTestCase(unittest.TestCase):
 
         # 1. test single eos_token_id
         eos_token_id = 6
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [True, True])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [True, True])
 
         eos_token_id = 7
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [False, True])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, True])
 
         # 2. get tokens
         eos_token_id = [6, 7]
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [False, True])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, True])
 
         eos_token_id = [10, 11]
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [True, False])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [True, False])
 
         # 3. get multi tokens
         eos_token_id = [[6, 7], [9, 10]]
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [False, True])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, True])
 
         eos_token_id = [[6, 7], [10, 11]]
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [False, False])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, False])
 
         eos_token_id = [[7], [11]]
-        unfinish_flag = paddle.to_tensor([True, True], dtype="bool")
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
         unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
-        self.assertEqual(unfinish_flag.tolist(), [False, False])
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, False])
+
+        eos_token_id = [[7], [10, 11]]
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
+        unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, False])
+
+        eos_token_id = [[7], [10, 12]]
+        unfinish_flag = paddle.to_tensor([[True], [True]], dtype="bool")
+        unfinish_flag = get_unfinished_flag(input_ids, unfinish_flag, eos_token_id)
+        self.assertEqual(unfinish_flag.reshape([2]).tolist(), [False, True])
 
     @slow
     def test_gpt_multi_stop_tokens(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
添加多个stop token 来阻止生成过程

本地测试代码如下所示：

```python
import paddle
from paddlenlp.transformers import AutoTokenizer, AutoModelForCausalLM, PretrainedTokenizer

tokenizer: PretrainedTokenizer = AutoTokenizer.from_pretrained("gpt-cpm-small-cn-distill")

input_ids = tokenizer("中国的首都是")["input_ids"]
input_ids = paddle.to_tensor([input_ids])
model = AutoModelForCausalLM.from_pretrained("gpt-cpm-small-cn-distill")

output = model.generate(input_ids, decoding_strategy="greedy_search", top_k=1, eos_token_id=[520, 15])[0].tolist()
for ids in output:
    tokens = tokenizer.convert_ids_to_tokens(output)
    print(tokenizer.convert_tokens_to_string(tokens[0]))

```