### PR TITLE
[config] fix unexpected `num_choices` error for ForMutipleChoice

### DIFF
--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -573,6 +573,7 @@ class PretrainedConfig:
             # Keys are always strings in JSON so convert ids to int here.
         else:
             self.num_labels = kwargs.pop("num_labels", 2)
+        self.num_choices = kwargs.pop("num_choices", None)
 
         self.classifier_dropout = kwargs.pop("classifier_dropout", None)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
- Fix Error when running the following code:
```
AutoModelForMultipleChoice.from_pretrained(model_name_or_path, num_choices=num_choices)
```