### PR TITLE
[Bug fixes] disable tiny-random-bert checking

### DIFF
--- a/paddlenlp/taskflow/text_similarity.py
+++ b/paddlenlp/taskflow/text_similarity.py
@@ -156,11 +156,11 @@ class TextSimilarityTask(Task):
         "__internal_testing__/tiny-random-bert": {
             "model_state": [
                 "https://bj.bcebos.com/paddlenlp/models/community/__internal_testing__/tiny-random-bert/model_state.pdparams",
-                "a7a54deee08235fc6ae454f5def2d663",
+                None,  # disable md5 checking
             ],
             "model_config": [
                 "https://bj.bcebos.com/paddlenlp/models/community/__internal_testing__/tiny-random-bert/config.json",
-                "136a73740ec1002d33eff32146678491",
+                None,
             ],
         },
     }

--- a/paddlenlp/taskflow/text_similarity.py
+++ b/paddlenlp/taskflow/text_similarity.py
@@ -160,7 +160,7 @@ class TextSimilarityTask(Task):
             ],
             "model_config": [
                 "https://bj.bcebos.com/paddlenlp/models/community/__internal_testing__/tiny-random-bert/config.json",
-                None
+                None,
             ],
         },
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
`tiny-random-bert` is different from hf-hub which will raise some error in unit testing, so disable md5value checking