### PR TITLE
Support local offline environment to read community config and model files

### DIFF
--- a/paddlenlp/transformers/auto/modeling.py
+++ b/paddlenlp/transformers/auto/modeling.py
@@ -340,6 +340,8 @@ class _BaseAutoModelClass:
                 logger.warning(f"{config_file}  is not a valid path to a model config file")
         # Assuming from community-contributed pretrained models
         else:
+            cached_standard_config = os.path.join(cache_dir, cls.model_config_file)
+            cached_legacy_config = os.path.join(cache_dir, cls.legacy_model_config_file)
             standard_community_url = "/".join(
                 [COMMUNITY_MODEL_PREFIX, pretrained_model_name_or_path, cls.model_config_file]
             )
@@ -347,8 +349,12 @@ class _BaseAutoModelClass:
                 [COMMUNITY_MODEL_PREFIX, pretrained_model_name_or_path, cls.legacy_model_config_file]
             )
             try:
-                if url_file_exists(standard_community_url):
+                if os.path.isfile(cached_standard_config):
+                    resolved_vocab_file = cached_standard_config
+                elif url_file_exists(standard_community_url):
                     resolved_vocab_file = get_path_from_url_with_filelock(standard_community_url, cache_dir)
+                elif os.path.isfile(cached_legacy_config):
+                    resolved_vocab_file = cached_legacy_config
                 elif url_file_exists(legacy_community_url):
                     logger.info("Standard config do not exist, loading from legacy config")
                     resolved_vocab_file = get_path_from_url_with_filelock(legacy_community_url, cache_dir)

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -841,6 +841,8 @@ class PretrainedConfig:
             resolved_config_file = resolve_hf_config_path(
                 repo_id=pretrained_model_name_or_path, cache_dir=cache_dir, subfolder=subfolder
             )
+        elif os.path.isfile(os.path.join(cache_dir, CONFIG_NAME)):
+            resolved_config_file = os.path.join(cache_dir, CONFIG_NAME)
         else:
             community_url = "/".join([COMMUNITY_MODEL_PREFIX, pretrained_model_name_or_path, CONFIG_NAME])
             if url_file_exists(community_url):

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -877,6 +877,8 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
         # 0. when it is local file
         if os.path.isfile(pretrained_model_name_or_path):
             return pretrained_model_name_or_path
+        elif os.path.isfile(os.path.join(cache_dir, cls.resource_files_names["model_state"])):
+            return os.path.join(cache_dir, cls.resource_files_names["model_state"])
 
         # 1. when it is model-name
         if pretrained_model_name_or_path in cls.pretrained_init_configuration:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->

This PR supports local offline environment to read config and model files, fixes issues like below:

---

I've already downloaded config and model files in `~/.paddlenlp`:

```bash
➜  .paddlenlp tree
.
├── datasets
├── models
│   ├── Salesforce
│   │   └── codegen-350M-mono
│   │       ├── added_tokens.json
│   │       ├── config.json
│   │       ├── merges.txt
│   │       ├── model_config.json
│   │       ├── model_state.pdparams
│   │       ├── special_tokens_map.json
│   │       ├── tokenizer_config.json
│   │       └── vocab.json
│   └── embeddings
└── packages
```

and when I use paddlenlp in an offline environment, I will get these exceptions:

