### PR TITLE
refactor llm/predictor.py

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -386,14 +386,14 @@ def dybatch_preprocess(
     tokenizer,
     texts: list[str],
     max_length: int,
-    architectures: str,
+    model_type: str,
     top_p: float,
     temperature: float,
     pre_caches_length: int = 0,
     benchmark: bool = False,
 ):
     """Pre-process generation inputs."""
-    if "chatglm" in architectures:
+    if "chatglm" in model_type:
         input_ids = []
         position_ids = []
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. 原来根据architectures[0].lower()分发的逻辑并不合理，有些模型的config的文件无architectures，改为使用config.model_type。
2. 将XXXpredictor类的config重命名为predictor_args，容易理解。