### PR TITLE
[Bug Fixes] fix weight casting with bfloat16 dtype

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1152,7 +1152,8 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             for key in state_dict.keys():
                 target_dtype = dtype
                 if isinstance(state_dict[key], np.ndarray):
-                    if not issubclass(state_dict[key].dtype.type, np.floating):
+                    state_dict_dtype = state_dict[key].dtype
+                    if not issubclass(state_dict_dtype.type, np.floating) and state_dict_dtype != np.uint16:
                         continue
 
                     # TODO(wj-Mcat): add `keep_in_fp32` feature to enable hybrid fp32 state-dict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->

在 load_state_as_np 开启时，np.uint16 不是floating 类型数据，此时将会导致数据类型 casting 的问题，相见 file diff。
