### PR TITLE
[TIPC] attrtdict 替换为 easydict

### DIFF
--- a/examples/machine_translation/requirements.txt
+++ b/examples/machine_translation/requirements.txt
@@ -1,3 +1,4 @@
+attrdict
 easydict
 pyyaml
 subword_nmt

--- a/examples/machine_translation/requirements.txt
+++ b/examples/machine_translation/requirements.txt
@@ -1,3 +1,3 @@
-attrdict
+easydict
 pyyaml
 subword_nmt

--- a/examples/machine_translation/transformer/deploy/python/inference.py
+++ b/examples/machine_translation/transformer/deploy/python/inference.py
@@ -19,7 +19,7 @@ from pprint import pprint
 
 import paddle
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 from paddle import inference
 
 from paddlenlp.utils.log import logger

--- a/examples/machine_translation/transformer/deploy/serving/transformer_web_client.py
+++ b/examples/machine_translation/transformer/deploy/serving/transformer_web_client.py
@@ -18,7 +18,7 @@ from pprint import pprint
 
 import requests
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 from paddle_serving_client.utils import MultiThreadRunner
 
 from paddlenlp.datasets import load_dataset

--- a/examples/machine_translation/transformer/deploy/serving/transformer_web_server.py
+++ b/examples/machine_translation/transformer/deploy/serving/transformer_web_server.py
@@ -17,7 +17,7 @@ from pprint import pprint
 
 import numpy as np
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 try:
     from paddle_serving_server_gpu.web_service import WebService

--- a/examples/machine_translation/transformer/export_model.py
+++ b/examples/machine_translation/transformer/export_model.py
@@ -19,7 +19,7 @@ from pprint import pprint
 import paddle
 import reader
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.transformers import InferTransformerModel, position_encoding_init
 from paddlenlp.utils.log import logger

--- a/examples/machine_translation/transformer/fast_transformer/encoder_decoding_predict.py
+++ b/examples/machine_translation/transformer/fast_transformer/encoder_decoding_predict.py
@@ -20,7 +20,7 @@ from pprint import pprint
 import numpy as np
 import paddle
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.ops import FasterTransformer
 from paddlenlp.utils.log import logger

--- a/examples/machine_translation/transformer/fast_transformer/export_model.py
+++ b/examples/machine_translation/transformer/fast_transformer/export_model.py
@@ -19,7 +19,7 @@ from pprint import pprint
 
 import paddle
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.ops import FasterTransformer
 from paddlenlp.utils.log import logger

--- a/examples/machine_translation/transformer/predict.py
+++ b/examples/machine_translation/transformer/predict.py
@@ -19,7 +19,7 @@ from pprint import pprint
 import paddle
 import reader
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.ops import TransformerGenerator
 

--- a/examples/machine_translation/transformer/static/predict.py
+++ b/examples/machine_translation/transformer/static/predict.py
@@ -20,7 +20,7 @@ from pprint import pprint
 import numpy as np
 import paddle
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.transformers import InferTransformerModel
 

--- a/examples/machine_translation/transformer/static/train.py
+++ b/examples/machine_translation/transformer/static/train.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import argparse
-import logging
 import os
 import sys
 import time
@@ -24,18 +23,15 @@ import paddle
 import paddle.distributed as dist
 import paddle.distributed.fleet as fleet
 import yaml
-from easydict import EasyDict as AttrDict
+from attrdict import AttrDict
 
 from paddlenlp.transformers import CrossEntropyCriterion, TransformerModel
 from paddlenlp.utils import profiler
+from paddlenlp.utils.log import logger
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 import reader  # noqa: E402
 from tls.record import AverageStatistical  # noqa: E402
-
-FORMAT = "%(asctime)s-%(levelname)s: %(message)s"
-logging.basicConfig(level=logging.INFO, format=FORMAT)
-logger = logging.getLogger(__name__)
 
 
 def parse_args():
@@ -307,7 +303,7 @@ def do_train(args):
                 total_avg_cost = total_sum_cost / total_token_num
 
                 if step_idx == 0:
