### PR TITLE
use pylayer version of recompute for llama

### DIFF
--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -778,7 +778,6 @@ class LlamaAttention(nn.Layer):
                 output_attentions,
                 alibi,
                 self.sequence_parallel,
-                use_reentrant=False,
             )
         else:
             outputs = scaled_dot_product_attention(
@@ -877,7 +876,6 @@ class LlamaDecoderLayer(nn.Layer):
                 output_attentions,
                 use_cache,
                 alibi,
-                use_reentrant=False,
             )
         else:
             outputs = self.self_attn(
@@ -1150,7 +1148,6 @@ class LlamaModel(LlamaPretrainedModel):
             past_key_value,
             use_cache,
             alibi,
-            use_reentrant=False,
         )
 
         return hidden_states


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
Llama use pylayer version of recompute.

This pr: https://github.com/PaddlePaddle/Paddle/pull/56793 fix llama generation bug under pylayer version recompute.