### PR TITLE
fix python include path

### DIFF
--- a/model_zoo/ernie-1.0/data_tools/Makefile
+++ b/model_zoo/ernie-1.0/data_tools/Makefile
@@ -1,5 +1,6 @@
 CXXFLAGS += -O3 -Wall -shared -std=c++11 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell python3 -m pybind11 --includes)
+CPPFLAGS += $(shell python3-config --includes)
 LIBNAME = helpers
 LIBEXT = $(shell python3-config --extension-suffix)
 

--- a/model_zoo/gpt-3/ppfleetx/data/data_tools/cpp/Makefile
+++ b/model_zoo/gpt-3/ppfleetx/data/data_tools/cpp/Makefile
@@ -1,5 +1,6 @@
 CXXFLAGS += -O3 -Wall -shared -std=c++11 -fPIC -fdiagnostics-color
 CPPFLAGS += $(shell $(PYTHON_BIN) -m pybind11 --includes)
+CPPFLAGS += $(shell python3-config --includes)
 
 LIBNAME = fast_index_map_helpers
 LIBEXT = .so


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
In some case, `python -m pybind11 --includes` returns `/usr/local/include/python3.x/`, but the real header file is in `/usr/include/python3.x/`. So, add `python-config --includes`.
Ref: https://stackoverflow.com/questions/72502292/fatal-error-python-h-no-such-file-or-directory-when-compiling-pybind11-example
