### PR TITLE
fix few_shot demo under multi class directory while running onnx inference

### DIFF
--- a/applications/text_classification/multi_class/few-shot/infer.py
+++ b/applications/text_classification/multi_class/few-shot/infer.py
@@ -63,7 +63,7 @@ class InferBackend(object):
         )
         infer_model_dir = model_path_prefix.rsplit("/", 1)[0]
         float_onnx_file = os.path.join(infer_model_dir, "model.onnx")
-        with open(float_onnx_file, "wb", encoding="utf-8") as f:
+        with open(float_onnx_file, "wb") as f:
             f.write(onnx_model)
 
         if device == "gpu":


### PR DESCRIPTION
- delete open onnx file encoding param

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
while running the demo's onnx inference task, it'll throw an error `ValueError: binary mode doesn't take an encoding argument`. It should be deleted.
