### PR TITLE
[llm benchmark] Add qlora  benchmark

### DIFF
--- a/examples/benchmark/peft/README.md
+++ b/examples/benchmark/peft/README.md
@@ -41,8 +41,8 @@
 | Llama-7b  | Finetune | 4        | 8           | MP4          |  2213.46                  | ZeRO 2      | 1621.52                  |  **36%**  |
 | Llama-7b  | Finetune | 4        | 16          | sharding 2   |  2804.19                  | ZeRO 2      | 2465.55                  |  **14%**  |
 | Llama-13b | Finetune | 4        | 8           | MP4 recompute|  1651.50                  | ZeRO 3      | 736.19                   |  **124%**  |
-| Llama-13b | LoRA     | 4        | 8           | MP4 recompute|  474.36                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 327.75          |  **45%** |
-| Llama-13b | LoRA     | 4        | 16          | MP4 recompute|  452.20                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 405.90          |  **11%** |
+| Llama-65b | LoRA     | 4        | 8           | MP4 recompute|  474.36                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 327.75          |  **45%** |
+| Llama-65b | LoRA     | 4        | 16          | MP4 recompute|  452.20                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 405.90          |  **11%** |
 
 
 ###### 多卡分布式实验记录

--- a/examples/benchmark/peft/README.md
+++ b/examples/benchmark/peft/README.md
@@ -41,6 +41,8 @@
 | Llama-7b  | Finetune | 4        | 8           | MP4          |  2213.46                  | ZeRO 2      | 1621.52                  |  **36%**  |
 | Llama-7b  | Finetune | 4        | 16          | sharding 2   |  2804.19                  | ZeRO 2      | 2465.55                  |  **14%**  |
 | Llama-13b | Finetune | 4        | 8           | MP4 recompute|  1651.50                  | ZeRO 3      | 736.19                   |  **124%**  |
+| Llama-13b | LoRA     | 4        | 8           | MP4 recompute|  474.36                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 327.75          |  **45%** |
+| Llama-13b | LoRA     | 4        | 16          | MP4 recompute|  452.20                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 405.90          |  **11%** |
 
 
 ###### 多卡分布式实验记录
@@ -84,5 +86,4 @@
 
 ### TODOs
 
-- Add Llama-30b and Llama-65b
 - Enable Flash Attention

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -17,13 +17,16 @@ from typing import Optional
 
 import paddle.profiler as profiler
 from datasets import load_dataset
-from utils import CustomTrainer, ProfilerCallback
+from utils import CustomTrainer, DataCollatorForSupervisedDataset, ProfilerCallback
 
 from paddlenlp.data import DataCollatorForSeq2Seq
 from paddlenlp.peft import LoRAConfig, LoRAModel
 from paddlenlp.trainer import PdArgumentParser, TrainingArguments
