### PR TITLE
[Bug Fixes] use device.synchornize to replace cuda.synchornize

### DIFF
--- a/paddlenlp/trainer/plugins/timer.py
+++ b/paddlenlp/trainer/plugins/timer.py
@@ -32,14 +32,14 @@ class _Timer:
     def start(self):
         """Start the timer."""
         assert not self.started_, "timer has already started"
-        paddle.device.cuda.synchronize()
+        paddle.device.synchronize()
         self.start_time = time.time()
         self.started_ = True
 
     def stop(self):
         """Stop the timers."""
         assert self.started_, "timer is not started."
-        paddle.device.cuda.synchronize()
+        paddle.device.synchronize()
         self.elapsed_ += time.time() - self.start_time
         self.started_ = False
 

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -929,7 +929,7 @@ class TrainingArguments:
                         )
                 start_time = time.time()
                 fleet.init(is_collective=True, strategy=strategy)
-                paddle.device.cuda.synchronize()
+                paddle.device.synchronize()
                 elapsed = time.time() - start_time
                 logger.info("NCCL-Connection costs {:.2f} ms.".format(elapsed))
 


### PR DESCRIPTION
…hornize

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
CustomDevice使用`cuda.synchornize`会报`RuntimeError: (Unavailable) Paddle is not compiled with CUDA. Cannot visit device synchronize.`错误。

Paddle主框架目前推荐采用`device.synchornize`统一多个设备后端的同步接口，建议将paddlenlp中的`cuda.synchornize`替换`device.synchornize`，支持更多设备的训练。