### PR TITLE
[Trainer] Fix load opt, since load opt to cpu tensor many leak mem.

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -72,7 +72,6 @@ from ..transformers.model_utils import (
     PretrainedModel,
     _add_variant,
     load_sharded_checkpoint,
-    paddlenlp_load,
     unwrap_model,
 )
 from ..transformers.tokenizer_utils import PretrainedTokenizer
@@ -2003,7 +2002,7 @@ class Trainer:
             optimizer_name = _add_variant(OPTIMIZER_NAME, self.args.optimizer_name_suffix)
             path = os.path.join(checkpoint, optimizer_name)
             if os.path.isfile(path):
-                opt_state_dict = paddlenlp_load(path, map_location="cpu")
+                opt_state_dict = paddle.load(path)
 
         if opt_state_dict is not None and os.path.isfile(os.path.join(checkpoint, SCHEDULER_NAME)):
             # Load in optimizer and scheduler states


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/optimizer/optimizer.py#L374-L375
猜测此处_master_weights依然在CPU，待排查。
```python
        if "master_weights" in state_dict:
            if hasattr(self, "_master_weights"):
                self._master_weights = state_dict["master_weights"]
            state_dict.pop("master_weights")
```
