### PR TITLE
fix bloom

### DIFF
--- a/paddlenlp/transformers/bloom/tokenizer.py
+++ b/paddlenlp/transformers/bloom/tokenizer.py
@@ -144,7 +144,8 @@ class BloomTokenizer(PretrainedTokenizer):
     max_model_input_sizes = {
         "bigscience/bloom-560m": 102400,
     }
-    padding_side = "right"
+    padding_side = "left"
+    model_input_names = ["input_ids", "attention_mask"]
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Models

### Description
修复现有bloom问题
- 模型统一行为为left padding
- bloom必须传入attention_mask保证alibi生成的正确性和计算attention_score时忽略pad部分
