### PR TITLE
[blip2]Fix inputs embedding batch_size bug

### DIFF
--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -851,7 +851,7 @@ class GenerationMixin(object):
         if input_ids is None and "inputs_embeds" not in model_kwargs:
             # Init `input_ids` with bos_token_id
             input_ids = self.prepare_input_ids_for_generation(bos_token_id)
-        else:
+        elif "inputs_embeds" in model_kwargs:
             # Add input embeds support
             input_ids = self.prepare_input_ids_for_generation(
                 bos_token_id, encoder_output=model_kwargs["inputs_embeds"]

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -848,10 +848,14 @@ class GenerationMixin(object):
                 logger.warning("FastGeneration is not available, " "and the original version would be used instead.")
 
         # params check
-        if input_ids is None:
+        if input_ids is None and "inputs_embeds" not in model_kwargs:
             # Init `input_ids` with bos_token_id
             input_ids = self.prepare_input_ids_for_generation(bos_token_id)
-
+        else:
+            # Add input embeds support
+            input_ids = self.prepare_input_ids_for_generation(
+                bos_token_id, encoder_output=model_kwargs["inputs_embeds"]
+            )
         # Add to model_kwargs
         model_kwargs["attention_mask"] = attention_mask
         if position_ids is not None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
+  Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

+ APIs

### Description
<!-- Describe what this PR does -->

+ batch_size>1 will fail

```
from PIL import Image
import requests
from paddlenlp.transformers import Blip2Processor, Blip2ForConditionalGeneration
import paddle

model_path = 'Salesforce/blip2-opt-2.7b'
processor = Blip2Processor.from_pretrained(model_path)
model = Blip2ForConditionalGeneration.from_pretrained(model_path)

img0 = "./000000039769.jpg"
img1 = './000000039769.jpg'
image_0 = Image.open(img0)
image_1 = Image.open(img1)
inputs = processor(images=[image_0,image_1], return_tensors="pd")['pixel_values']
print(len(inputs),inputs.shape)
generated_ids, scores = model.generate(pixel_values=inputs)
print(generated_ids)
```
<img width="1264" alt="c5e0140dd9a2e96b4adc8891d049e0ef" src="https://github.com/PaddlePaddle/PaddleNLP/assets/12107462/b02336ce-5773-4b45-a623-dd282d92051a">
