### PR TITLE
[Dy2St]Support @to_static training in GPT3 by -o Strategy.to_static=True

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
+++ b/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/pretrain_gpt_base.yaml
@@ -101,3 +101,6 @@ Profiler:
 
 Distributed:
   fuse_sequence_parallel_allreduce: False
+
+Strategy:
+  to_static: False

--- a/model_zoo/gpt-3/tools/train.py
+++ b/model_zoo/gpt-3/tools/train.py
@@ -29,6 +29,7 @@ from ppfleetx.distributed.apis import env
 from ppfleetx.models import build_module
 from ppfleetx.ops.fused_layers import mock_layers
 from ppfleetx.utils import config
+from ppfleetx.utils.log import logger
 
 
 def set_default_flags(flags):
@@ -51,6 +52,11 @@ if __name__ == "__main__":
 
     module = build_module(cfg)
     config.print_config(cfg)
+
+    if cfg["Strategy"]["to_static"]:
+        paddle.jit.set_code_level()
+        module = paddle.jit.to_static(module)
+        logger.info("Successfully to apply @to_static, and model.forward convert into: {}".format(module.forward))
 
     train_data_loader = build_dataloader(cfg.Data, "Train")
     eval_data_loader = build_dataloader(cfg.Data, "Eval")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->

[Dy2St]Support @to_static training in GPT3 by -o Strategy.to_static=True

开启方式：在训练命令中添加`-o Strategy.to_static=True`，以单卡训练为例：

```bash
python tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_345M_single_card.yaml -o Strategy.to_static=True
```

执行日志：
<img width="1313" alt="image" src="https://github.com/PaddlePaddle/PaddleNLP/assets/9301846/231a16d2-509f-4771-8fae-8cb9c07e2620">
<img width="1384" alt="image" src="https://github.com/PaddlePaddle/PaddleNLP/assets/9301846/e6f807e6-0a24-42f5-893e-70d1d9f10d3f">

