### PR TITLE
[lora prefix tuning]unify dtype

### DIFF
--- a/examples/language_model/bloom/predict_generation.py
+++ b/examples/language_model/bloom/predict_generation.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 import paddle
 from paddle.distributed import fleet
 
-from paddlenlp.layers import LoRAModel
-from paddlenlp.transformers import AutoTokenizer, BloomForCausalLM
+from paddlenlp.layers import LoRAConfig, LoRAModel
+from paddlenlp.transformers import AutoConfig, AutoTokenizer, BloomForCausalLM
 
 
 def parse_arguments():
@@ -30,16 +30,6 @@ def parse_arguments():
     parser.add_argument("--max_length", type=int, default=200, help="The batch size of data.")
     parser.add_argument("--seed", type=int, default=20, help="the seed of parameter initialization")
     parser.add_argument("--lora_path", default=None, help="The directory of LoRA parameters. Default to None")
-    parser.add_argument(
-        "--fp16",
-        action="store_true",
-        help="Whether to use fp16 16-bit (mixed) precision training instead of 32-bit training.",
-    )
-    parser.add_argument(
-        "--bf16",
-        action="store_true",
-        help="Whether to use bf16 (mixed) precision instead of 32-bit. Requires Ampere or higher NVIDIA architecture or using CPU (no_cuda).",
-    )
     return parser.parse_args()
 
 
@@ -71,13 +61,14 @@ class Predictor(object):
             fleet.init(is_collective=True, strategy=strategy)
             hcg = fleet.get_hybrid_communicate_group()
             tensor_parallel_rank = hcg.get_model_parallel_rank()
-        if args.fp16:
-            dtype = "float16"
-        elif args.bf16:
-            dtype = "bfloat16"
+
+        if self.args.lora_path is not None:
+            lora_config = LoRAConfig.from_pretrained(self.args.lora_path)
+            dtype = lora_config.dtype
         else:
-            dtype = "float32"
-        paddle.set_default_dtype(dtype)
+            config = AutoConfig.from_pretrained(args.model_name_or_path)
+            dtype = config.dtype if config.dtype is not None else "float16"
+
         self.model = BloomForCausalLM.from_pretrained(
             args.model_name_or_path,
             load_state_as_np=True,

--- a/examples/language_model/chatglm/README.md
+++ b/examples/language_model/chatglm/README.md
@@ -136,15 +136,14 @@ python -m paddle.distributed.launch --gpus 0,1,2,3 predict_generation.py \
 ```
 python export_generation_model.py \
    --model_name_or_path ./checkpoints/chatglm-6b \
-   --output_path ./checkpoints/infer/chatglm \
-   --dtype "float32"
+   --output_path ./checkpoints/infer/chatglm
 ```
 
 其中参数定义如下：
 
 - `model_name_or_path`: 预训练模型内置名称或者模型所在目录。
 - `output_path`: 导出模型存储地址和文件前缀。示例中导出地址为 `./checkpoints/infer`，模型前缀为 `chatglm`。
-- `dtype`: 模型参数类型，默认为`float32`，可选参数`float16`和`float32`。
+- `dtype`: 模型参数类型，可选参数`float16`和`float32`，默认为None，即为加载的动态图模型参数类型一致。
 
 ## 模型推理（c++推理）
 

--- a/examples/language_model/chatglm/finetune_generation.py
+++ b/examples/language_model/chatglm/finetune_generation.py
@@ -101,7 +101,7 @@ def main():
             num_attention_heads=model.config.num_attention_heads,
             num_hidden_layers=model.config.num_hidden_layers,
             hidden_size=model.config.hidden_size,
-            prefix_projection=True,
+            # prefix_projection=True,
             prefix_projection_hidden_size=model.config.hidden_size,
             dtype=dtype,
         )

--- a/examples/language_model/chatglm/predict_generation.py
+++ b/examples/language_model/chatglm/predict_generation.py
@@ -15,8 +15,8 @@
 import paddle
 from paddle.distributed import fleet
 
