### PR TITLE
[fix bug] argsort does not support bfloat16

### DIFF
--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1927,10 +1927,8 @@ def TopPProcess(probs, top_p, min_tokens_to_keep):
     org_probs = probs
     if probs.dtype == paddle.bfloat16:
         probs = paddle.cast(probs, paddle.float32)
-        sorted_indices = paddle.argsort(probs, descending=True)
-    else:
-        sorted_indices = paddle.argsort(probs, descending=True)
 
+    sorted_indices = paddle.argsort(probs, descending=True)
     if isinstance(sorted_indices, tuple):
         sorted_probs, sorted_indices = sorted_indices
     else:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1924,11 +1924,11 @@ def TopKProcess(probs, top_k, min_tokens_to_keep):
 
 
 def TopPProcess(probs, top_p, min_tokens_to_keep):
-    org_probs = probs
-    if probs.dtype == paddle.bfloat16:
+    org_dtype = probs.dtype
+    if org_dtype == paddle.bfloat16:
         probs = paddle.cast(probs, paddle.float32)
-
     sorted_indices = paddle.argsort(probs, descending=True)
+
     if isinstance(sorted_indices, tuple):
         sorted_probs, sorted_indices = sorted_indices
     else:
@@ -1954,6 +1954,7 @@ def TopPProcess(probs, top_p, min_tokens_to_keep):
     )
     condition = paddle.cast(condition, "bool").reshape(probs.shape)
     probs = paddle.where(condition, paddle.full_like(probs, 0.0), probs)
-    if org_probs.dtype == paddle.bfloat16:
+
+    if org_dtype == paddle.bfloat16:
         probs = paddle.cast(probs, paddle.bfloat16)
     return probs

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1924,10 +1924,10 @@ def TopKProcess(probs, top_k, min_tokens_to_keep):
 
 
 def TopPProcess(probs, top_p, min_tokens_to_keep):
+    org_probs = probs
     if probs.dtype == paddle.bfloat16:
         probs = paddle.cast(probs, paddle.float32)
         sorted_indices = paddle.argsort(probs, descending=True)
-        sorted_indices = paddle.cast(sorted_indices, dtype="int64")
     else:
         sorted_indices = paddle.argsort(probs, descending=True)
 
@@ -1956,4 +1956,6 @@ def TopPProcess(probs, top_p, min_tokens_to_keep):
     )
     condition = paddle.cast(condition, "bool").reshape(probs.shape)
     probs = paddle.where(condition, paddle.full_like(probs, 0.0), probs)
+    if org_probs.dtype == paddle.bfloat16:
+        probs = paddle.cast(probs, paddle.bfloat16)
     return probs

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1923,7 +1923,6 @@ def TopKProcess(probs, top_k, min_tokens_to_keep):
     return probs
 
 
-
 def TopPProcess(probs, top_p, min_tokens_to_keep):
     org_dtype = probs.dtype
     if org_dtype == paddle.bfloat16:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1923,6 +1923,7 @@ def TopKProcess(probs, top_k, min_tokens_to_keep):
     return probs
 
 
+
 def TopPProcess(probs, top_p, min_tokens_to_keep):
     org_dtype = probs.dtype
     if org_dtype == paddle.bfloat16:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1924,7 +1924,13 @@ def TopKProcess(probs, top_k, min_tokens_to_keep):
 
 
 def TopPProcess(probs, top_p, min_tokens_to_keep):
-    sorted_indices = paddle.argsort(probs, descending=True)
+    if probs.dtype == paddle.bfloat16:
+        probs = paddle.cast(probs, paddle.float32)
+        sorted_indices = paddle.argsort(probs, descending=True)
+        sorted_indices = paddle.cast(sorted_indices, dtype="int64")
+    else:
+        sorted_indices = paddle.argsort(probs, descending=True)
+
     if isinstance(sorted_indices, tuple):
         sorted_probs, sorted_indices = sorted_indices
     else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
修复topp函数不能传入bf16数据