### PR TITLE
Add recompute for llama

### DIFF
--- a/llm/llama/modeling_pp.py
+++ b/llm/llama/modeling_pp.py
@@ -241,7 +241,7 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
         self.add_sequential_layer(LayerDesc(LlamaEmbeddingPipe, config=config), "llama")
         for i in range(config.num_hidden_layers):
             self.add_sequential_layer(
-                LayerDesc(LlamaDecoderLayerPipe, config=config, do_recompute=i not in self.no_recompute_layers),
+                LayerDesc(LlamaDecoderLayerPipe, config=config, layerwise_recompute=i not in self.no_recompute_layers),
                 f"llama.layers.{i}",
             )
 

--- a/llm/llama/modeling_pp.py
+++ b/llm/llama/modeling_pp.py
@@ -216,18 +216,18 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
     def __init__(
         self,
         config,
-        # use_recompute=None,
         # scale_qk_by_layer_num=True,
-        # recompute_granularity="full",
         # virtual_pp_degree=4,
-        # sequence_parallel=False,
-        # no_recompute_layers=None,
-        pp_recompute_interval=1,
     ):
         self.config = config
 
-        use_recompute = self.config.use_recompute
-        recompute_granularity = self.config.recompute_granularity
+        self.use_recompute = self.config.use_recompute
+        self.recompute_granularity = self.config.recompute_granularity
+        self.pp_recompute_interval = self.config.pp_recompute_interval
+        self.no_recompute_layers = config.no_recompute_layers if config.no_recompute_layers is not None else []
+        if self.recompute_granularity == "full":
+            assert len(self.no_recompute_layers) == 0, "for pp with full recompute, no_recompute_layers is not support"
+
         # virtual_pp_degree = self.config.virtual_pp_degree
         virtual_pp_degree = getattr(self.config, "virtual_pp_degree", 1)
 
@@ -240,17 +240,20 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
 
         self.add_sequential_layer(LayerDesc(LlamaEmbeddingPipe, config=config), "llama")
         for i in range(config.num_hidden_layers):
-            self.add_sequential_layer(LayerDesc(LlamaDecoderLayerPipe, config=config), f"llama.layers.{i}")
+            self.add_sequential_layer(
+                LayerDesc(LlamaDecoderLayerPipe, config=config, do_recompute=i not in self.no_recompute_layers),
+                f"llama.layers.{i}",
+            )
 
         self.add_sequential_layer(LayerDesc(LlamaRMSNormPipe, config=config), "llama.norm")
         self.add_sequential_layer(LayerDesc(LlamaLMHead, config=config), "lm_head")
 
         recompute_interval = 0
-        if use_recompute and recompute_granularity == "full":
-            assert pp_recompute_interval <= config.num_hidden_layers // (
+        if self.use_recompute and self.recompute_granularity == "full":
+            assert self.config.pp_recompute_interval <= config.num_hidden_layers // (
                 virtual_pp_degree * get_hcg().topology().get_dim_size("pipe")
             ), "pp recompute interval should smaller than num layers of each pp chunk"
-            recompute_interval = pp_recompute_interval
+            recompute_interval = self.config.pp_recompute_interval
 
         seg_method = "layer:LlamaDecoderLayer"
         if config.num_hidden_layers % get_hcg().topology().get_dim_size("pipe") != 0:

--- a/llm/llama/run_pretrain.py
+++ b/llm/llama/run_pretrain.py
@@ -151,7 +151,7 @@ class ModelArguments:
     )
     recompute_granularity: str = field(
         default="full",
-        metadata={"help": "full core_attn"},
+        metadata={"help": "one of full core_attn full_attn"},
     )
     virtual_pp_degree: int = field(
         default=1,
@@ -171,7 +171,6 @@ class ModelArguments:
         default=False,
         metadata={"help": "whether to use fuse sequence parallel allreduce"},
     )
-
     rope_fusion_level: Optional[str] = field(
         default=None,
         metadata={
@@ -179,6 +178,16 @@ class ModelArguments:
             "(1) 'full': fuse sin cos compute and rope embedding\n"
             "(2) 'core': only fuse rope embedding, will compute the sin and cos\n"
             "(3) None: don't fuse any part of the rope embedding"
+        },
+    )
+    no_recompute_layers: Optional[str] = field(
+        default=None,
+        metadata={"help": "Specify the full transformer layers that should not be recomputed."},
+    )
+    pp_recompute_interval: int = field(
+        default=0,
+        metadata={
+            "help": "The interval for the number of layers at which recomputation occurs. A value of 0 indicates no recomputation. Default is 0."
         },
     )
 
