### PR TITLE
eliminate transpose in sequence parallel for llama

### DIFF
--- a/llm/llama/run_pretrain.py
+++ b/llm/llama/run_pretrain.py
@@ -430,6 +430,7 @@ def main():
 
     config = config_class.from_pretrained(model_args.model_name_or_path)
 
+    config.seq_length = data_args.max_seq_length
     # There are some technique extend RotaryEmbedding context. so don't change max_position_embeddings
     if not model_args.continue_training:
         config.max_position_embeddings = max(config.max_position_embeddings, data_args.max_seq_length)

--- a/llm/llama/tests/test_sequence_parallel.py
+++ b/llm/llama/tests/test_sequence_parallel.py
@@ -55,7 +55,11 @@ class TestLlama(unittest.TestCase):
         # model_name_or_path = "facebook/llama-7b"
         model_name_or_path = "__internal_testing__/tiny-random-llama"
 
+        seq_len = 2048
+        batch_size = 2
+
         config = LlamaConfig.from_pretrained(model_name_or_path)
+        config.seq_length = seq_len
         config.lm_shift_labels = False
         config.use_flash_attention = False
         config.use_fused_rms_norm = False
@@ -80,12 +84,13 @@ class TestLlama(unittest.TestCase):
 
         model.eval()
 
-        seq_len = 2048
-        input_ids = paddle.arange(100, 100 + seq_len, dtype="int64").reshape([1, -1])
-        labels = paddle.arange(101, 101 + seq_len, dtype="int64").reshape([1, -1])
+        input_ids = paddle.arange(100, 100 + batch_size * seq_len, dtype="int64").reshape([batch_size, seq_len])
+        labels = paddle.arange(101, 101 + batch_size * seq_len, dtype="int64").reshape([batch_size, seq_len])
+
         attention_mask = None
         if pp_degree > 1:
             pp_model = PipelineParallel(layers=model, hcg=hcg, strategy=strategy)
+            pp_model.accumulate_steps = batch_size  # for micro_batch_size * acc_steps == batch_size
             ret = pp_model.eval_batch(data=[input_ids, labels], compute_loss=True)
         else:
             # pp_model = PipelineParallel(layers=model, hcg=hcg, strategy=strategy)
@@ -98,11 +103,7 @@ class TestLlama(unittest.TestCase):
         print(f"ret mp{tp_degree} pp{pp_degree}", ret.item())
         ret_mp_pp = ret.item()
 
-        single_model = LlamaForCausalLM.from_pretrained(
-            model_name_or_path,
-            lm_shift_labels=False,
-            tensor_parallel_output=False,
-        )
+        single_model = LlamaForCausalLM.from_pretrained(model_name_or_path, config=config)
         single_model.eval()
         ret = single_model(input_ids=input_ids, labels=labels, attention_mask=attention_mask)
         print("ret single", ret[0].item())

--- a/paddlenlp/transformers/llama/configuration.py
+++ b/paddlenlp/transformers/llama/configuration.py
@@ -214,7 +214,7 @@ class LlamaConfig(PretrainedConfig):
         hidden_size=4096,
         intermediate_size=11008,
         max_position_embeddings=2048,
-        seq_length=1024,
+        seq_length=2048,
         num_hidden_layers=32,
         num_attention_heads=32,
         num_key_value_heads=None,

--- a/paddlenlp/transformers/llama/configuration.py
+++ b/paddlenlp/transformers/llama/configuration.py
@@ -214,6 +214,7 @@ class LlamaConfig(PretrainedConfig):
         hidden_size=4096,
         intermediate_size=11008,
         max_position_embeddings=2048,
+        seq_length=1024,
         num_hidden_layers=32,
         num_attention_heads=32,
         num_key_value_heads=None,
@@ -242,6 +243,7 @@ class LlamaConfig(PretrainedConfig):
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
         self.max_position_embeddings = max_position_embeddings
+        self.seq_length = seq_length
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
 

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -179,6 +179,7 @@ def scaled_dot_product_attention(
     output_attentions,
     is_causal=True,
     alibi=None,
+    sequence_parallel=False,
 ):
     bsz, q_len, num_heads, head_dim = query_states.shape
     _, kv_seq_len, _, _ = value_states.shape
@@ -198,8 +199,10 @@ def scaled_dot_product_attention(
             causal=is_causal and query_states.shape[1] != 1,
             return_softmax=output_attentions,
         )
-
-        attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
+        if sequence_parallel:
+            attn_output = attn_output.reshape([bsz * q_len, head_dim * num_heads])
+        else:
+            attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
         return attn_output, attn_weights
     else:
         query_states = paddle.transpose(query_states, [0, 2, 1, 3])
