### PR TITLE
[TIPC]update tipc configs

### DIFF
--- a/tests/test_tipc/configs/bert_for_question_answering/train_infer_python.txt
+++ b/tests/test_tipc/configs/bert_for_question_answering/train_infer_python.txt
@@ -13,7 +13,7 @@ null:null
 null:null
 ##
 trainer:norm_train
-norm_train:test_tipc/train.py --model bert_for_question_answering --optimizer sgd --max_seq_len 512 --generated_inputs --learning_rate 0.01
+norm_train:test_tipc/train.py --model bert_for_question_answering --optimizer sgd --max_seq_len 512 --generated_inputs --learning_rate 0.01 --max_steps 150
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/tests/test_tipc/configs/ernie3_for_sequence_classification/train_infer_python.txt
+++ b/tests/test_tipc/configs/ernie3_for_sequence_classification/train_infer_python.txt
@@ -13,7 +13,7 @@ null:null
 null:null
 ##
 trainer:norm_train
-norm_train:test_tipc/train.py --model ernie3_for_sequence_classification --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path ernie-3.0-base-zh --pad_to_max_seq_len --max_seq_len 512 --logging_steps 10 --seed 42 --task_name tnews
+norm_train:test_tipc/train.py --model ernie3_for_sequence_classification --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path ernie-3.0-base-zh --pad_to_max_seq_len --max_seq_len 512 --logging_steps 10 --seed 42 --task_name tnews --max_steps 150
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/tests/test_tipc/configs/ernie_tiny/train_infer_python.txt
+++ b/tests/test_tipc/configs/ernie_tiny/train_infer_python.txt
@@ -13,7 +13,7 @@ null:null
 null:null
 ##
 trainer:norm_train
-norm_train:test_tipc/train.py --amp_level O2 --model ernie_tiny --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path ernie-tiny --pad_to_max_seq_len --max_seq_len 128 --logging_steps 1 --task_name tnews
+norm_train:test_tipc/train.py --amp_level O2 --model ernie_tiny --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path ernie-tiny --pad_to_max_seq_len --max_seq_len 128 --logging_steps 1 --task_name tnews --max_steps 150
 null:null
 null:null
 null:null

--- a/tests/test_tipc/configs/seq2seq/train_infer_python.txt
+++ b/tests/test_tipc/configs/seq2seq/train_infer_python.txt
@@ -13,7 +13,7 @@ null:null
 null:null
 ##
 trainer:norm_train
-norm_train:test_tipc/train.py --model seq2seq --optimizer adam --max_seq_len 50 --learning_rate 0.001 --max_grad_norm 5.0
+norm_train:test_tipc/train.py --model seq2seq --optimizer adam --max_seq_len 50 --learning_rate 0.001 --max_grad_norm 5.0 --max_steps 150
 null:null
 null:null
 null:null

--- a/tests/test_tipc/configs/xlnet/train_infer_python.txt
+++ b/tests/test_tipc/configs/xlnet/train_infer_python.txt
@@ -13,7 +13,7 @@ null:null
 null:null
 ##
 trainer:norm_train
-norm_train:test_tipc/train.py --model xlnet --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path xlnet-base-cased --pad_to_max_seq_len --max_seq_len 128 --logging_steps 1 --task_name SST-2
+norm_train:test_tipc/train.py --model xlnet --optimizer adamw --lr_scheduler linear_decay_with_warmup --learning_rate 2e-5 --max_grad_norm 1.0 --model_name_or_path xlnet-base-cased --pad_to_max_seq_len --max_seq_len 128 --logging_steps 1 --task_name SST-2 --max_steps 150
 null:null
 null:null
 null:null


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
目前有几个tipc模型的配置文件中没有设置`max_steps`，导致需完整跑完训练流程，造成时间与机器资源浪费，与TIPC初衷违背。此PR参考https://github.com/PaddlePaddle/PaddleNLP/blob/271bcd001cf4035dcdec768d1fb2f34312be38fe/tests/test_tipc/configs/bert_base_text_cls/train_infer_python.txt#L16
为这几个模型配置`max_steps=150`