### PR TITLE
Add LLM benchmark scripts

### DIFF
--- a/csrc/generation/stop_generation_multi_ends.cu
+++ b/csrc/generation/stop_generation_multi_ends.cu
@@ -22,16 +22,6 @@
 #include<sys/mman.h>
 #include<stdio.h>
 
-void set_flags_multi_ends(char *str_flags, bool *res, int length) {
-    for (int i = 0; i < length; i++) {
-        if (str_flags[i] == '0') {
-            res[i] = false;
-        } else {
-            res[i] = true;
-        }
-    }
-}
-
 __device__ bool is_in_end(const int64_t id, const int64_t *end_ids, int length) {
     bool flag = false;
     for (int i = 0; i < length; i++) {
@@ -42,85 +32,40 @@ __device__ bool is_in_end(const int64_t id, const int64_t *end_ids, int length) 
     return flag;
 }
 
-__global__ void set_value_by_flags(const bool *stop_flags, const int64_t *end_ids, int64_t *topk_ids, bool *stop_flags_out, const int bs, int end_length) {
+__global__ void set_value_by_flags(
+        bool *stop_flags, 
+        const int64_t *end_ids, 
+        const int64_t *topk_ids, 
+        const int bs, 
+        const int end_length) {
     int tid = threadIdx.x;
     if (tid < bs) {
-        topk_ids[tid] = stop_flags[tid] ? end_ids[0] : topk_ids[tid];
-        __syncthreads();
         if (is_in_end(topk_ids[tid], end_ids, end_length)) {
-            stop_flags_out[tid] = true;
+            stop_flags[tid] = true;
         }
     }
 }
 
-__global__ void set_value_by_flags_both(const bool *flags, const bool *stop_flags, const int64_t *end_ids, int64_t *topk_ids, bool *stop_flags_out, const int bs, int end_length) {
-    int tid = threadIdx.x;
-    if (tid < bs) {
-        topk_ids[tid] = flags[tid] || stop_flags[tid] ? end_ids[0] : topk_ids[tid];
-        __syncthreads();
-        if (is_in_end(topk_ids[tid], end_ids, end_length)) {
-            stop_flags_out[tid] = true;
-        }
-    }
-}
-
-std::vector<paddle::Tensor> GetStopFlagsMulti(const paddle::Tensor& topk_ids, const paddle::Tensor& stop_flags, const paddle::Tensor& end_ids, int64_t mode) {
-    // mode = 0, stop_generation and stop_flags
-    // mode = 1, just stop_generation
-    // mode = 2, just stop_flags
-    PD_CHECK(mode <= 2);
+void GetStopFlagsMulti(const paddle::Tensor& topk_ids, const paddle::Tensor& stop_flags, const paddle::Tensor& end_ids) {
     PD_CHECK(topk_ids.dtype() == paddle::DataType::INT64);
     PD_CHECK(stop_flags.dtype() == paddle::DataType::BOOL);
-
+    
     auto cu_stream = topk_ids.stream();
     std::vector<int64_t> shape = topk_ids.shape();
     int64_t bs_now = shape[0];
     int64_t end_length = end_ids.shape()[0];
-    auto topk_ids_out = topk_ids.copy_to(topk_ids.place(), false); // gpu -> gpu
-    auto stop_flags_out = stop_flags.copy_to(stop_flags.place(), false); // gpu -> gpu
-    if (mode == 0 || mode == 1) {
-        constexpr char *path = "/root/paddlejob/workspace/env_run/lzy/ERNIE_ALL/early_stop/ERNIE3.0-fused-fp16/ops/test";
-        auto flags = paddle::full({bs_now, 1}, 1, paddle::DataType::BOOL, paddle::CPUPlace());
-        int fd = -1;
-        int ret = -1;
-        void *addr = nullptr;
-        fd = open(path, O_RDWR);
-        if(-1 == fd){
-            perror("open error");
-        }
-        addr = mmap(NULL, bs_now, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if(addr == MAP_FAILED){
-            perror("mmap error");
-        }
-        close(fd);
-        set_flags_multi_ends((char *)addr, flags.data<bool>(), bs_now);
-        munmap(addr, bs_now);
-        auto flags_gpu = flags.copy_to(topk_ids.place(), false); // cpu -> gpu
-        int block_size = (bs_now + 32 - 1) / 32 * 32;
-        if (mode == 0) {
-            set_value_by_flags_both<<<1, block_size, 0, cu_stream>>>(flags_gpu.data<bool>(), stop_flags.data<bool>(), end_ids.data<int64_t>(), topk_ids_out.data<int64_t>(), stop_flags_out.data<bool>(), bs_now, end_length);
-        } else {
-            set_value_by_flags<<<1, block_size, 0, cu_stream>>>(flags_gpu.data<bool>(), end_ids.data<int64_t>(), topk_ids_out.data<int64_t>(), stop_flags_out.data<bool>(), bs_now, end_length);
-        }
-    } else if (mode == 2) {
-        int block_size = (bs_now + 32 - 1) / 32 * 32;
-        set_value_by_flags<<<1, block_size, 0, cu_stream>>>(stop_flags.data<bool>(), end_ids.data<int64_t>(), topk_ids_out.data<int64_t>(), stop_flags_out.data<bool>(), bs_now, end_length);
-    }
-    return {topk_ids_out, stop_flags_out};
-}
-
-std::vector<std::vector<int64_t>> GetStopFlagsMultiInferShape(const std::vector<int64_t>& topk_ids_shape, const std::vector<int64_t>& stop_flags_shape, const std::vector<int64_t>& end_ids_shape) {
-    return {topk_ids_shape, stop_flags_shape};
-}
-
-std::vector<paddle::DataType> GetStopFlagsMultiInferDtype(const paddle::DataType& topk_ids_dtype, const paddle::DataType& stop_flags_dtype, const paddle::DataType& end_ids_dtype) {
-    return {topk_ids_dtype, stop_flags_dtype};
+    int block_size = (bs_now + 32 - 1) / 32 * 32;
+    set_value_by_flags<<<1, block_size, 0, cu_stream>>>(
+        const_cast<bool*>(stop_flags.data<bool>()), 
+        end_ids.data<int64_t>(), 
+        topk_ids.data<int64_t>(), 
+        bs_now, end_length);
 }
 
 PD_BUILD_OP(set_stop_value_multi_ends)
     .Inputs({"topk_ids", "stop_flags", "end_ids"})
     .Outputs({"topk_ids_out", "stop_flags_out"})
     .Attrs({"mode: int64_t"})
-    .SetKernelFn(PD_KERNEL(GetStopFlagsMulti))
-    .SetInferShapeFn(PD_INFER_SHAPE(GetStopFlagsMultiInferShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(GetStopFlagsMultiInferDtype));
+    .SetInplaceMap({{"topk_ids", "topk_ids_out"},
+                    {"stop_flags", "stop_flags_out"}})
+    .SetKernelFn(PD_KERNEL(GetStopFlagsMulti));

--- a/llm/benchmark.sh
+++ b/llm/benchmark.sh
@@ -1,0 +1,18 @@
+export PYTHONPATH=$PYTHONPATH:/root/paddlejob/workspace/env_run/zhengzekang/DevelopPaddleNLP/PaddleNLP
+
+export FLAGS_control_flow_use_new_executor=1
+export FLAGS_new_executor_serial_run=1
+export FLAGS_allocator_strategy=naive_best_fit
+export FLAGS_fraction_of_gpu_memory_to_use=0.92
+
+
+python predictor.py \
+    --model_name_or_path ./llama-13b-inference_model_fp16 \
+    --dtype float16 \
+    --src_length 300 \
+    --max_length 400 \
+    --output_file "infer.json" \
+    --mode "static" \
+    --batch_size 1 \
+    --benchmark \
+    --inference_model

--- a/llm/benchmark.sh
+++ b/llm/benchmark.sh
@@ -1,10 +1,9 @@
-export PYTHONPATH=$PYTHONPATH:/root/paddlejob/workspace/env_run/zhengzekang/DevelopPaddleNLP/PaddleNLP
+export PYTHONPATH=$(dirname $(pwd)):$PYTHONPATH
 
 export FLAGS_control_flow_use_new_executor=1
 export FLAGS_new_executor_serial_run=1
 export FLAGS_allocator_strategy=naive_best_fit
 export FLAGS_fraction_of_gpu_memory_to_use=0.92
-
 
 python predictor.py \
     --model_name_or_path ./llama-13b-inference_model_fp16 \

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -652,24 +652,24 @@ def predict():
         source_texts = ["hello world, how are you?", "你好，请问你是谁?"]
         target_texts = ["", ""]
 
-    # batch_source_texts = batchfy_text(source_texts, predictor_args.batch_size)
-    # batch_target_texts = batchfy_text(target_texts, predictor_args.batch_size)
+    batch_source_texts = batchfy_text(source_texts, predictor_args.batch_size)
+    batch_target_texts = batchfy_text(target_texts, predictor_args.batch_size)
 
-    # with open(model_args.output_file, "w", encoding="utf-8") as f:
-    #     for bs, batch_source_text in enumerate(batch_source_texts):
-    #         outputs = predictor.predict(batch_source_text)
+    with open(model_args.output_file, "w", encoding="utf-8") as f:
+        for bs, batch_source_text in enumerate(batch_source_texts):
+            outputs = predictor.predict(batch_source_text)
 
-    #         if predictor.tensor_parallel_rank > 0:
-    #             continue
-    #         for output, source, target in zip(outputs, batch_source_texts[bs], batch_target_texts[bs]):
-    #             print("***********Source**********")
-    #             print(source)
-    #             print("***********Target**********")
-    #             print(target)
-    #             print("***********Output**********")
-    #             print(output)
-    #             out = {"src": source, "tgt": target, "output": output}
-    #             f.write(json.dumps(out, ensure_ascii=False) + "\n")
+            if predictor.tensor_parallel_rank > 0:
+                continue
+            for output, source, target in zip(outputs, batch_source_texts[bs], batch_target_texts[bs]):
+                print("***********Source**********")
+                print(source)
+                print("***********Target**********")
+                print(target)
+                print("***********Output**********")
+                print(output)
+                out = {"src": source, "tgt": target, "output": output}
+                f.write(json.dumps(out, ensure_ascii=False) + "\n")
 
     if predictor_args.benchmark:
         benchmark(predictor, predictor_args, model_args)

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from abc import abstractmethod
 from dataclasses import dataclass, field
 
@@ -43,7 +44,6 @@ from paddlenlp.transformers import (
 )
 from paddlenlp.utils.import_utils import import_module, is_paddlenlp_ops_available
 
-import time
 
 @dataclass
 class PredictorArgument:
@@ -74,7 +74,12 @@ class PredictorArgument:
     inference_model: bool = field(default=False, metadata={"help": "whether use InferenceModel to do generation"})
     batch_size: int = field(default=1, metadata={"help": "The batch size of data."})
     max_batch_size: int = field(default=None, metadata={"help": "The max batch size of data during serving."})
-    benchmark: bool = field(default=False, metadata={"help": "If benchmark set as `True`, we will force model decode to max_length, which is helpful to compute throughput. "})
+    benchmark: bool = field(
+        default=False,
+        metadata={
+            "help": "If benchmark set as `True`, we will force model decode to max_length, which is helpful to compute throughput. "
+        },
+    )
 
 
 @dataclass
@@ -647,49 +652,65 @@ def predict():
         source_texts = ["hello world, how are you?", "你好，请问你是谁?"]
         target_texts = ["", ""]
 
-    batch_source_texts = batchfy_text(source_texts, predictor_args.batch_size)
-    batch_target_texts = batchfy_text(target_texts, predictor_args.batch_size)
+    # batch_source_texts = batchfy_text(source_texts, predictor_args.batch_size)
+    # batch_target_texts = batchfy_text(target_texts, predictor_args.batch_size)
 
-    with open(model_args.output_file, "w", encoding="utf-8") as f:
-        for bs, batch_source_text in enumerate(batch_source_texts):
+    # with open(model_args.output_file, "w", encoding="utf-8") as f:
+    #     for bs, batch_source_text in enumerate(batch_source_texts):
+    #         outputs = predictor.predict(batch_source_text)
+
+    #         if predictor.tensor_parallel_rank > 0:
+    #             continue
+    #         for output, source, target in zip(outputs, batch_source_texts[bs], batch_target_texts[bs]):
+    #             print("***********Source**********")
+    #             print(source)
+    #             print("***********Target**********")
+    #             print(target)
+    #             print("***********Output**********")
+    #             print(output)
+    #             out = {"src": source, "tgt": target, "output": output}
+    #             f.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+    if predictor_args.benchmark:
+        benchmark(predictor, predictor_args, model_args)
+
+
+def benchmark(predictor, predictor_args, model_args):
+    # Just construct a simple benchmark input. We pad input to the src_length.
+    test_texts = "hello world, how are you?"
+    benchmark_texts = [test_texts + "<pad>" * predictor_args.src_length for _ in range(predictor_args.batch_size)]
+
+    benchmark_texts = [
+        "<pad>" * (predictor_args.src_length // 2 - 3) + "My name is " for _ in range(predictor_args.batch_size)
+    ]
+    batch_benchmark_texts = batchfy_text(benchmark_texts, predictor_args.batch_size)
+    print("***********Start Benchmark**********")
+
+    warmup_time = 1
+    test_time = 1
+
+    print("***********Start Warmup**********")
+    for _ in range(warmup_time):
+        for bs, batch_source_text in enumerate(batch_benchmark_texts):
             outputs = predictor.predict(batch_source_text)
 
-            if predictor.tensor_parallel_rank > 0:
-                continue
-            for output, source, target in zip(outputs, batch_source_texts[bs], batch_target_texts[bs]):
-                print("***********Source**********")
-                print(source)
-                print("***********Target**********")
-                print(target)
-                print("***********Output**********")
-                print(output)
-                out = {"src": source, "tgt": target, "output": output}
-                f.write(json.dumps(out, ensure_ascii=False) + "\n")
+    print("***********Start Speed Test**********")
+    start = time.perf_counter()
+    for _ in range(test_time):
+        for bs, batch_source_text in enumerate(batch_benchmark_texts):
+            outputs = predictor.predict(batch_source_text)
+    end = time.perf_counter()
 
-    if predictor_args.benchmark: 
-        # Just construct a simple benchmark input. We pad input to the src_length. 
-        benchmark_texts = ["<pad>" * (predictor_args.src_length // 2 - 3) + "My name is " for _ in range(predictor_args.batch_size)]
-        batch_benchmark_texts = batchfy_text(benchmark_texts, predictor_args.batch_size)
-        print("***********Start Benchmark**********")
-
-        warmup_time = 5 
-        test_time = 10
-
-        print("***********Start Warmup**********")
-        for _ in range(warmup_time): 
-            for bs, batch_source_text in enumerate(batch_benchmark_texts):
-                outputs = predictor.predict(batch_source_text)
-
-        print("***********Start Speed Test**********")
-        start = time.perf_counter()
-        for _ in range(test_time): 
-            for bs, batch_source_text in enumerate(batch_benchmark_texts):
-                outputs = predictor.predict(batch_source_text)
-        print("Input length is: {}, Output length is: {}, bs is: {}, Avg time is: {}s. ".format(predictor_args.src_length, 
-                                                                                                predictor_args.max_length - predictor_args.src_length, 
-                                                                                                predictor_args.batch_size, 
-                                                                                                (time.perf_counter() - start) / test_time))
-
+    output_tokens = sum([len(output) for output in outputs])
+    print(
+        "Input length is: {}, Output length is: {}, bs is: {}, Generate speed is: {:.3f} tokens/s(ips), QPS: {:.3f} requests/s. ".format(
+            predictor_args.src_length,
+            predictor_args.max_length - predictor_args.src_length,
+            predictor_args.batch_size,
+            (output_tokens / (end - start) / test_time),
+            (predictor_args.batch_size / (end - start) / test_time),
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -462,7 +462,7 @@ def dybatch_preprocess(tokenizer, texts: list[str], max_length: int, architectur
     inputs["min_length"] = (
         np.array(
             [
-                2 if not benchmark else max_length - seq_len, # Note(Zhengzekang): When in benchmark mode, we need to set a fixed decode length. 
+                1 if not benchmark else max_length - seq_len, # Note(Zhengzekang): When in benchmark mode, we need to set a fixed decode length. 
             ]
             * bs
         )

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -365,7 +365,7 @@ def pad_batch_data(insts, pad_id=0, return_seq_len=False, pad_style="right"):
         return inst_data.astype("int64").reshape([-1, max_len])
 
 
-def dybatch_preprocess(tokenizer, texts: list[str], max_length: int, architectures: str):
+def dybatch_preprocess(tokenizer, texts: list[str], max_length: int, architectures: str, benchmark=False):
     """Pre-process generation inputs."""
     if "chatglm" in architectures:
         input_ids = []
@@ -462,7 +462,7 @@ def dybatch_preprocess(tokenizer, texts: list[str], max_length: int, architectur
     inputs["min_length"] = (
         np.array(
             [
-                2,
+                2 if not benchmark else max_length - seq_len, # Note(Zhengzekang): When in benchmark mode, we need to set a fixed decode length. 
             ]
             * bs
         )

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -151,7 +151,7 @@ class GenerationInferenceModel(GenerationMixin):
                 model_kwargs["step_idx"],
                 model_kwargs["step_idx"] + 1,
             )
-        length_cond = paddle.greater_equal(model_kwargs["step_idx"], model_kwargs["max_dec_len"])
+        length_cond = paddle.greater_than(model_kwargs["step_idx"], model_kwargs["max_dec_len"])
         model_kwargs["stop_flags"] = paddle.logical_or(model_kwargs["stop_flags"], length_cond)
         if cache is None:
             next_tokens = paddle.where(just_decoder, paddle.full_like(next_tokens, -1), next_tokens)

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -81,7 +81,7 @@ class GenerationInferenceModel(GenerationMixin):
             )  # position_ids
             input_spec[16] = paddle.static.InputSpec(shape=[None, 2, 1], dtype="int64", name="tgt_pos")  # tgt_pos
         model = paddle.jit.to_static(self.generate, input_spec=input_spec)
-        paddle.jit.save(model, output_path)
+        paddle.jit.save(model, output_path, skip_prune_program=True) # Note(Zhengzekang): If we prune program it may cause some inference error. 
 
     @paddle.no_grad()
     def generate(

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -81,7 +81,9 @@ class GenerationInferenceModel(GenerationMixin):
             )  # position_ids
             input_spec[16] = paddle.static.InputSpec(shape=[None, 2, 1], dtype="int64", name="tgt_pos")  # tgt_pos
         model = paddle.jit.to_static(self.generate, input_spec=input_spec)
-        paddle.jit.save(model, output_path, skip_prune_program=True) # Note(Zhengzekang): If we prune program it may cause some inference error. 
+        paddle.jit.save(
+            model, output_path, skip_prune_program=True
+        )  # Note(Zhengzekang): If we prune program it may cause some inference error.
 
     @paddle.no_grad()
     def generate(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
New features

### PR changes
Others

### Description
Support Benchmark in LLM

when benchmark argument is set, we will let LLM input padding to src_length and decode to max_length, which is helpful to compute LLM Inference throughput. 

if you run in multi devices, use: 
```python
python3 -m paddle.distributed.launch --gpus "0,1,2,3,4,5,6,7" predictor.py \
    --model_name_or_path ./llama-13b-inference_model_fp16 \
    --dtype float16 \
    --src_length 300 \
    --max_length 400 \
    --output_file "infer.json" \
    --mode "static" \
    --batch_size 1 \
    --benchmark \
    --inference_model
```
