### PR TITLE
llm supports advertisegen dataset

### DIFF
--- a/paddlenlp/datasets/advertisegen.py
+++ b/paddlenlp/datasets/advertisegen.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,5 +65,11 @@ class AdvertiseGen(DatasetBuilder):
                     continue
                 json_data = json.loads(line)
 
-                yield {"source": json_data["content"], "target": json_data.get("summary", ""), "id": data_id}
+                yield {
+                    "source": json_data["content"],
+                    "src": json_data["content"],
+                    "target": json_data.get("summary", ""),
+                    "tgt": json_data.get("summary", ""),
+                    "id": data_id,
+                }
                 data_id += 1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
- Advertisegen returns "src" and "tgt" to support llm SFT.