### PR TITLE
Add config for mp_asycn_allreduce.

### DIFF
--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -532,30 +532,6 @@ class TrainingArguments:
             )
         },
     )
-    mp_async_allreduce: bool = field(
-        default=False,
-        metadata={
-            "help": (
-                "Support all_reduce(dx) overlap with matmul(dw) in ColumnParallelLinear when it set True, which can accelerate model parallel performance."
-            )
-        },
-    )
-    mp_skip_c_identity: bool = field(
-        default=False,
-        metadata={
-            "help": (
-                "Support skip c_identity in ColumnParallelLinear and RowParallelLinear. Only works when mp_async_allreduce is True. It can accelerate model parallel further."
-            )
-        },
-    )
-    mp_fused_linear_param_grad_add: bool = field(
-        default=False,
-        metadata={
-            "help": (
-                "Support fused_linear_param_grad_add in ColumnParallelLinear (cuda >= 11.6). Only works when mp_async_allreduce is true.  It can accelerate model parallel further."
-            )
-        },
-    )
     pipeline_parallel_degree: int = field(
         default=-1,
         metadata={
@@ -565,6 +541,18 @@ class TrainingArguments:
                 "pipeline_parallel_degree means split all transformer layers to how many stages."
                 "default -1 for not use pipeline parallel."
                 "Note. this need model support in source code, see llama modeling_pp.py file"
+            )
+        },
+    )
+    tensor_parallel_config: str = field(
+        default="",
+        metadata={
+            "help": (
+                "Some additional configs which affect model parallel performance, we provide some option to config it."
+                "following config is support:\n"
+                "enable_mp_async_allreduce, it supports all_reduce(dx) overlap with matmul(dw) in ColumnParallelLinear backward when it set True, which can accelerate model parallel performance. \n"
+                "enable_mp_skip_c_identity, it supports skip c_identity in ColumnParallelLinear and RowParallelLinear. It only works when set mp_async_allreduce is True. It can accelerate model parallel further.\n"
+                "enable_mp_fused_linear_param_grad_add, it supports fused_linear_param_grad_add in ColumnParallelLinear (cuda >= 11.6). It only works when mp_async_allreduce is true.  It can accelerate model parallel further."
             )
         },
     )
@@ -891,6 +879,39 @@ class TrainingArguments:
 
                 if tensor_parallel_degree > 1:
                     strategy.tensor_parallel_configs = {"tensor_init_seed": self.seed}
+                    mp_config = set(self.tensor_parallel_config.split(" "))
+                    for x in mp_config:
+                        if len(x) > 0:
+                            if x not in [
+                                "enable_mp_async_allreduce",
+                                "enable_mp_skip_c_identity",
+                                "enable_mp_fused_linear_param_grad_add",
+                            ]:
+                                raise ValueError(
+                                    f"Found unknown tensor parallell config {x}, "
+                                    f"accept config is enable_mp_async_allreduce, enable_mp_skip_c_identity and enable_mp_fused_linear_param_grad_add"
+                                )
+                    try:
+                        if "enable_mp_async_allreduce" in mp_config:
+                            strategy.hybrid_configs["mp_configs"].mp_async_allreduce = True
+                            if "enable_mp_skip_c_identity" in mp_config:
+                                strategy.hybrid_configs["mp_configs"].mp_skip_c_identity = True
+                            if "enable_mp_fused_linear_param_grad_add" in mp_config:
+                                strategy.hybrid_configs["mp_configs"].mp_fused_linear_param_grad_add = True
+                        else:
+                            if "enable_mp_skip_c_identity" in mp_config:
+                                warnings.warn(
+                                    "enable_mp_skip_c_identity only works with enable_mp_async_allreduce. It will not work."
+                                )
+                            if "enable_mp_fused_linear_param_grad_add" in mp_config:
+                                warnings.warn(
+                                    "enable_mp_fused_linear_param_grad_add only works with enable_mp_async_allreduce. It will not work."
+                                )
+                    except:
+                        warnings.warn(
+                            "The enable_mp_async_allreduce, enable_mp_skip_c_identity and enable_mp_fused_linear_param_grad_add are not supported "
+                            "by current version of Paddle. Please try latest develop Paddle."
+                        )
 
                 if tensor_parallel_degree == 1 and sharding_parallel_degree == 1:
                     order = ["pp", "dp", "sharding", "mp"]
@@ -912,21 +933,6 @@ class TrainingArguments:
 
                 # setter once https://github.com/PaddlePaddle/Paddle/blob/b7295120b0e78b293cd7ae29706e21769d06a3cc/python/paddle/distributed/fleet/base/distributed_strategy.py#L1692
                 strategy.hybrid_configs = hybrid_configs
-
-                if tensor_parallel_degree > 1:
-                    strategy.hybrid_configs["mp_configs"].mp_async_allreduce = self.mp_async_allreduce
-                    strategy.hybrid_configs["mp_configs"].mp_skip_c_identity = (
-                        self.mp_async_allreduce and self.mp_skip_c_identity
-                    )
-                    strategy.hybrid_configs["mp_configs"].mp_fused_linear_param_grad_add = (
-                        self.mp_async_allreduce and self.mp_fused_linear_param_grad_add
-                    )
-                    if not self.mp_async_allreduce and self.mp_skip_c_identity:
-                        warnings.warn("mp_skip_c_identity only works with mp_async_allreduce. It will not work.")
-                    if not self.mp_async_allreduce and self.mp_fused_linear_param_grad_add:
-                        warnings.warn(
-                            "mp_fused_linear_param_grad_add only works with mp_async_allreduce. It will not work."
-                        )
 
                 if sharding_parallel_degree > 1:
                     sharding_parallel_config = set(self.sharding_parallel_config.split(" "))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
Add config for mp_asycn_allreduce.
`mp_async_allreduce`: Support all_reduce(dx) overlap with matmul(dw) in ColumnParallelLinear when it set True, which can accelerate model parallel performance.
`mp_skip_c_identity`: Support skip c_identity in ColumnParallelLinear and RowParallelLinear. Only works when mp_async_allreduce is True. It can accelerate model parallel further.
`mp_fused_linear_param_grad_add`: Support fused_linear_param_grad_add in ColumnParallelLinear (cuda >= 11.6). Only works when mp_async_allreduce is true.  It can accelerate model parallel further.
