### PR TITLE
disable kernel promotion for amp training

### DIFF
--- a/examples/language_model/moe/dygraph/run_moe_pretrain.py
+++ b/examples/language_model/moe/dygraph/run_moe_pretrain.py
@@ -88,6 +88,7 @@ def run_evaluate(args, data_loader, model, criterion, iter_steps, log_writer, gl
                 "elementwise_div",
             ],
             level="O2",
+            use_promote=False,
         ):
             preds = model(tokens)
         preds = paddle.cast(preds, dtype="float32")
@@ -517,7 +518,6 @@ def do_train(args):
             # many times. and start a new random dataloader.
             valid_data_loader = valid_data_loader()
             test_data_loader = test_data_loader()
-
             for step, batch in enumerate(train_data_loader()):
                 # to remove the train data that has been studyed.
                 if step < global_step - pass_num:
@@ -542,6 +542,7 @@ def do_train(args):
                             "elementwise_div",
                         ],
                         level="O2",
+                        use_promote=False,
                     ):
                         preds = model(tokens[start_index:end_index, :])
                         loss_mbs = criterion(

--- a/tests/test_tipc/benchmark/options.py
+++ b/tests/test_tipc/benchmark/options.py
@@ -132,6 +132,7 @@ def get_parser():
     parser.add_argument("--use_amp", type=str2bool, nargs="?", const=False, help="Enable AMP. ")
     parser.add_argument("--scale_loss", type=float, default=128, help="Loss scale. ")
     parser.add_argument("--amp_level", type=str, default="O2", help="AMP LEVEL. O1 or O2. ")
+    parser.add_argument("--amp_use_promote", action="store_true", help="Enable kernel promotion for AMP training. ")
     parser.add_argument("--custom_black_list", type=str, nargs="+", default=None, help="Custom black list for AMP. ")
 
     parser.add_argument("--to_static", action="store_true", help="Enable to static. ")

--- a/tests/test_tipc/train.py
+++ b/tests/test_tipc/train.py
@@ -103,12 +103,21 @@ def do_generated_inputs(args):
             cloned_inputs = clone_inputs(example_inputs)
 
             if args.use_amp:
-                with paddle.amp.auto_cast(
-                    custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
-                    level=args.amp_level,
-                    use_promote=args.amp_use_promote,
-                ):
-                    loss, sample_per_cards = benchmark_model.forward(model, args, cloned_inputs)
+                # paddle version >= 2.5.0 or develop
+                paddle_version = float(paddle.__version__[:3])
+                if (paddle_version == 0.0) or (paddle_version >= 2.5):
+                    with paddle.amp.auto_cast(
+                        custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
+                        level=args.amp_level,
+                        use_promote=args.amp_use_promote,
+                    ):
+                        loss, sample_per_cards = benchmark_model.forward(model, args, cloned_inputs)
+                else:
+                    with paddle.amp.auto_cast(
+                        custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
+                        level=args.amp_level,
+                    ):
+                        loss, sample_per_cards = benchmark_model.forward(model, args, cloned_inputs)
 
                 scaled = scaler.scale(loss)
                 scaled.backward()
@@ -249,10 +258,21 @@ def do_train(args):
             train_reader_cost = time.time() - batch_start
 
             if args.use_amp:
-                with paddle.amp.auto_cast(
-                    custom_black_list=args.custom_black_list if args.amp_level == "O2" else {}, level=args.amp_level
-                ):
-                    loss, sample_per_cards = benchmark_model.forward(model, args, input_data)
+                # paddle version >= 2.5.0 or develop
+                paddle_version = float(paddle.__version__[:3])
+                if (paddle_version == 0.0) or (paddle_version >= 2.5):
+                    with paddle.amp.auto_cast(
+                        custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
+                        level=args.amp_level,
+                        use_promote=args.amp_use_promote,
+                    ):
+                        loss, sample_per_cards = benchmark_model.forward(model, args, input_data)
+                else:
+                    with paddle.amp.auto_cast(
+                        custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
+                        level=args.amp_level,
+                    ):
+                        loss, sample_per_cards = benchmark_model.forward(model, args, input_data)
 
                 scaled = scaler.scale(loss)
                 scaled.backward()

--- a/tests/test_tipc/train.py
+++ b/tests/test_tipc/train.py
@@ -104,7 +104,9 @@ def do_generated_inputs(args):
 
             if args.use_amp:
                 with paddle.amp.auto_cast(
-                    custom_black_list=args.custom_black_list if args.amp_level == "O2" else {}, level=args.amp_level
+                    custom_black_list=args.custom_black_list if args.amp_level == "O2" else {},
+                    level=args.amp_level,
+                    use_promote=args.amp_use_promote,
                 ):
                     loss, sample_per_cards = benchmark_model.forward(model, args, cloned_inputs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] --> Models

### Description
<!-- Describe what this PR does -->
背景：过去框架AMP在O2模式下，当OP支持低精度就会选择低精度的kernel，但这样的策略出现精度问题的风险较高。为保障训练精度，框架在2.5版本对AMP 策略进行了调整，即在O2模式下，仅当Op所有输入为低精度时才会选择低精度kernel，否则则采用FP32 Kernel（即promote的策略），因此可能会引起部分模型出现性能下降。

目前可以通过给auto_cast设置use_promote=False参数来回退到旧版本的O2策略，为了减少对模型配置的修改，本PR给模型库添加该参数的设置功能，当前模型库默认设置为use_promote=False，使用的是旧版本的O2策略，以解决性能下降问题。

PaddlePaddle框架动态图下默认的行为是use_promote=True，未来新增的模型如果出现精度问题，可以尝试给模型配置中增加设置去进行调试。

框架PR：https://github.com/PaddlePaddle/Paddle/pull/53742
