### PR TITLE
[blip2] Update blip2 to support fp16

### DIFF
--- a/paddlenlp/transformers/blip_2/modeling.py
+++ b/paddlenlp/transformers/blip_2/modeling.py
@@ -1473,13 +1473,11 @@ class Blip2ForConditionalGeneration(Blip2PretrainedModel):
         self.qformer = Blip2QFormerModel(config.qformer_config)
         self.language_projection = nn.Linear(config.qformer_config.hidden_size, config.text_config.hidden_size)
         if config.use_decoder_only_language_model:
-            # language_model = AutoModelForCausalLM.from_config(config.text_config)
             if isinstance(config.text_config, OPTConfig):
                 language_model = OPTForCausalLM(config.text_config)
             else:
                 raise NotImplementedError
         else:
-            # language_model = AutoModelForSeq2SeqLM.from_config(config.text_config)
             if isinstance(config.text_config, T5Config):
                 language_model = T5ForConditionalGeneration(config.text_config)
             else:
@@ -1570,7 +1568,7 @@ class Blip2ForConditionalGeneration(Blip2PretrainedModel):
         # step 3: use the language model, conditioned on the query outputs and the prompt
         language_model_inputs = self.language_projection(query_output)
         language_model_attention_mask = paddle.ones(language_model_inputs.shape[:-1], dtype="int64")
-        inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
+        inputs_embeds = self.language_model.get_input_embeddings()(input_ids).cast(dtype=self.config.dtype)
         inputs_embeds = paddle.concat([language_model_inputs, inputs_embeds], axis=1)
 
         if attention_mask is None:

--- a/paddlenlp/transformers/blip_2/modeling.py
+++ b/paddlenlp/transformers/blip_2/modeling.py
@@ -1568,7 +1568,7 @@ class Blip2ForConditionalGeneration(Blip2PretrainedModel):
         # step 3: use the language model, conditioned on the query outputs and the prompt
         language_model_inputs = self.language_projection(query_output)
         language_model_attention_mask = paddle.ones(language_model_inputs.shape[:-1], dtype="int64")
-        inputs_embeds = self.language_model.get_input_embeddings()(input_ids).cast(dtype=self.config.dtype)
+        inputs_embeds = self.language_model.get_input_embeddings()(input_ids).cast(dtype=language_model_inputs.dtype)
         inputs_embeds = paddle.concat([language_model_inputs, inputs_embeds], axis=1)
 
         if attention_mask is None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

```
import paddle
from paddlenlp.transformers import Blip2Processor, Blip2ForConditionalGeneration, Blip2QFormerModel
from paddlenlp.transformers import Blip2VisionModel, Blip2Model, OPTModel
from PIL import Image
model_name_or_path="Salesforce/blip2-opt-2.7b"

model = Blip2ForConditionalGeneration.from_pretrained(model_name_or_path,load_state_as_np=True,dtype="float16")
processor = Blip2Processor.from_pretrained(model_name_or_path)
image = Image.open('000000039769.jpg')
prompt = "Question: how many cats are there? Answer:"

inputs = processor(images=image, text=prompt, return_tensors="pd")
inputs["pixel_values"] = paddle.to_tensor(inputs["pixel_values"],dtype="float16")
outputs = model(pixel_values=inputs["pixel_values"],input_ids=inputs["input_ids"])
```

![image](https://github.com/PaddlePaddle/PaddleNLP/assets/12107462/8507f922-43d9-4190-aa10-d08a194ecec4)
