### PR TITLE
[arange] set dtype="int64" explicitly.

### DIFF
--- a/examples/language_model/llama/convert_llama_weights_to_pd.py
+++ b/examples/language_model/llama/convert_llama_weights_to_pd.py
@@ -80,7 +80,7 @@ def write_model(model_path, input_base_path, model_size):
     dim = params["dim"]
     dims_per_head = dim // n_heads
     base = 10000.0
-    inv_freq = 1.0 / (base ** (paddle.arange(0, dims_per_head, 2) / dims_per_head))
+    inv_freq = 1.0 / (base ** (paddle.arange(0, dims_per_head, 2, dtype="int64") / dims_per_head))
 
     # permute for sliced rotary
     def permute(w):

--- a/examples/torch_migration/pipeline/models/pd_bert.py
+++ b/examples/torch_migration/pipeline/models/pd_bert.py
@@ -84,7 +84,9 @@ class BertEmbeddings(nn.Layer):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).reshape((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").reshape((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/albert/modeling.py
+++ b/paddlenlp/transformers/albert/modeling.py
@@ -107,7 +107,9 @@ class AlbertEmbeddings(Layer):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         # Position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/bigbird/modeling.py
+++ b/paddlenlp/transformers/bigbird/modeling.py
@@ -1230,7 +1230,7 @@ class BigBirdForQuestionAnswering(BigBirdPretrainedModel):
 
     @staticmethod
     def prepare_question_mask(q_lengths, maxlen):
-        mask = paddle.arange(0, maxlen).unsqueeze_(0)
+        mask = paddle.arange(0, maxlen, dtype="int64").unsqueeze_(0)
         mask = mask < q_lengths
         return mask
 

--- a/paddlenlp/transformers/blip/modeling.py
+++ b/paddlenlp/transformers/blip/modeling.py
@@ -257,7 +257,9 @@ class BlipTextEmbeddings(nn.Layer):
         self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).reshape((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").reshape((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/blip/modeling_text.py
+++ b/paddlenlp/transformers/blip/modeling_text.py
@@ -135,7 +135,9 @@ class BlipTextEmbeddings(nn.Layer):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).reshape((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").reshape((1, -1))
+        )
         self.position_embedding_type = getattr(config, "position_embedding_type", "absolute")
 
         self.config = config

--- a/paddlenlp/transformers/clip/modeling.py
+++ b/paddlenlp/transformers/clip/modeling.py
@@ -728,7 +728,9 @@ class CLIPTextTransformer(nn.Layer):
             ),
             persistable=False,
         )
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).reshape((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").reshape((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/clipseg/modeling.py
+++ b/paddlenlp/transformers/clipseg/modeling.py
@@ -237,7 +237,9 @@ class CLIPSegTextEmbeddings(nn.Layer):
         self.position_embedding = nn.Embedding(config.max_position_embeddings, embed_dim)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/ernie_layout/modeling.py
+++ b/paddlenlp/transformers/ernie_layout/modeling.py
@@ -126,7 +126,9 @@ class ErnieLayoutEmbeddings(Layer):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def _cal_spatial_position_embeddings(self, bbox):
         try:

--- a/paddlenlp/transformers/fnet/modeling.py
+++ b/paddlenlp/transformers/fnet/modeling.py
@@ -143,7 +143,9 @@ class FNetEmbeddings(Layer):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(
         self,

--- a/paddlenlp/transformers/layoutlm/modeling.py
+++ b/paddlenlp/transformers/layoutlm/modeling.py
@@ -74,7 +74,9 @@ class LayoutLMEmbeddings(Layer):
         self.layer_norm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(self, input_ids, bbox=None, token_type_ids=None, position_ids=None):
         # input_shape = input_ids.size()

--- a/paddlenlp/transformers/layoutlmv2/modeling.py
+++ b/paddlenlp/transformers/layoutlmv2/modeling.py
@@ -104,7 +104,9 @@ class LayoutLMv2Embeddings(Layer):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def _cal_spatial_position_embeddings(self, bbox):
         try:

--- a/paddlenlp/transformers/layoutxlm/modeling.py
+++ b/paddlenlp/transformers/layoutxlm/modeling.py
@@ -130,7 +130,9 @@ class LayoutXLMEmbeddings(Layer):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def _cal_spatial_position_embeddings(self, bbox):
         try:

--- a/paddlenlp/transformers/mobilebert/modeling.py
+++ b/paddlenlp/transformers/mobilebert/modeling.py
@@ -83,7 +83,9 @@ class MobileBertEmbeddings(nn.Layer):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(self, input_ids=None, token_type_ids=None, position_ids=None, inputs_embeds=None):
         if input_ids is not None:

--- a/paddlenlp/transformers/nystromformer/modeling.py
+++ b/paddlenlp/transformers/nystromformer/modeling.py
@@ -68,7 +68,9 @@ class NystromformerEmbeddings(nn.Layer):
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)) + 2)
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1)) + 2
+        )
         self.position_embedding_type = getattr(config, "position_embedding_type", "absolute")
         self.register_buffer(
             "token_type_ids",

--- a/paddlenlp/transformers/squeezebert/modeling.py
+++ b/paddlenlp/transformers/squeezebert/modeling.py
@@ -58,7 +58,9 @@ class SqueezeBertEmbeddings(nn.Layer):
         self.LayerNorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
-        self.register_buffer("position_ids", paddle.arange(config.max_position_embeddings).expand((1, -1)))
+        self.register_buffer(
+            "position_ids", paddle.arange(config.max_position_embeddings, dtype="int64").expand((1, -1))
+        )
 
     def forward(self, input_ids=None, token_type_ids=None, position_ids=None):
         input_shape = input_ids.shape

--- a/paddlenlp/transformers/t5/modeling.py
+++ b/paddlenlp/transformers/t5/modeling.py
@@ -308,8 +308,8 @@ class T5Attention(nn.Layer):
 
     def compute_bias(self, query_length, key_length):
         """Compute binned relative position bias"""
-        context_position = paddle.arange(query_length).unsqueeze(-1)
-        memory_position = paddle.arange(key_length).unsqueeze(0)
+        context_position = paddle.arange(query_length, dtype="int64").unsqueeze(-1)
+        memory_position = paddle.arange(key_length, dtype="int64").unsqueeze(0)
         relative_position = memory_position - context_position  # shape (query_length, key_length)
         relative_position_bucket = self._relative_position_bucket(
             relative_position,  # shape (query_length, key_length)
@@ -1139,7 +1139,7 @@ class T5Stack(T5PretrainedModel):
             # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
             if self.is_decoder:
                 batch_size, seq_length = input_shape
-                seq_ids = paddle.arange(seq_length)
+                seq_ids = paddle.arange(seq_length, dtype="int64")
                 causal_mask = paddle.tile(
                     seq_ids.unsqueeze(axis=[0, 1]), [batch_size, seq_length, 1]
                 ) <= seq_ids.unsqueeze(axis=[0, 2])
@@ -1164,7 +1164,7 @@ class T5Stack(T5PretrainedModel):
         elif attention_mask.ndim == 4:
             if self.is_decoder:
                 batch_size, seq_length = input_shape
-                seq_ids = paddle.arange(seq_length)
+                seq_ids = paddle.arange(seq_length, dtype="int64")
                 causal_mask = paddle.tile(
                     seq_ids.unsqueeze(axis=[0, 1]), [batch_size, seq_length, 1]
                 ) <= seq_ids.unsqueeze(axis=[0, 2])
@@ -1788,7 +1788,9 @@ class T5ForConditionalGeneration(T5PretrainedModel):
 
     @staticmethod
     def expand_inputs_for_generation(input_ids, expand_size, attention_mask=None, **model_kwargs):
-        index = paddle.tile(paddle.arange(input_ids.shape[0]).unsqueeze(-1), [1, expand_size]).reshape([-1])
+        index = paddle.tile(paddle.arange(input_ids.shape[0], dtype="int64").unsqueeze(-1), [1, expand_size]).reshape(
+            [-1]
+        )
 
         input_ids = paddle.index_select(input_ids, index)
 

--- a/ppdiffusers/examples/Stable-CycleDiffusion/seq_aligner.py
+++ b/ppdiffusers/examples/Stable-CycleDiffusion/seq_aligner.py
@@ -124,7 +124,7 @@ def get_mapper(x: str, y: str, tokenizer, max_len=77):
         dtype=paddle.int64,
     )
     mapper[: mapper_base.shape[0]] = mapper_base[:, 1]
-    mapper[mapper_base.shape[0] :] = len(y_seq) + paddle.arange(max_len - len(y_seq))
+    mapper[mapper_base.shape[0] :] = len(y_seq) + paddle.arange(max_len - len(y_seq), dtype="int64")
     return mapper, alphas
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- Set `dtype="int64"` in `paddle.arange` explicitly, as the behavior of `dtype=None` will change in next PaddlePaddle version.