@@ -439,6 +448,22 @@ def main():
         config.vocab_size = max(config.vocab_size, ((tokenizer.vocab_size - 1) // 128 + 1) * 128)
         logger.info(f"Reset vocab size to {config.vocab_size} for batter amp peformance.")
 
+    if model_args.no_recompute_layers is not None:
+        import re
+
+        def check_format(s):
+            pattern = r"^\d+(,\d+)*$"
+            return bool(re.match(pattern, s))
+
+        if check_format(model_args.no_recompute_layers) is False:
+            raise ValueError(
+                f"no_recompute_layers should be fomated like int,int,...,int but recieved {model_args.no_recompute_layers}"
+            )
+
+        model_args.no_recompute_layers = list(map(int, model_args.no_recompute_layers.split(",")))
+        model_args.no_recompute_layers.sort()
+
+    config.lm_shift_labels = False
     config.use_flash_attention = model_args.use_flash_attention
     config.use_fused_rms_norm = model_args.use_fused_rms_norm
     config.fuse_attention_qkv = model_args.fuse_attention_qkv
@@ -448,6 +473,8 @@ def main():
     config.sequence_parallel = model_args.sequence_parallel
     config.fuse_sequence_parallel_allreduce = model_args.fuse_sequence_parallel_allreduce
     config.rope_fusion_level = model_args.rope_fusion_level
+    config.no_recompute_layers = model_args.no_recompute_layers
+    config.pp_recompute_interval = model_args.pp_recompute_interval
 
     config.use_recompute = training_args.recompute
     config.tensor_parallel_degree = training_args.tensor_parallel_degree
@@ -480,6 +507,9 @@ def main():
         register_sequence_parallel_allreduce_hooks(
             model, training_args.gradient_accumulation_steps, model_args.fuse_sequence_parallel_allreduce
         )
+
+    if training_args.recompute:
+        model.recompute_enable()
 
     # Create the learning_rate sheduler and optimizer
     if training_args.decay_steps is None:

--- a/llm/llama/run_trainer_tp4pp2.sh
+++ b/llm/llama/run_trainer_tp4pp2.sh
@@ -65,5 +65,5 @@ python -u  -m paddle.distributed.launch \
     --device "gpu"
     # --pipeline_parallel_config "disable_partial_send_recv"  # if set sequence_parallel True, please note off this line.
     # reompute settings:
-    # --no_recompute_layers 0,1,2,3,4,5,6...,int,int
+    # --no_recompute_layers 0 1 2 3 4 5 6 7 8 9 10 ... int int
     # --pp_recompute_interval 0 # A value of 0 indicates no recomputation.

--- a/llm/llama/run_trainer_tp4pp2.sh
+++ b/llm/llama/run_trainer_tp4pp2.sh
@@ -57,9 +57,13 @@ python -u  -m paddle.distributed.launch \
     --report_to "visualdl" \
     --sharding "stage1" \
     --disable_tqdm true \
-    --continue_training 1\
-    --recompute 1 \
+    --continue_training 1 \
+    --recompute 0 \
+    --recompute_granularity full \
     --do_train \
     --do_eval \
     --device "gpu"
     # --pipeline_parallel_config "disable_partial_send_recv"  # if set sequence_parallel True, please note off this line.
+    # reompute settings:
+    # --no_recompute_layers 0,1,2,3,4,5,6...,int,int
+    # --pp_recompute_interval 0 # A value of 0 indicates no recomputation.

--- a/paddlenlp/transformers/llama/configuration.py
+++ b/paddlenlp/transformers/llama/configuration.py
@@ -222,6 +222,8 @@ class LlamaConfig(PretrainedConfig):
         use_cache=True,
         use_recompute=False,
         recompute_granularity="full",
+        pp_recompute_interval=0,
+        no_recompute_layers=None,
         fuse_attention_qkv=False,
         use_flash_attention=False,
         fuse_attention_ffn=False,
@@ -255,6 +257,8 @@ class LlamaConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.use_recompute = use_recompute
         self.recompute_granularity = recompute_granularity
+        self.no_recompute_layers = no_recompute_layers
+        self.pp_recompute_interval = pp_recompute_interval
         self.fuse_attention_qkv = fuse_attention_qkv
         self.use_flash_attention = use_flash_attention
         self.fuse_attention_ffn = fuse_attention_ffn

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -704,9 +704,11 @@ class LlamaAttention(nn.Layer):
         if not output_attentions:
             attn_weights = None
 
-        outputs = [attn_output, attn_weights, past_key_value]
-        outputs = [output for output in outputs if output is not None]
-        return outputs[0] if len(outputs) == 1 else outputs
+        outputs = dict()
+        outputs["attn_output"] = attn_output
+        outputs["attn_weights"] = attn_weights
+        outputs["past_key_value"] = past_key_value
+        return outputs
 
 
 class LlamaDecoderLayer(nn.Layer):
@@ -776,14 +778,9 @@ class LlamaDecoderLayer(nn.Layer):
                 alibi,
             )
 
-        if use_cache and output_attentions:
-            hidden_states, self_attn_weights, present_key_value = outputs
-        elif use_cache:
-            hidden_states, present_key_value = outputs
-        elif output_attentions:
-            hidden_states, self_attn_weights = outputs
-        else:
-            hidden_states = outputs
+        hidden_states = outputs.get("attn_output")
+        self_attn_weights = outputs.get("attn_weights", None)
+        present_key_value = outputs.get("past_key_value", None)
 
         hidden_states = residual + hidden_states
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others 

### PR changes
Models

### Description
We are enhancing LLAMA by introducing support for more granular recomputation. Specifically, we've added three levels of granularity: 'full_attn', 'core_attn', 'full' and layer-wise control.

Following cases have been tested already
- [x] pp + core_attn, full_atn + no_computer_layers
- [x] pp + core_attn, full_atn
- [x] pp + full
- [x] tp + core_attn, full_atn, full
- [x] tp + core_attn, full_atn, full + no_computer_layers
