### PR TITLE
set llama pp_recompute_interval default value to 1

### DIFF
--- a/paddlenlp/transformers/llama/configuration.py
+++ b/paddlenlp/transformers/llama/configuration.py
@@ -151,7 +151,7 @@ class LlamaConfig(PretrainedConfig):
         use_cache=True,
         use_recompute=False,
         recompute_granularity="full",
-        pp_recompute_interval=0,
+        pp_recompute_interval=1,
         no_recompute_layers=None,
         fuse_attention_qkv=False,
         use_flash_attention=False,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others
### Description
set llama pp_recompute_interval default value to 1
