### PR TITLE
[Bug fixes] profiler export path not work

### DIFF
--- a/paddlenlp/utils/profiler.py
+++ b/paddlenlp/utils/profiler.py
@@ -107,7 +107,7 @@ def add_profiler_step(options_str=None):
         _timer_only = str(_profiler_options["timer_only"]) == str(True)
         _prof = profiler.Profiler(
             scheduler=(_profiler_options["batch_range"][0], _profiler_options["batch_range"][1]),
-            on_trace_ready=profiler.export_chrome_tracing("./profiler_log"),
+            on_trace_ready=profiler.export_chrome_tracing(_profiler_options["profile_path"]),
             timer_only=_timer_only,
         )
         _prof.start()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug Fix

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
修复`utils.profiler`工具设置导出路径不生效的问题