### PR TITLE
[XPU] fix merge checkpoint fail on XPU

### DIFF
--- a/paddlenlp/transformers/conversion_utils.py
+++ b/paddlenlp/transformers/conversion_utils.py
@@ -37,7 +37,7 @@ from numpy import allclose, ndarray, transpose
 from paddle import Tensor
 from paddle.nn import Layer
 
-from paddlenlp.utils.distributed import distributed_gather
+from paddlenlp.utils.distributed import distributed_gather, distributed_allgather
 from paddlenlp.utils.env import CONFIG_NAME, PADDLE_WEIGHTS_NAME, PYTORCH_WEIGHTS_NAME
 from paddlenlp.utils.import_utils import (
     is_package_available,
@@ -1008,7 +1008,10 @@ class ConversionMixin:
         for key in state_dict.keys():
             tensor = state_dict[key]
             if key in name_action_mappings:
-                ret = distributed_gather(tensor, group=mp_group, offload=True)
+                if paddle.is_compiled_with_xpu():
+                    ret = distributed_allgather(tensor, group=mp_group, offload=True)
+                else:
+                    ret = distributed_gather(tensor, group=mp_group, offload=True)
                 action = name_action_mappings.pop(key)
                 tensor = action(ret) if is_dst else None
             else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

Save Checkpoint 时候的参数合并出错，原因是GPU的dist_gather逻辑是gather到0，但是XPU的BKCL上有些限制导致会有问题，于是改成dist_allgather，虽然有点浪费但反正是训练结束只做一次，对性能影响不是特别大。
