### PR TITLE
Add `.skip()` API to `IterDataset`, use `.skip()` API in LLM finetune

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,6 +25,4 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
-      path: .
   system_packages: true

--- a/llm/finetune_generation.py
+++ b/llm/finetune_generation.py
@@ -31,6 +31,7 @@ from paddlenlp.datasets import load_dataset
 from paddlenlp.metrics import BLEU, Rouge1, Rouge2, RougeL
 from paddlenlp.peft import LoRAConfig, LoRAModel, PrefixConfig, PrefixModelForCausalLM
 from paddlenlp.trainer import PdArgumentParser, TrainingArguments
+from paddlenlp.trainer.trainer_callback import TrainerState
 from paddlenlp.transformers import (
     AutoConfig,
     AutoModelForCausalLM,
@@ -145,6 +146,21 @@ def main():
             )
         else:
             train_ds, dev_ds = load_dataset(data_args.dataset_name_or_path, splits=["train", "dev"])
+    # TODO(ZHUI & sijunhe): Temporary implementation. Generalize this logic and move to Trainer later.
+    if training_args.resume_from_checkpoint is not None and data_args.lazy:
+        logger.warning(
+            f"Loading from '{training_args.resume_from_checkpoint}', manually skipping dataset and setting `ignore_data_skip` to True."
+        )
+        training_args.ignore_data_skip = True
+        state = TrainerState.load_from_json(os.path.join(training_args.resume_from_checkpoint, "trainer_state.json"))
+        consumed_samples = (
+            state.global_step
+            * training_args.per_device_train_batch_size
+            * training_args.gradient_accumulation_steps
+            * training_args.dataset_world_size
+        )
+        train_ds = train_ds.skip(consumed_samples)
+
     if training_args.pipeline_parallel_degree > 1:
         from data import convert_example_common
 

--- a/paddlenlp/datasets/dataset.py
+++ b/paddlenlp/datasets/dataset.py
@@ -18,6 +18,7 @@ import os
 import time
 import warnings
 from collections import namedtuple
+from itertools import islice
 
 import datasets
 from multiprocess import Pool, RLock
@@ -447,6 +448,12 @@ class IterDataset(IterableDataset):
                 ):
                     yield self._transform(example) if self._transform_pipline else example
                 num_samples += 1
+
+    def skip(self, n):
+        if inspect.isfunction(self.data):
+            raise NotImplementedError("Function-based IterDataset does not support `.skip()`")
+        self.data = islice(self.data, n, None)
+        return self
 
     def filter(self, fn):
         """

--- a/tests/dataset/test_iter_datasets.py
+++ b/tests/dataset/test_iter_datasets.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from paddlenlp.datasets import load_dataset
+from tests.testing_utils import get_tests_dir
+
+
+class TestIterDataset(unittest.TestCase):
+    def test_skip(self):
+        fixture_path = get_tests_dir(os.path.join("fixtures", "dummy"))
+        first_ds = load_dataset("json", data_files=os.path.join(fixture_path, "tnews", "train.json"), lazy=True)[0]
+        first_ds = first_ds.skip(5)
+        first_data = next(iter(first_ds))
+        second_ds = iter(
+            load_dataset("json", data_files=os.path.join(fixture_path, "tnews", "train.json"), lazy=True)[0]
+        )
+        for i in range(5):
+            next(second_ds)
+        second_data = next(second_ds)
+        self.assertEqual(first_data, second_data)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