-from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer, ChatGLMForConditionalGeneration
-
+from paddlenlp.transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    ChatGLMForConditionalGeneration,
+)
 
 """
 单卡
@@ -60,6 +63,9 @@ class ModelArguments:
     lora: Optional[bool] = field(default=False, metadata={"help": "whether to use LoRA"})
     english: Optional[bool] = field(default=False, metadata={"help": "whether to english benchmark dataset"})
     profiler: Optional[bool] = field(default=False, metadata={"help": "whether to use profiler"})
+    padding_to_max_length: Optional[bool] = field(
+        default=False, metadata={"help": "whether to padding to  fixd max length"}
+    )
 
 
 def main():
@@ -74,12 +80,12 @@ def main():
         if training_args.bf16:
             dtype = "bfloat16"
     else:
-        dtype="float32"
+        dtype = "float32"
 
     tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
     if "llama" in model_args.model_name_or_path:
         tokenizer.pad_token = tokenizer.unk_token
-    if 'chatglm' in model_args.model_name_or_path:
+    if "chatglm" in model_args.model_name_or_path:
         model = ChatGLMForConditionalGeneration.from_pretrained(
             model_args.model_name_or_path,
             load_state_as_np=True,
@@ -131,14 +137,14 @@ def main():
         model_inputs["input_ids"] = model_inputs["input_ids"] + labels_input_ids
 
         return model_inputs
-    
+
     if model_args.english:
         dataset = load_dataset("tatsu-lab/alpaca")
     else:
         dataset = load_dataset("Chinese-Vicuna/guanaco_belle_merge_v1.0")
 
     # select first 10k examples for benchmarking
-    dataset = dataset["train"].select(range(10000))
+    dataset = dataset["train"].select(range(1000))
     dataset = dataset.map(
         lambda example: preprocess_function(example), remove_columns=["instruction", "input", "output"]
     )
@@ -146,29 +152,32 @@ def main():
 
     if model_args.profiler:
         prof = profiler.Profiler(
-            targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.GPU],profile_memory=True,
-            scheduler = profiler.make_scheduler(closed=1, ready=2, record=1, repeat=1),
-            on_trace_ready = profiler.export_chrome_tracing('./log'),
+            targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.GPU],
+            profile_memory=True,
+            scheduler=profiler.make_scheduler(closed=1, ready=2, record=1, repeat=1),
+            on_trace_ready=profiler.export_chrome_tracing("./log"),
         )
+    if model_args.padding_to_max_length:
+        data_collator = DataCollatorForSupervisedDataset(
+            return_tensors="pd", tokenizer=tokenizer, padding="max_length", max_length=768
+        )
+    else:
+        data_collator = DataCollatorForSeq2Seq(return_tensors="pd", tokenizer=tokenizer)
 
-    
     trainer = CustomTrainer(
         model=model,
         tokenizer=tokenizer,
         train_dataset=dataset,
         callbacks=[ProfilerCallback(prof)] if model_args.profiler else [],
         args=training_args,
-        data_collator=DataCollatorForSeq2Seq(return_tensors="pd", tokenizer=tokenizer),
+        data_collator=data_collator,
     )
-
 
     train_metrics = trainer.train()
     tokens_per_second = trainer.total_observed_tokens / train_metrics.metrics["train_runtime"]
     effective_tokens_per_second = total_effective_tokens / train_metrics.metrics["train_runtime"]
     print(f"Tokens per second: {tokens_per_second:.2f}")
     print(f"Effective Tokens per second: {effective_tokens_per_second:.2f}")
-
-
 
 
 if __name__ == "__main__":

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -28,9 +27,6 @@ from paddlenlp.transformers import (
     AutoTokenizer,
     ChatGLMForConditionalGeneration,
 )
-
-os.environ["http_proxy"] = "http://172.19.56.199:3128"
-os.environ["https_proxy"] = "http://172.19.56.199:3128"
 
 """
 单卡