-                    logging.info(
+                    logger.info(
                         "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "
                         "normalized loss: %f, ppl: %f"
                         % (
@@ -321,7 +317,7 @@ def do_train(args):
                     )
                 else:
                     train_avg_batch_cost = args.print_step / batch_cost_avg.get_total_time()
-                    logging.info(
+                    logger.info(
                         "step_idx: %d, epoch: %d, batch: %d, avg loss: %f, "
                         "normalized loss: %f, ppl: %f, avg_speed: %.2f step/s, "
                         "batch_cost: %.5f sec, reader_cost: %.5f sec, tokens: %d, "

--- a/examples/machine_translation/transformer/static/train.py
+++ b/examples/machine_translation/transformer/static/train.py
@@ -23,7 +23,7 @@ import paddle
 import paddle.distributed as dist
 import paddle.distributed.fleet as fleet
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.transformers import CrossEntropyCriterion, TransformerModel
 from paddlenlp.utils import profiler

--- a/examples/machine_translation/transformer/static/train.py
+++ b/examples/machine_translation/transformer/static/train.py
@@ -24,7 +24,7 @@ import paddle
 import paddle.distributed as dist
 import paddle.distributed.fleet as fleet
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 
 from paddlenlp.transformers import CrossEntropyCriterion, TransformerModel
 from paddlenlp.utils import profiler

--- a/examples/machine_translation/transformer/train.py
+++ b/examples/machine_translation/transformer/train.py
@@ -23,7 +23,7 @@ import paddle
 import paddle.distributed as dist
 import reader
 import yaml
-from attrdict import AttrDict
+from easydict import EasyDict as AttrDict
 from tls.record import AverageStatistical
 from tls.to_static import apply_to_static
 

--- a/scripts/regression/requirements_ci.txt
+++ b/scripts/regression/requirements_ci.txt
@@ -2,6 +2,7 @@ opencv-python==4.6.0.66
 opencv-contrib-python==4.6.0.66
 regex
 attrdict==2.0.1
+easydict==1.10.0
 PyYAML==5.4.1
 subword_nmt==0.3.7
 visualdl

--- a/tests/test_tipc/prepare.sh
+++ b/tests/test_tipc/prepare.sh
@@ -411,7 +411,7 @@ elif [ ${MODE} = "benchmark_train" ];then
     python -m pip install setuptools_scm 
     python -m pip install Cython 
     python -m pip install -r ../requirements.txt  #-i https://pypi.tuna.tsinghua.edu.cn/simple
-    python -m pip install pybind11 regex sentencepiece tqdm visualdl attrdict pyyaml rouge -i https://mirror.baidu.com/pypi/simple
+    python -m pip install pybind11 regex sentencepiece tqdm visualdl attrdict easydict pyyaml rouge -i https://mirror.baidu.com/pypi/simple
 
     python -m pip install -e ../
     # python -m pip install paddlenlp    # PDC 镜像中安装失败

--- a/tests/test_tipc/static/dp/transformer/benchmark_common/prepare.sh
+++ b/tests/test_tipc/static/dp/transformer/benchmark_common/prepare.sh
@@ -1,3 +1,17 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd ../examples/machine_translation/transformer/
 
 sed -i "s/^random_seed:.*/random_seed: 128/g" configs/transformer.base.yaml
@@ -53,7 +67,7 @@ python -m pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple
 python -m pip install setuptools_scm 
 python -m pip install Cython 
 python -m pip install -r ../requirements.txt  #-i https://pypi.tuna.tsinghua.edu.cn/simple
-python -m pip install attrdict pyyaml #-i https://pypi.tuna.tsinghua.edu.cn/simple
+python -m pip install easydict pyyaml #-i https://pypi.tuna.tsinghua.edu.cn/simple
 
 python -m pip install -e ../
 # python -m pip install paddlenlp    # PDC 镜像中安装失败

--- a/tests/test_tipc/static/dp/transformer/benchmark_common/prepare.sh
+++ b/tests/test_tipc/static/dp/transformer/benchmark_common/prepare.sh
@@ -67,7 +67,7 @@ python -m pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple
 python -m pip install setuptools_scm 
 python -m pip install Cython 
 python -m pip install -r ../requirements.txt  #-i https://pypi.tuna.tsinghua.edu.cn/simple
-python -m pip install easydict pyyaml #-i https://pypi.tuna.tsinghua.edu.cn/simple
+python -m pip install attrdict easydict pyyaml #-i https://pypi.tuna.tsinghua.edu.cn/simple
 
 python -m pip install -e ../
 # python -m pip install paddlenlp    # PDC 镜像中安装失败


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- 使用easydict替换attrtdict，由于attrtdict不支持python310.
- 修改使用paddlenlp的logger。自己的logging不出日志。
<img width="504" alt="8a16aacf18d8a29e2f01b3c5a52fd3d4" src="https://github.com/PaddlePaddle/PaddleNLP/assets/50394665/efefd426-6941-464f-90f6-2cc76b0c4530">
<img width="1498" alt="106b59f29fe0a10896afff2fcfff1b70" src="https://github.com/PaddlePaddle/PaddleNLP/assets/50394665/140afc48-8611-49a1-a8c0-e8ba373968ab">