@@ -238,7 +241,10 @@ def scaled_dot_product_attention(
 
         attn_output = paddle.matmul(attn_weights, value_states)
         attn_output = attn_output.transpose([0, 2, 1, 3])
-        attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
+        if sequence_parallel:
+            attn_output = attn_output.reshape([bsz * q_len, head_dim * num_heads])
+        else:
+            attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
         return attn_output, attn_weights
 
 
@@ -457,6 +463,7 @@ class LlamaAttention(nn.Layer):
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
 
         self.max_position_embeddings = config.max_position_embeddings
+        self.seq_length = config.seq_length
         self.sequence_parallel = config.sequence_parallel
 
         self.fuse_attention_qkv = config.fuse_attention_qkv
@@ -596,18 +603,25 @@ class LlamaAttention(nn.Layer):
         # [bs, seq_len, num_head * head_dim] -> [seq_len / n, bs, num_head * head_dim] (n is model parallelism)
 
         if self.fuse_attention_qkv:
+            if self.sequence_parallel:
+                target_shape = [-1, self.seq_length, self.num_heads, 3 * self.head_dim]
+            else:
+                target_shape = [0, 0, self.num_heads, 3 * self.head_dim]
+
             mix_layer = self.qkv_proj(hidden_states)
-            mix_layer = paddle.reshape_(mix_layer, [0, 0, self.num_heads, 3 * self.head_dim])
+            mix_layer = paddle.reshape_(mix_layer, target_shape)
             query_states, key_states, value_states = paddle.split(mix_layer, num_or_sections=3, axis=-1)
         else:
-            query_states = self.q_proj(hidden_states).reshape(shape=[0, 0, self.num_heads, self.head_dim])
-            key_states = self.k_proj(hidden_states).reshape(shape=[0, 0, self.num_key_value_heads, self.head_dim])
-            value_states = self.v_proj(hidden_states).reshape(shape=[0, 0, self.num_key_value_heads, self.head_dim])
+            if self.sequence_parallel:
+                target_query_shape = [-1, self.seq_length, self.num_heads, self.head_dim]
+                target_key_value_shape = [-1, self.seq_length, self.num_key_value_heads, self.head_dim]
+            else:
+                target_query_shape = [0, 0, self.num_heads, self.head_dim]
+                target_key_value_shape = [0, 0, self.num_key_value_heads, self.head_dim]
 
-        if self.sequence_parallel:
-            query_states = query_states.transpose([1, 0, 2, 3])
-            key_states = key_states.transpose([1, 0, 2, 3])
-            value_states = value_states.transpose([1, 0, 2, 3])
+            query_states = self.q_proj(hidden_states).reshape(shape=target_query_shape)
+            key_states = self.k_proj(hidden_states).reshape(shape=target_key_value_shape)
+            value_states = self.v_proj(hidden_states).reshape(shape=target_key_value_shape)
 
         offset = 0
         kv_seq_len = key_states.shape[-3]
@@ -656,10 +670,8 @@ class LlamaAttention(nn.Layer):
             attention_mask=attention_mask,
             output_attentions=output_attentions,
             alibi=alibi,
+            sequence_parallel=self.sequence_parallel,
         )
-
-        if self.sequence_parallel:
-            attn_output = paddle.transpose(attn_output, [1, 0, 2])
 
         # if sequence_parallel is true, out shape are [q_len / n, bs, num_head * head_dim]
         # else their shape are [bs, q_len, num_head * head_dim], n is mp parallelism.
@@ -704,7 +716,7 @@ class LlamaDecoderLayer(nn.Layer):
             cache (`Tuple(paddle.Tensor)`, *optional*): cached past key and value projection states
         """
 
-        # [bs, seq_len, embed_dim] -> [seq_len / n, bs, embed_dim] (sequence_parallel)
+        # [bs * seq_len, embed_dim] -> [seq_len * bs / n, embed_dim] (sequence_parallel)
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
@@ -1006,9 +1018,10 @@ class LlamaModel(LlamaPretrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if self.sequence_parallel:
-            # [bs, seq_len, num_head * head_dim] -> [seq_len, bs, num_head * head_dim]
-            inputs_embeds = paddle.transpose(inputs_embeds, perm=[1, 0, 2])
-            # [seq_len / n, bs, num_head * head_dim] (n is mp parallelism)
+            # [bs, seq_len, num_head * head_dim] -> [bs * seq_len, num_head * head_dim]
+            bs, seq_len, hidden_size = inputs_embeds.shape
+            inputs_embeds = paddle.reshape_(inputs_embeds, [bs * seq_len, hidden_size])
+            # [seq_len * bs / n, num_head * head_dim] (n is mp parallelism)
             inputs_embeds = ScatterOp.apply(inputs_embeds)
 
         # embed positions
@@ -1159,7 +1172,7 @@ class LlamaLMHead(nn.Layer):
     def forward(self, hidden_states, tensor_parallel_output=None):
         if self.config.sequence_parallel:
             hidden_states = GatherOp.apply(hidden_states)
-            hidden_states = paddle.transpose(hidden_states, [1, 0, 2])
+            hidden_states = paddle.reshape_(hidden_states, [-1, self.config.seq_length, self.config.hidden_size])
 
         if tensor_parallel_output is None:
             tensor_parallel_output = self.config.tensor_parallel_output


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Performance optimization

### PR changes
Models

### Description
Eliminate transpose operation in sequence parallel for LLAMA, resulting in a 3% performance increase in the mp4pp2 configuration.
