### PR TITLE
Fix log variable formatting order

### DIFF
--- a/paddlenlp/transformers/unimo/tokenizer.py
+++ b/paddlenlp/transformers/unimo/tokenizer.py
@@ -442,7 +442,7 @@ class UNIMOTokenizer(PretrainedTokenizer):
         assert max_seq_len > max_title_len + max_target_len, (
             "`max_seq_len` must be greater than the sum of `max_target_len` "
             "and `max_title_len`. But received `max_seq_len` is {}, "
-            "`max_target_len` is {}, `max_title_len` is {}.".format(max_seq_len, max_title_len, max_target_len)
+            "`max_title_len` is {}, `max_target_len` is {}.".format(max_seq_len, max_title_len, max_target_len)
         )
         assert target is None or not add_start_token_for_decoding, (
             "`add_start_token_for_decoding` only works when `target` is "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
***Bug fixes***

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
***Comment***

### Description
<!-- Describe what this PR does -->
Fix log variable formatting order for `max_target_len` and `max_title_len`.