--- a/examples/benchmark/peft/paddle/utils.py
+++ b/examples/benchmark/peft/paddle/utils.py
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-from dataclasses import dataclass
-
-import numpy as np
-
-from paddlenlp.data import DataCollatorForSeq2Seq
 from paddlenlp.trainer import (
     Trainer,
     TrainerCallback,
@@ -25,8 +19,6 @@ from paddlenlp.trainer import (
     TrainerState,
     TrainingArguments,
 )
-
-IGNORE_INDEX = -100
 
 
 class CustomTrainer(Trainer):
@@ -54,52 +46,3 @@ class ProfilerCallback(TrainerCallback):
     def on_train_end(self, args, state, control, **kwargs):
         self.prof.stop()
         self.prof.summary()
-
-
-@dataclass
-class DataCollatorForSupervisedDataset(DataCollatorForSeq2Seq):
-    """Collate examples for supervised fine-tuning."""
-
-    def __call__(self, features, return_tensors=None):
-        # Deep copy to avoid modifying features in-place
-        batch = copy.deepcopy(features)
-        if return_tensors is None:
-            return_tensors = self.return_tensors
-        labels = [feature["labels"] for feature in batch] if "labels" in batch[0].keys() else None
-        # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
-        # same length to return tensors.
-        if labels is not None:
-            # Note(gongenlei): In pipeline, max_label_length = self.max_length
-            if self.padding == "max_length" and self.max_length is not None:
-                max_label_length = self.max_length
-            else:
-                max_label_length = max(len(l) for l in labels)
-            if self.pad_to_multiple_of is not None:
-                max_label_length = (
-                    (max_label_length + self.pad_to_multiple_of - 1)
-                    // self.pad_to_multiple_of
-                    * self.pad_to_multiple_of
-                )
-
-            padding_side = self.tokenizer.padding_side
-            for feature in batch:
-                remainder = [IGNORE_INDEX] * (max_label_length - len(feature["labels"]))
-                if isinstance(feature["labels"], list):
-                    feature["labels"] = (
-                        feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
-                    )
-                elif padding_side == "right":
-                    feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
-                else:
-                    feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
-
-        batch = self.tokenizer.pad(
-            batch,
-            padding=self.padding,
-            max_length=self.max_length,
-            pad_to_multiple_of=self.pad_to_multiple_of,
-            return_tensors=return_tensors,
-            return_attention_mask=True,
-        )
-
-        return batch

--- a/examples/benchmark/peft/paddle/utils.py
+++ b/examples/benchmark/peft/paddle/utils.py
@@ -12,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddlenlp.trainer import Trainer, TrainerCallback, TrainingArguments, TrainerState, TrainerControl
+import copy
+from dataclasses import dataclass
+
+import numpy as np
+
+from paddlenlp.data import DataCollatorForSeq2Seq
+from paddlenlp.trainer import (
+    Trainer,
+    TrainerCallback,
+    TrainerControl,
+    TrainerState,
+    TrainingArguments,
+)
+
+IGNORE_INDEX = -100
 
 
 class CustomTrainer(Trainer):
@@ -26,6 +40,7 @@ class CustomTrainer(Trainer):
 
 class ProfilerCallback(TrainerCallback):
     "A callback that prints a message at the beginning of training"
+
     def __init__(self, prof):
         self.prof = prof
         self.prof.start()
@@ -39,3 +54,52 @@ class ProfilerCallback(TrainerCallback):
     def on_train_end(self, args, state, control, **kwargs):
         self.prof.stop()
         self.prof.summary()
+
+
+@dataclass
+class DataCollatorForSupervisedDataset(DataCollatorForSeq2Seq):
+    """Collate examples for supervised fine-tuning."""
+
+    def __call__(self, features, return_tensors=None):
+        # Deep copy to avoid modifying features in-place
+        batch = copy.deepcopy(features)
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+        labels = [feature["labels"] for feature in batch] if "labels" in batch[0].keys() else None
+        # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
+        # same length to return tensors.
+        if labels is not None:
+            # Note(gongenlei): In pipeline, max_label_length = self.max_length
+            if self.padding == "max_length" and self.max_length is not None:
+                max_label_length = self.max_length
+            else:
+                max_label_length = max(len(l) for l in labels)
+            if self.pad_to_multiple_of is not None:
+                max_label_length = (
+                    (max_label_length + self.pad_to_multiple_of - 1)
+                    // self.pad_to_multiple_of
+                    * self.pad_to_multiple_of
+                )
+
+            padding_side = self.tokenizer.padding_side
+            for feature in batch:
+                remainder = [IGNORE_INDEX] * (max_label_length - len(feature["labels"]))
+                if isinstance(feature["labels"], list):
+                    feature["labels"] = (
+                        feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
+                    )
+                elif padding_side == "right":
+                    feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
+                else:
+                    feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
+
+        batch = self.tokenizer.pad(
+            batch,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+            return_attention_mask=True,
+        )
+
+        return batch

--- a/examples/benchmark/peft/torch/benchmark.py
+++ b/examples/benchmark/peft/torch/benchmark.py
@@ -11,26 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 
-from datasets import load_dataset
-from peft import LoraConfig, TaskType, get_peft_model
 import torch
 import torch.profiler as profiler
+from datasets import load_dataset
+from peft import LoraConfig, TaskType, get_peft_model
 from transformers import (
+    AutoModel,
     AutoModelForCausalLM,
     AutoTokenizer,
+    BitsAndBytesConfig,
     DataCollatorForSeq2Seq,
-    LlamaTokenizer,
     HfArgumentParser,
+    LlamaTokenizer,
     TrainingArguments,
-    AutoModel,
 )
-import numpy as np
-from utils import CustomTrainer, ProfilerCallback
-
+from utils import CustomTrainer, DataCollatorForSupervisedDataset, ProfilerCallback
 
 """
 单卡
@@ -58,8 +57,20 @@ class ModelArguments:
 
     model_name_or_path: str = field(default=None, metadata={"help": "model name or local path"})
     lora: Optional[bool] = field(default=False, metadata={"help": "whether to use LoRA"})
+    qlora: Optional[bool] = field(default=False, metadata={"help": "whether to use qLoRA"})
     english: Optional[bool] = field(default=False, metadata={"help": "whether to english benchmark dataset"})
     profiler: Optional[bool] = field(default=False, metadata={"help": "whether to use profiler"})
+    double_quant: bool = field(
+        default=True, metadata={"help": "Compress the quantization statistics through double quantization."}
+    )
+    quant_type: str = field(
+        default="nf4", metadata={"help": "Quantization data type to use. Should be one of `fp4` or `nf4`."}
+    )
+    bits: int = field(default=4, metadata={"help": "How many bits to use."})
+    max_memory_MB: int = field(default=80000, metadata={"help": "Free memory per gpu."})
+    padding_to_max_length: Optional[bool] = field(
+        default=False, metadata={"help": "whether to padding to  fixd max length"}
+    )
 
 
 def main():
@@ -67,22 +78,58 @@ def main():
     model_args, training_args = parser.parse_args_into_dataclasses()
 
     if "llama" in model_args.model_name_or_path:
-        tokenizer = LlamaTokenizer.from_pretrained(model_args.model_name_or_path,
-                                                    use_fast=False)
+        tokenizer = LlamaTokenizer.from_pretrained(model_args.model_name_or_path, use_fast=False)
         tokenizer.pad_token_id = 0
     elif "chatglm" in model_args.model_name_or_path:
         tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path, trust_remote_code=True)
     else:
         tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
 
-    if 'chatglm' in model_args.model_name_or_path:
+    compute_dtype = torch.float16 if training_args.fp16 else (torch.bfloat16 if training_args.bf16 else torch.float32)
+    if "chatglm" in model_args.model_name_or_path:
         # Add empty_init=False for zero3 training, refer to https://github.com/THUDM/ChatGLM-6B/issues/530
-        model = AutoModel.from_pretrained(model_args.model_name_or_path, 
-                                        empty_init=False if training_args.deepspeed is not None else True,
-                                        trust_remote_code=True, torch_dtype="auto")
-       
+        model = AutoModel.from_pretrained(
+            model_args.model_name_or_path,
+            empty_init=False if training_args.deepspeed is not None else True,
+            trust_remote_code=True,
+            torch_dtype="auto",
+        )
+
     else:
-        model = AutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, torch_dtype="auto")
+        if model_args.qlora:
+            n_gpus = torch.cuda.device_count()
+            max_memory = f"{model_args.max_memory_MB}MB"
+            max_memory = {i: max_memory for i in range(n_gpus)}
+            device_map = "auto"
+
+            # if we are in a distributed setting, we need to set the device map and max memory per device
+            if os.environ.get("LOCAL_RANK") is not None:
+                local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+                device_map = {"": local_rank}
+                max_memory = {"": max_memory[local_rank]}
+
+            model = AutoModelForCausalLM.from_pretrained(
+                model_args.model_name_or_path,
+                torch_dtype="auto",
+                load_in_4bit=model_args.bits == 4,
+                load_in_8bit=model_args.bits == 8,
+                device_map=device_map,
+                max_memory=max_memory,
+                quantization_config=BitsAndBytesConfig(
+                    load_in_4bit=model_args.bits == 4,
+                    load_in_8bit=model_args.bits == 8,
+                    llm_int8_threshold=6.0,
+                    llm_int8_has_fp16_weight=False,
+                    bnb_4bit_compute_dtype=compute_dtype,
+                    bnb_4bit_use_double_quant=model_args.double_quant,
+                    bnb_4bit_quant_type=model_args.quant_type,
+                ),
+            )
+        else:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_args.model_name_or_path,
+                torch_dtype="auto",
+            )
 
     if model_args.lora:
         if "llama" in model_args.model_name_or_path:
@@ -94,14 +141,16 @@ def main():
         )
         model = get_peft_model(model, peft_config)
         model.print_trainable_parameters()
-    
+
     if model_args.lora and training_args.gradient_checkpointing:
         # For backward compatibility
         if hasattr(model, "enable_input_require_grads"):
             model.enable_input_require_grads()
         else:
+
             def make_inputs_require_grad(module, input, output):
                 output.requires_grad_(True)
+
             model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
         # enable gradient checkpointing for memory efficiency
@@ -113,52 +162,52 @@ def main():
             inputs += example["input"]
         targets = example["output"]
         model_inputs = tokenizer(inputs, max_length=max_src_length, truncation=True, return_attention_mask=False)
-        
+
         labels = tokenizer(targets, max_length=max_tgt_length, truncation=True, return_attention_mask=False)
         labels_input_ids = labels["input_ids"] + [tokenizer.eos_token_id]
-        
+
         model_inputs["labels"] = [-100] * len(model_inputs["input_ids"]) + labels_input_ids
         model_inputs["input_ids"] = model_inputs["input_ids"] + labels_input_ids
         return model_inputs
 
-    
     if model_args.english:
         dataset = load_dataset("tatsu-lab/alpaca")
     else:
         dataset = load_dataset("Chinese-Vicuna/guanaco_belle_merge_v1.0")
 
     # select first 10k examples for benchmarking
-    dataset = dataset["train"].select(range(10000))
+    dataset = dataset["train"].select(range(1000))
     dataset = dataset.map(
         lambda example: preprocess_function(example), remove_columns=["instruction", "input", "output"]
     )
     total_effective_tokens = sum([len(i["input_ids"]) for i in dataset]) * training_args.num_train_epochs
 
-
-
     if model_args.profiler:
         prof = profiler.profile(
-                activities=[
-                    torch.profiler.ProfilerActivity.CPU,
-                    torch.profiler.ProfilerActivity.CUDA,
-                ],
-                schedule=torch.profiler.schedule(
-                    wait=1,
-                    warmup=1,
-                    active=2,
-                    repeat=1),
-                on_trace_ready=torch.profiler.tensorboard_trace_handler('hf-training-trainer'),
-                profile_memory=True,
-                with_stack=True,
-            )
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(wait=1, warmup=1, active=2, repeat=1),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler("hf-training-trainer"),
+            profile_memory=True,
+            with_stack=True,
+        )
+
+    if model_args.padding_to_max_length:
+        data_collator = DataCollatorForSupervisedDataset(
+            return_tensors="pt", tokenizer=tokenizer, padding="max_length", max_length=768
+        )
+    else:
+        data_collator = DataCollatorForSeq2Seq(return_tensors="pt", tokenizer=tokenizer)
 
     trainer = CustomTrainer(
         model=model,
-        tokenizer=tokenizer, 
+        tokenizer=tokenizer,
         train_dataset=dataset,
         callbacks=[ProfilerCallback(prof=prof)] if model_args.profiler else [],
         args=training_args,
-        data_collator=DataCollatorForSeq2Seq(return_tensors="pt", tokenizer=tokenizer),
+        data_collator=data_collator,
     )
     model.config.use_cache = False  # silence the warnings. Please re-enable for inference!
     train_metrics = trainer.train()

--- a/examples/benchmark/peft/torch/requirements.txt
+++ b/examples/benchmark/peft/torch/requirements.txt
@@ -4,4 +4,5 @@ peft @ git+https://github.com/huggingface/peft.git
 transformers==4.30.2
 torch==2.0.1
 sentencepiece
+bitsandbytes==0.39.0
 # CUDA VERSION 11.7

--- a/examples/benchmark/peft/torch/utils.py
+++ b/examples/benchmark/peft/torch/utils.py
@@ -12,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from transformers import Trainer, TrainerCallback, TrainingArguments, TrainerState, TrainerControl
+import copy
+from dataclasses import dataclass
+
+import numpy as np
+from transformers import (
+    DataCollatorForSeq2Seq,
+    Trainer,
+    TrainerCallback,
+    TrainerControl,
+    TrainerState,
+    TrainingArguments,
+)
+
+IGNORE_INDEX = -100
+
 
 class CustomTrainer(Trainer):
     total_observed_tokens = 0.0
@@ -22,8 +36,10 @@ class CustomTrainer(Trainer):
         self.total_observed_tokens += float(input_ids.shape[0] * input_ids.shape[1])
         return super().training_step(model, inputs)
 
+
 class ProfilerCallback(TrainerCallback):
     "A callback that prints a message at the beginning of training"
+
     def __init__(self, prof):
         self.prof = prof
 
@@ -32,3 +48,52 @@ class ProfilerCallback(TrainerCallback):
 
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         self.prof.step()
+
+
+@dataclass
+class DataCollatorForSupervisedDataset(DataCollatorForSeq2Seq):
+    """Collate examples for supervised fine-tuning."""
+
+    def __call__(self, features, return_tensors=None):
+        # Deep copy to avoid modifying features in-place
+        batch = copy.deepcopy(features)
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+        labels = [feature["labels"] for feature in batch] if "labels" in batch[0].keys() else None
+        # We have to pad the labels before calling `tokenizer.pad` as this method won't pad them and needs them of the
+        # same length to return tensors.
+        if labels is not None:
+            # Note(gongenlei): In pipeline, max_label_length = self.max_length
+            if self.padding == "max_length" and self.max_length is not None:
+                max_label_length = self.max_length
+            else:
+                max_label_length = max(len(l) for l in labels)
+            if self.pad_to_multiple_of is not None:
+                max_label_length = (
+                    (max_label_length + self.pad_to_multiple_of - 1)
+                    // self.pad_to_multiple_of
+                    * self.pad_to_multiple_of
+                )
+
+            padding_side = self.tokenizer.padding_side
+            for feature in batch:
+                remainder = [IGNORE_INDEX] * (max_label_length - len(feature["labels"]))
+                if isinstance(feature["labels"], list):
+                    feature["labels"] = (
+                        feature["labels"] + remainder if padding_side == "right" else remainder + feature["labels"]
+                    )
+                elif padding_side == "right":
+                    feature["labels"] = np.concatenate([feature["labels"], remainder]).astype(np.int64)
+                else:
+                    feature["labels"] = np.concatenate([remainder, feature["labels"]]).astype(np.int64)
+
+        batch = self.tokenizer.pad(
+            batch,
+            padding=self.padding,
+            max_length=self.max_length,
+            pad_to_multiple_of=self.pad_to_multiple_of,
+            return_tensors=return_tensors,
+            return_attention_mask=True,
+        )
+
+        return batch


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

| Model     | Method   | Num GPUs | Batch Size  | Paddle Setup | Paddle Effective Tokens/s | Torch Setup | Torch Effective Tokens/s | Speedup |
|-----------|----------|----------|-------------|--------------|---------------------------|-------------|--------------------------|---------|
| Llama-65b | LoRA     | 4        | 8           | MP4 recompute|  474.36                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 327.75          |  **45%** |
| Llama-65b | LoRA     | 4        | 16          | MP4 recompute|  452.20                   | gradient ckpt, bits 4, max_memory_MB 50000, qlora        | 405.90          |  **11%** |

+ qlora
```
export CUDA_VISIBLE_DEVICES=5
python benchmark.py --model_name_or_path  llama-65b-hf-pt \
    --num_train_epochs 1 --per_device_train_batch_size 4 \
    --evaluation_strategy no --save_strategy no \
    --gradient_checkpointing \
    --fp16 \
    --fp16_opt_level O2 \
    --bits 4 \
    --lora \
    --tf32 False  \
    --fp16_full_eval \
    --logging_steps 50 --output_dir outputs
```

```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
python -m torch.distributed.run --nproc_per_node=8 benchmark.py \
    --model_name_or_path  llama-65b-hf-pt \
    --num_train_epochs 1 --per_device_train_batch_size 1 \
    --gradient_checkpointing \
    --evaluation_strategy no --save_strategy no \
    --fp16 \
    --qlora \
    --max_memory_MB 50000 \
    --bits 4 \
    --logging_steps 50 --output_dir outputs
```