-from paddlenlp.layers import LoRAModel
-from paddlenlp.prompt import PrefixModelForCausalLM
+from paddlenlp.layers import LoRAConfig, LoRAModel
+from paddlenlp.prompt import PrefixConfig, PrefixModelForCausalLM
 from paddlenlp.prompt.prefix import (
     chatglm_pad_attention_mask,
     chatglm_postprocess_past_key_value,
@@ -77,15 +77,22 @@ class Predictor(object):
             hcg = fleet.get_hybrid_communicate_group()
             tensor_parallel_rank = hcg.get_model_parallel_rank()
 
-        config = ChatGLMConfig.from_pretrained(args.model_name_or_path)
-        paddle.set_default_dtype(config.paddle_dtype)
+        if self.args.lora_path is not None:
+            lora_config = LoRAConfig.from_pretrained(self.args.lora_path)
+            dtype = lora_config.dtype
+        elif self.args.prefix_path is not None:
+            prefix_config = PrefixConfig.from_pretrained(self.args.prefix_path)
+            dtype = prefix_config.dtype
+        else:
+            config = ChatGLMConfig.from_pretrained(args.model_name_or_path)
+            dtype = config.dtype if config.dtype is not None else config.paddle_dtype
 
         self.model = ChatGLMForConditionalGeneration.from_pretrained(
             args.model_name_or_path,
             tensor_parallel_degree=tensor_parallel_degree,
             tensor_parallel_rank=tensor_parallel_rank,
             load_state_as_np=True,
-            dtype=config.paddle_dtype,
+            dtype=dtype,
         )
         if self.args.lora_path is not None:
             self.model = LoRAModel.from_pretrained(self.model, self.args.lora_path)

--- a/examples/language_model/glm/README.md
+++ b/examples/language_model/glm/README.md
@@ -138,7 +138,7 @@ python -m paddle.distributed.launch --gpus "0,1,2,3,4,5,6,7" finetune_instructio
 
 ## 模型导出
 
-使用`export_generation_model.py`脚本，传入我们需要的模型地址，和输出地址即可。如果需要导出`float16`参数的模型，请指定`paddle_dtype`参数为`float16`。
+使用`export_generation_model.py`脚本，传入我们需要的模型地址，和输出地址即可。默认导出模型参数类型与动态图模型参数类型一致，如果需要导出`float16`参数的模型，请指定`dtype`参数为`float16`。
 
 ```
 python export_generation_model.py \

--- a/examples/language_model/glm/finetune_instruction_generation.py
+++ b/examples/language_model/glm/finetune_instruction_generation.py
@@ -119,6 +119,7 @@ def main():
             merge_weights=True,
             enable_lora_list=[[True, False, True]],
             tensor_parallel_degree=training_args.tensor_parallel_degree,
+            dtype=dtype,
         )
         model = LoRAModel(model, lora_config)
         model.mark_only_lora_as_trainable()

--- a/examples/language_model/glm/predict_generation.py
+++ b/examples/language_model/glm/predict_generation.py
@@ -15,8 +15,12 @@
 import paddle
 from paddle.distributed import fleet
 
-from paddlenlp.layers import LoRAModel
-from paddlenlp.transformers import AutoModelForConditionalGeneration, AutoTokenizer
+from paddlenlp.layers import LoRAConfig, LoRAModel
+from paddlenlp.transformers import (
+    AutoConfig,
+    AutoModelForConditionalGeneration,
+    AutoTokenizer,
+)
 
 
 def parse_arguments():
@@ -33,16 +37,6 @@ def parse_arguments():
     parser.add_argument("--batch_size", type=int, default=2, help="The batch size of data.")
     parser.add_argument("--src_length", type=int, default=200, help="The batch size of data.")
     parser.add_argument("--tgt_length", type=int, default=20, help="The batch size of data.")
-    parser.add_argument(
-        "--fp16",
-        action="store_true",
-        help="Whether to use fp16 16-bit (mixed) precision training instead of 32-bit training.",
-    )
-    parser.add_argument(
-        "--bf16",
-        action="store_true",
-        help="Whether to use bf16 (mixed) precision instead of 32-bit. Requires Ampere or higher NVIDIA architecture or using CPU (no_cuda).",
-    )
     return parser.parse_args()
 
 
@@ -74,13 +68,14 @@ class Predictor(object):
             fleet.init(is_collective=True, strategy=strategy)
             hcg = fleet.get_hybrid_communicate_group()
             tensor_parallel_rank = hcg.get_model_parallel_rank()
-        if args.fp16:
-            dtype = "float16"
-        elif args.bf16:
-            dtype = "bfloat16"
+
+        if self.args.lora_path is not None:
+            lora_config = LoRAConfig.from_pretrained(self.args.lora_path)
+            dtype = lora_config.dtype
         else:
-            dtype = "float32"
-        paddle.set_default_dtype(dtype)
+            config = AutoConfig.from_pretrained(args.model_name_or_path)
+            dtype = config.dtype if config.dtype is not None else "float32"
+
         self.model = AutoModelForConditionalGeneration.from_pretrained(
             args.model_name_or_path,
             tensor_parallel_degree=tensor_parallel_degree,

--- a/examples/language_model/llama/export_generation_model.py
+++ b/examples/language_model/llama/export_generation_model.py
@@ -17,8 +17,8 @@ import os
 
 import paddle
 
-from paddlenlp.layers import LoRAModel
-from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer
+from paddlenlp.layers import LoRAConfig, LoRAModel
+from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer, LlamaConfig
 
 
 def parse_args():
@@ -36,7 +36,7 @@ def parse_args():
         type=str,
         help="The output file prefix used to save the exported inference model.",
     )
-    parser.add_argument("--dtype", default="float32", type=str, help="The data type of exported model")
+    parser.add_argument("--dtype", default=None, help="The data type of exported model")
     parser.add_argument("--tgt_length", type=int, default=100, help="The batch size of data.")
     parser.add_argument("--lora_path", default=None, help="The directory of LoRA parameters. Default to None")
     args = parser.parse_args()
@@ -47,8 +47,15 @@ def main():
     args = parse_args()
 
     paddle.seed(100)
-    paddle.set_default_dtype(args.dtype)
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    if args.lora_path is not None:
+        lora_config = LoRAConfig.from_pretrained(args.lora_path)
+        dtype = lora_config.dtype
+    elif args.dtype is not None:
+        dtype = args.dtype
+    else:
+        config = LlamaConfig.from_pretrained(args.model_name_or_path)
+        dtype = "float16" if config.dtype is None else config.dtype
 
     model = AutoModelForCausalLM.from_pretrained(
         args.model_path,
@@ -56,7 +63,7 @@ def main():
         low_cpu_mem_usage=True,
         use_recompute=False,
         use_cache=True,
-        dtype=args.dtype,
+        dtype=dtype,
     )
     model.config.fp16_opt_level = None  # For dygraph to static only
     if args.lora_path is not None:

--- a/paddlenlp/layers/lora.py
+++ b/paddlenlp/layers/lora.py
@@ -599,11 +599,9 @@ class LoRAModel(nn.Layer):
     def __init__(self, model, lora_config: LoRAConfig) -> None:
         super().__init__()
         self.lora_config = lora_config
-        if self.lora_config.dtype:
-            self.dtype = self.lora_config.dtype
-        else:
-            self.dtype = paddle.get_default_dtype()
-        with dtype_guard(self.dtype):
+        if self.lora_config.dtype is None:
+            self.lora_config.dtype = paddle.get_default_dtype()
+        with dtype_guard(self.lora_config.dtype):
             self.model = self.get_lora_model(model, lora_config)
         if self.lora_config.tensor_parallel_degree != self.model.config.tensor_parallel_degree:
             self.lora_config.tensor_parallel_degree = self.model.config.tensor_parallel_degree

--- a/paddlenlp/layers/lora.py
+++ b/paddlenlp/layers/lora.py
@@ -28,7 +28,7 @@ from paddle.distributed.fleet.layers.mpu import mp_ops
 from paddle.distributed.fleet.meta_parallel import ColumnParallelLinear
 
 from ..transformers.conversion_utils import ConversionMixin
-from ..transformers.model_utils import PretrainedModel, _add_variant
+from ..transformers.model_utils import PretrainedModel, _add_variant, dtype_guard
 from ..utils.distributed import distributed_gather
 from ..utils.env import LORA_CONFIG_NAME, LORA_WEIGHT_FILE_NAME
 from ..utils.log import logger
@@ -599,7 +599,12 @@ class LoRAModel(nn.Layer):
     def __init__(self, model, lora_config: LoRAConfig) -> None:
         super().__init__()
         self.lora_config = lora_config
-        self.model = self.get_lora_model(model, lora_config)
+        if self.lora_config.dtype:
+            self.dtype = self.lora_config.dtype
+        else:
+            self.dtype = paddle.get_default_dtype()
+        with dtype_guard(self.dtype):
+            self.model = self.get_lora_model(model, lora_config)
         if self.lora_config.tensor_parallel_degree != self.model.config.tensor_parallel_degree:
             self.lora_config.tensor_parallel_degree = self.model.config.tensor_parallel_degree
             logger.warning(

--- a/paddlenlp/prompt/prefix.py
+++ b/paddlenlp/prompt/prefix.py
@@ -22,7 +22,7 @@ import paddle
 import paddle.nn as nn
 from paddle.distributed import fleet
 
-from ..transformers.model_utils import _add_variant
+from ..transformers.model_utils import _add_variant, dtype_guard
 from ..utils.distributed import distributed_gather
 from ..utils.env import (
     PAST_KEY_VALUES_FILE_NAME,
@@ -136,8 +136,13 @@ class PrefixModelForCausalLM(paddle.nn.Layer):
         self.model = model
         self.forward_keys = signature(self.model.forward)
         self.config = model.config
-        self.prefix_encoder = self._create_prefix_encoder()
-        self.prefix_dropout = nn.Dropout(p=prefix_config.prefix_dropout)
+        if self.prefix_config.dtype:
+            self.dtype = self.prefix_config.dtype
+        else:
+            self.dtype = paddle.get_default_dtype()
+        with dtype_guard(self.dtype):
+            self.prefix_encoder = self._create_prefix_encoder()
+            self.prefix_dropout = nn.Dropout(p=prefix_config.prefix_dropout)
         self.prefix_tokens = paddle.arange(self.prefix_config.num_prefix_tokens, dtype="int64")
         self.model_prepare_inputs_for_generation = self.model.prepare_inputs_for_generation
         self.inference = False
@@ -161,13 +166,14 @@ class PrefixModelForCausalLM(paddle.nn.Layer):
         past_key_values = self._get_past_key_values(batch_size)
 
         if attention_mask is not None:
-
             if self.pad_attention_mask is not None:
                 attention_mask = self.pad_attention_mask(
                     input_ids.shape, self.prefix_config.num_prefix_tokens, attention_mask
                 )
             else:
-                prefix_attention_mask = paddle.ones([batch_size, self.prefix_config.num_prefix_tokens])
+                prefix_attention_mask = paddle.ones(
+                    [batch_size, self.prefix_config.num_prefix_tokens], dtype=attention_mask.dtype
+                )
                 attention_mask = paddle.concat((prefix_attention_mask, attention_mask), axis=1)
             kwargs["attention_mask"] = attention_mask
 
@@ -197,7 +203,7 @@ class PrefixModelForCausalLM(paddle.nn.Layer):
             )
         else:
             prefix_attention_mask = paddle.ones(
-                [model_kwargs["input_ids"].shape[0], self.prefix_config.num_prefix_tokens]
+                [model_kwargs["input_ids"].shape[0], self.prefix_config.num_prefix_tokens], dtype=attention_mask.dtype
             )
             attention_mask = paddle.concat((prefix_attention_mask, attention_mask), axis=1)
         model_kwargs["attention_mask"] = attention_mask
@@ -502,6 +508,8 @@ def llama_postprocess_past_key_value(past_key_values):
 
 
 def chatglm_pad_attention_mask(input_ids_shape, num_prefix_tokens, attention_mask):
-    prefix_attention_mask = paddle.ones([input_ids_shape[0], 1, input_ids_shape[-1], num_prefix_tokens])
+    prefix_attention_mask = paddle.ones(
+        [input_ids_shape[0], 1, input_ids_shape[-1], num_prefix_tokens], dtype=attention_mask.dtype
+    )
     prefix_attention_mask = (prefix_attention_mask < 0.5).astype("int64")
     return paddle.concat((prefix_attention_mask, attention_mask), axis=3)

--- a/paddlenlp/prompt/prefix.py
+++ b/paddlenlp/prompt/prefix.py
@@ -136,11 +136,9 @@ class PrefixModelForCausalLM(paddle.nn.Layer):
         self.model = model
         self.forward_keys = signature(self.model.forward)
         self.config = model.config
-        if self.prefix_config.dtype:
-            self.dtype = self.prefix_config.dtype
-        else:
-            self.dtype = paddle.get_default_dtype()
-        with dtype_guard(self.dtype):
+        if self.prefix_config.dtype is None:
+            self.prefix_config.dtype = paddle.get_default_dtype()
+        with dtype_guard(self.prefix_config.dtype):
             self.prefix_encoder = self._create_prefix_encoder()
             self.prefix_dropout = nn.Dropout(p=prefix_config.prefix_dropout)
         self.prefix_tokens = paddle.arange(self.prefix_config.num_prefix_tokens, dtype="int64")

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1226,6 +1226,8 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
 
         if dtype is None:
             dtype = config.dtype
+        else:
+            config.dtype = dtype
 
         if not os.path.exists(os.path.join(cache_dir, CONFIG_NAME)):
             config.save_pretrained(cache_dir)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes
### PR changes
Others

### Description
明确一下finetune、predict和export时候，模型和lora，prefix相关参数的dtype
1、finetune的时候根据fp16_opt_level确定dtype；
2、predict和export的时候：
- 加载预训练模型（非lora/prefix）与预训练参数数据类型保持一致
- 加载微调后的模型，根据config.dtype
- 加载预训练模型+lora/prefix,默认以lora/prefix 的config.dtype为准