```bash
>>> from paddlenlp import Taskflow
>>> codegen = Taskflow("code_generation", model="Salesforce/codegen-350M-mono",decode_strategy="greedy_search", repetition_penalty=1.0)
[2023-05-02 08:45:13,182] [    INFO] - Already cached /Users/alphahinex/.paddlenlp/models/Salesforce/codegen-350M-mono/vocab.json
[2023-05-02 08:45:13,182] [    INFO] - Already cached /Users/alphahinex/.paddlenlp/models/Salesforce/codegen-350M-mono/merges.txt
[2023-05-02 08:45:13,182] [    INFO] - Already cached /Users/alphahinex/.paddlenlp/models/Salesforce/codegen-350M-mono/added_tokens.json
[2023-05-02 08:45:13,182] [    INFO] - Already cached /Users/alphahinex/.paddlenlp/models/Salesforce/codegen-350M-mono/special_tokens_map.json
[2023-05-02 08:45:13,182] [    INFO] - Already cached /Users/alphahinex/.paddlenlp/models/Salesforce/codegen-350M-mono/tokenizer_config.json
[2023-05-02 08:45:13,246] [    INFO] - Adding                                 to the vocabulary
[2023-05-02 08:45:13,246] [    INFO] - Adding                                to the vocabulary
[2023-05-02 08:45:13,246] [    INFO] - Adding                               to the vocabulary
[2023-05-02 08:45:13,246] [    INFO] - Adding                              to the vocabulary
[2023-05-02 08:45:13,246] [    INFO] - Adding                             to the vocabulary
[2023-05-02 08:45:13,247] [    INFO] - Adding                            to the vocabulary
[2023-05-02 08:45:13,247] [    INFO] - Adding                           to the vocabulary
[2023-05-02 08:45:13,247] [    INFO] - Adding                          to the vocabulary
[2023-05-02 08:45:13,247] [    INFO] - Adding                         to the vocabulary
[2023-05-02 08:45:13,247] [    INFO] - Adding                        to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                       to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                      to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                     to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                    to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                   to the vocabulary
[2023-05-02 08:45:13,248] [    INFO] - Adding                  to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding                 to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding                to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding               to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding              to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding             to the vocabulary
[2023-05-02 08:45:13,249] [    INFO] - Adding            to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding           to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding          to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding         to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding        to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding       to the vocabulary
[2023-05-02 08:45:13,250] [    INFO] - Adding      to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding     to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding    to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding                                      to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding                                  to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding                              to the vocabulary
[2023-05-02 08:45:13,251] [    INFO] - Adding                          to the vocabulary
[2023-05-02 08:45:13,252] [    INFO] - Adding                      to the vocabulary
[2023-05-02 08:45:13,252] [    INFO] - Adding                  to the vocabulary
[2023-05-02 08:45:13,252] [    INFO] - Adding              to the vocabulary
[2023-05-02 08:45:13,252] [    INFO] - Adding          to the vocabulary
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/util/connection.py", line 72, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/socket.py", line 954, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 8] nodename nor servname provided, or not known


During handling of the above exception, another exception occurred:


Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in urlopen
    httplib_response = self._make_request(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 386, in _make_request
    self._validate_conn(conn)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 1042, in _validate_conn
    conn.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connection.py", line 363, in connect
    self.sock = conn = self._new_conn()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x140053a90>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known


During handling of the above exception, another exception occurred:


Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/adapters.py", line 489, in send
    resp = conn.urlopen(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    retries = retries.increment(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='bj.bcebos.com', port=443): Max retries exceeded with url: /paddlenlp/models/community/Salesforce/codegen-350M-mono/config.json (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x140053a90>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))


During handling of the above exception, another exception occurred:


Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/taskflow/taskflow.py", line 837, in __init__
    self.task_instance = task_class(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/taskflow/code_generation.py", line 59, in __init__
    self._construct_model(model)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/taskflow/code_generation.py", line 65, in _construct_model
    self._model = CodeGenForCausalLM.from_pretrained(model)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/transformers/model_utils.py", line 484, in from_pretrained
    return cls.from_pretrained_v2(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/transformers/model_utils.py", line 1320, in from_pretrained_v2
    config, model_kwargs = cls.config_class.from_pretrained(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/transformers/configuration_utils.py", line 735, in from_pretrained
    config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/transformers/configuration_utils.py", line 761, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/transformers/configuration_utils.py", line 829, in _get_config_dict
    if url_file_exists(community_url):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/paddlenlp/utils/downloader.py", line 440, in url_file_exists
    result = requests.head(url)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/api.py", line 100, in head
    return request("head", url, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/requests/adapters.py", line 565, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='bj.bcebos.com', port=443): Max retries exceeded with url: /paddlenlp/models/community/Salesforce/codegen-350M-mono/config.json (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x140053a90>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
```

the related dependencies in my env:

```bash
$ pip3 list|grep paddle
paddle-bfloat       0.1.7
paddle2onnx         1.0.5
paddlefsl           1.1.0
paddlenlp           2.5.2
paddlepaddle        2.4.2
```