### PR TITLE
将ChineseCLIP use_cache 默认设置成 False

### DIFF
--- a/paddlenlp/transformers/chineseclip/configuration.py
+++ b/paddlenlp/transformers/chineseclip/configuration.py
@@ -75,7 +75,7 @@ class ChineseCLIPTextConfig(PretrainedConfig):
             [Self-Attention with Relative Position Representations (Shaw et al.)](https://arxiv.org/abs/1803.02155).
             For more information on `"relative_key_query"`, please refer to *Method 4* in [Improve Transformer Models
             with Better Relative Position Embeddings (Huang et al.)](https://arxiv.org/abs/2009.13658).
-        use_cache (`bool`, *optional*, defaults to `True`):
+        use_cache (`bool`, *optional*, defaults to `False`):
             Whether or not the model should return the last key/values attentions (not used by all models). Only
             relevant if `config.is_decoder=True`.
 
@@ -116,7 +116,7 @@ class ChineseCLIPTextConfig(PretrainedConfig):
         pool_act: str = "tanh",
         fuse: bool = False,
         position_embedding_type="absolute",
-        use_cache=True,
+        use_cache=False,  # may has OOM bug, must set this to False,
         **kwargs
     ):
         kwargs["return_dict"] = kwargs.pop("return_dict", True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

use_cache如果默认为True的话，会存在BUG。在训练的时候显存会不断增长直至撑爆了。因此需要修改这个默认值为False，然后修改BOS上的Config文件里面的为False。
![image](https://github.com/PaddlePaddle/PaddleNLP/assets/50394665/0478f649-0129-43e9-b673-9620627269b5)
![67efc8f45f6dcfbb92cbb7701e8e31f6](https://github.com/PaddlePaddle/PaddleNLP/assets/50394665/2c11e117-158f-4c9a-bc2b-1244ec1a0035)

