### PR TITLE
[llm benchmark] Add flash attention 2

### DIFF
--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -24,7 +24,7 @@ from utils import CustomTrainer, ProfilerCallback
 from paddlenlp.data import DataCollatorForSeq2Seq
 from paddlenlp.datasets import InTokensMapDataset
 from paddlenlp.peft import LoRAConfig, LoRAModel
-from paddlenlp.trainer import PdArgumentParser, TrainingArguments
+from paddlenlp.trainer import PdArgumentParser, TrainingArguments, set_seed
 from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer, GPTForCausalLM
 
 """
@@ -71,7 +71,7 @@ class ModelArguments:
 def main():
     parser = PdArgumentParser((ModelArguments, TrainingArguments))
     model_args, training_args = parser.parse_args_into_dataclasses()
-
+    set_seed(args=training_args)
     # Set the dtype for loading model
     dtype = None
     if training_args.fp16_opt_level == "O2":

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -109,7 +109,6 @@ def main():
             dtype=dtype,
             tensor_parallel_degree=training_args.tensor_parallel_degree,
             tensor_parallel_rank=training_args.tensor_parallel_rank,
-            is_causal=False,
         )
 
     if model_args.lora:

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -26,6 +27,9 @@ from paddlenlp.datasets import InTokensMapDataset
 from paddlenlp.peft import LoRAConfig, LoRAModel
 from paddlenlp.trainer import PdArgumentParser, TrainingArguments
 from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer, GPTForCausalLM
+
+os.environ["http_proxy"] = "http://172.19.57.45:3128"
+os.environ["https_proxy"] = "http://172.19.57.45:3128"
 
 """
 单卡

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -109,6 +109,7 @@ def main():
             dtype=dtype,
             tensor_parallel_degree=training_args.tensor_parallel_degree,
             tensor_parallel_rank=training_args.tensor_parallel_rank,
+            is_causal=False,
         )
 
     if model_args.lora:

--- a/examples/benchmark/peft/paddle/benchmark.py
+++ b/examples/benchmark/peft/paddle/benchmark.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -27,9 +26,6 @@ from paddlenlp.datasets import InTokensMapDataset
 from paddlenlp.peft import LoRAConfig, LoRAModel
 from paddlenlp.trainer import PdArgumentParser, TrainingArguments
 from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer, GPTForCausalLM
-
-os.environ["http_proxy"] = "http://172.19.57.45:3128"
-os.environ["https_proxy"] = "http://172.19.57.45:3128"
 
 """
 单卡

--- a/llm/finetune_generation.py
+++ b/llm/finetune_generation.py
@@ -129,8 +129,6 @@ def main():
         )
         if hasattr(model_config, "use_flash_attention"):
             model_config.use_flash_attention = model_args.use_flash_attention
-            # SFT only support addition attention mask
-            model_config.is_causal = False
         model = AutoModelForCausalLM.from_pretrained(
             model_args.model_name_or_path,
             config=model_config,

--- a/llm/finetune_generation.py
+++ b/llm/finetune_generation.py
@@ -129,6 +129,8 @@ def main():
         )
         if hasattr(model_config, "use_flash_attention"):
             model_config.use_flash_attention = model_args.use_flash_attention
+            # SFT only support addition attention mask
+            model_config.is_causal = False
         model = AutoModelForCausalLM.from_pretrained(
             model_args.model_name_or_path,
             config=model_config,

--- a/paddlenlp/transformers/bloom/configuration.py
+++ b/paddlenlp/transformers/bloom/configuration.py
@@ -124,6 +124,7 @@ class BloomConfig(PretrainedConfig):
         slow_but_exact=False,
         use_recompute=False,
         use_pure_fp16=False,
+        use_flash_attention=False,
         **kwargs,
     ):
 
@@ -148,3 +149,4 @@ class BloomConfig(PretrainedConfig):
         self.slow_but_exact = slow_but_exact
         self.use_recompute = use_recompute
         self.use_pure_fp16 = use_pure_fp16
+        self.use_flash_attention = use_flash_attention

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -389,7 +389,7 @@ class BloomAttention(nn.Layer):
                 query_states,
                 key_states,
                 value_states,
-                attn_mask=attention_mask if self.config.is_causal is False else None,,
+                attn_mask=attention_mask if self.config.is_causal is False else None,
                 is_causal=self.config.is_causal,
             )
             attn_weights = None

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -389,7 +389,7 @@ class BloomAttention(nn.Layer):
                 query_states,
                 key_states,
                 value_states,
-                attn_mask=attention_mask,
+                attn_mask=attention_mask if self.config.is_causal is False else None,,
                 is_causal=self.config.is_causal,
             )
             attn_weights = None

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -389,8 +389,8 @@ class BloomAttention(nn.Layer):
                 query_states,
                 key_states,
                 value_states,
-                attn_mask=attention_mask if self.config.is_causal is False else None,
-                is_causal=self.config.is_causal,
+                attn_mask=attention_mask,
+                is_causal=False,
             )
             attn_weights = None
             # [batch_size, seq_len, num_heads, head_dim] = > [batch_size, seq_len, hidden_size]

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -390,7 +390,7 @@ class BloomAttention(nn.Layer):
                 key_states,
                 value_states,
                 attn_mask=attention_mask,
-                is_causal=attention_mask is None,
+                is_causal=self.config.is_causal,
             )
             attn_weights = None
             # [batch_size, seq_len, num_heads, head_dim] = > [batch_size, seq_len, hidden_size]

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -379,75 +379,97 @@ class BloomAttention(nn.Layer):
 
         batch_size, q_length, _, _ = query_layer.shape
 
-        query_layer = query_layer.transpose([0, 2, 1, 3])
-        key_layer = key_layer.transpose([0, 2, 3, 1])
-        value_layer = value_layer.transpose([0, 2, 1, 3])
-        if layer_past is not None:
-            past_key, past_value = layer_past
-            # concatenate along seq_length dimension:
-            #  - key: [batch_size, self.num_heads, head_dim, kv_length]
-            #  - value: [batch_size, self.num_heads, kv_length, head_dim]
-            key_layer = paddle.concat((past_key, key_layer), axis=3)
-            value_layer = paddle.concat((past_value, value_layer), axis=2)
-
-        if use_cache is True:
-            present = (key_layer, value_layer)
-        else:
+        if self.config.use_flash_attention:
+            query_states, key_states, value_states = query_layer, key_layer, value_layer
+            attention_mask = attention_mask.cast(alibi.dtype) + alibi
+            attention_mask = attention_mask.reshape(
+                [query_states.shape[0], -1, attention_mask.shape[-2], attention_mask.shape[-1]]
+            )
+            attn_output = F.scaled_dot_product_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_mask=attention_mask,
+                is_causal=attention_mask is None,
+            )
+            attn_weights = None
+            # [batch_size, seq_len, num_heads, head_dim] = > [batch_size, seq_len, hidden_size]
+            attn_output = attn_output.reshape([attn_output.shape[0], attn_output.shape[1], -1])
+            output_tensor = self.dense(attn_output)
             present = None
-
-        _, _, _, kv_length = key_layer.shape
-
-        query_layer = query_layer.reshape([batch_size * self.num_heads, q_length, self.head_dim])
-        key_layer = key_layer.reshape([batch_size * self.num_heads, self.head_dim, kv_length])
-        value_layer = value_layer.reshape([batch_size * self.num_heads, kv_length, self.head_dim])
-
-        # [batch_size * num_heads, q_length, kv_length]
-        # alibi:[batch_size * num_heads, q_length, kv_length]
-        # we use `Tensor.baddbmm` instead of `paddle.baddbmm` as the latter isn't supported by TorchScript v1.11
-        attention_scores = baddbmm(
-            alibi, batch1=query_layer, batch2=key_layer, beta=self.beta, alpha=self.inv_norm_factor
-        )
-
-        # change view to [batch_size, num_heads, q_length, kv_length]
-        # attention_scores = matmul_result.reshape([batch_size, self.num_heads, q_length, kv_length])
-
-        # cast attention scores to fp32, compute scaled softmax and cast back to initial dtype - [batch_size, num_heads, q_length, kv_length]
-        input_dtype = query_layer.dtype
-        # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
-        if input_dtype != paddle.float32:
-            attention_scores = paddle.cast(attention_scores, paddle.float32)
-            attn_weights = attention_scores + attention_mask
-            attention_probs = paddle.cast(F.softmax(attn_weights, axis=-1, dtype=paddle.float32), dtype=input_dtype)
         else:
-            attn_weights = attention_scores + attention_mask
-            attention_probs = F.softmax(attn_weights, axis=-1)
 
-        # [batch_size, num_heads, q_length, kv_length]
-        attention_probs = self.attention_dropout(attention_probs)
+            query_layer = query_layer.transpose([0, 2, 1, 3])
+            key_layer = key_layer.transpose([0, 2, 3, 1])
+            value_layer = value_layer.transpose([0, 2, 1, 3])
+            if layer_past is not None:
+                past_key, past_value = layer_past
+                # concatenate along seq_length dimension:
+                #  - key: [batch_size, self.num_heads, head_dim, kv_length]
+                #  - value: [batch_size, self.num_heads, kv_length, head_dim]
+                key_layer = paddle.concat((past_key, key_layer), axis=3)
+                value_layer = paddle.concat((past_value, value_layer), axis=2)
 
-        if head_mask is not None:
-            attention_probs = attention_probs * head_mask
+            if use_cache is True:
+                present = (key_layer, value_layer)
+            else:
+                present = None
 
-        # change view [batch_size x num_heads, q_length, kv_length]
-        attention_probs_reshaped = attention_probs.reshape([batch_size * self.num_heads, q_length, kv_length])
+            _, _, _, kv_length = key_layer.shape
 
-        # matmul: [batch_size * num_heads, q_length, head_dim]
-        context_layer = paddle.matmul(attention_probs_reshaped, value_layer)
+            query_layer = query_layer.reshape([batch_size * self.num_heads, q_length, self.head_dim])
+            key_layer = key_layer.reshape([batch_size * self.num_heads, self.head_dim, kv_length])
+            value_layer = value_layer.reshape([batch_size * self.num_heads, kv_length, self.head_dim])
 
-        # change view [batch_size, num_heads, q_length, head_dim]
-        context_layer = self._merge_heads(context_layer)
+            # [batch_size * num_heads, q_length, kv_length]
+            # alibi:[batch_size * num_heads, q_length, kv_length]
+            # we use `Tensor.baddbmm` instead of `paddle.baddbmm` as the latter isn't supported by TorchScript v1.11
+            attention_scores = baddbmm(
+                alibi, batch1=query_layer, batch2=key_layer, beta=self.beta, alpha=self.inv_norm_factor
+            )
 
-        # aggregate results across tp ranks. See here: https://github.com/pypaddle/pypaddle/issues/76232
-        if self.pretraining_tp > 1 and self.slow_but_exact:
-            slices = self.hidden_size / self.pretraining_tp
-            output_tensor = paddle.zeros_like(context_layer)
-            for i in range(self.pretraining_tp):
-                output_tensor = output_tensor + F.linear(
-                    context_layer[:, :, int(i * slices) : int((i + 1) * slices)],
-                    self.dense.weight[:, int(i * slices) : int((i + 1) * slices)],
+            # change view to [batch_size, num_heads, q_length, kv_length]
+            # attention_scores = matmul_result.reshape([batch_size, self.num_heads, q_length, kv_length])
+
+            # cast attention scores to fp32, compute scaled softmax and cast back to initial dtype - [batch_size, num_heads, q_length, kv_length]
+            input_dtype = query_layer.dtype
+            # `float16` has a minimum value of -65504.0, whereas `bfloat16` and `float32` have a minimum value of `-3.4e+38`
+            if input_dtype != paddle.float32:
+                attention_scores = paddle.cast(attention_scores, paddle.float32)
+                attn_weights = attention_scores + attention_mask
+                attention_probs = paddle.cast(
+                    F.softmax(attn_weights, axis=-1, dtype=paddle.float32), dtype=input_dtype
                 )
-        else:
-            output_tensor = self.dense(context_layer)
+            else:
+                attn_weights = attention_scores + attention_mask
+                attention_probs = F.softmax(attn_weights, axis=-1)
+
+            # [batch_size, num_heads, q_length, kv_length]
+            attention_probs = self.attention_dropout(attention_probs)
+
+            if head_mask is not None:
+                attention_probs = attention_probs * head_mask
+
+            # change view [batch_size x num_heads, q_length, kv_length]
+            attention_probs_reshaped = attention_probs.reshape([batch_size * self.num_heads, q_length, kv_length])
+
+            # matmul: [batch_size * num_heads, q_length, head_dim]
+            context_layer = paddle.matmul(attention_probs_reshaped, value_layer)
+
+            # change view [batch_size, num_heads, q_length, head_dim]
+            context_layer = self._merge_heads(context_layer)
+
+            # aggregate results across tp ranks. See here: https://github.com/pypaddle/pypaddle/issues/76232
+            if self.pretraining_tp > 1 and self.slow_but_exact:
+                slices = self.hidden_size / self.pretraining_tp
+                output_tensor = paddle.zeros_like(context_layer)
+                for i in range(self.pretraining_tp):
+                    output_tensor = output_tensor + F.linear(
+                        context_layer[:, :, int(i * slices) : int((i + 1) * slices)],
+                        self.dense.weight[:, int(i * slices) : int((i + 1) * slices)],
+                    )
+            else:
+                output_tensor = self.dense(context_layer)
 
         output_tensor = dropout_add(output_tensor, residual, self.hidden_dropout, self.training)
 

--- a/paddlenlp/transformers/chatglm/configuration.py
+++ b/paddlenlp/transformers/chatglm/configuration.py
@@ -103,6 +103,7 @@ class ChatGLMConfig(PretrainedConfig):
         attention_scale=True,
         activation="gelu",
         num_image_tokens=0,
+        use_flash_attention=False,
         **kwargs
     ):
         super().__init__(pad_token_id=pad_token_id, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs)
@@ -127,3 +128,4 @@ class ChatGLMConfig(PretrainedConfig):
         self.attention_scale = attention_scale
         self.activation = activation
         self.num_image_tokens = num_image_tokens
+        self.use_flash_attention = use_flash_attention

--- a/paddlenlp/transformers/chatglm/modeling.py
+++ b/paddlenlp/transformers/chatglm/modeling.py
@@ -264,66 +264,94 @@ class ChatGLMAttention(nn.Layer):
         # [s, b, n, h/n]
         q_layer, k_layer = self._core_attention(q_layer, k_layer, position_ids, rotary_embeds)
 
-        if cache is not None:
-            cache_k, cache_v = cache[0], cache[1]
-            # [s + c, b, n, h/n]
-            k_layer = paddle.concat([cache_k, k_layer], axis=0)
-            v_layer = paddle.concat([cache_v, v_layer], axis=0)
+        if self.config.use_flash_attention:
+            # Flash Attention now ignore attention mask
+            # Current Flash Attention doesn't support attn maskt
+            # Paddle Flash Attention input [ bz, seqlen, nhead, head_dim]
+            # Torch Flash Attention input [ bz, nhead, seqlen, head_dim]
 
-        seq_length, batch_size, num_heads, hidden_size = k_layer.shape
+            # [s, b, n, h/n] = > [batch_size, seq_len, num_heads, head_dim]
+            q_layer = paddle.transpose(q_layer, [1, 0, 2, 3])
+            k_layer = paddle.transpose(k_layer, [1, 0, 2, 3])
+            v_layer = paddle.transpose(v_layer, [1, 0, 2, 3])
+            query_states, key_states, value_states = q_layer, k_layer, v_layer
 
-        cache_kv = None
-        if use_cache:
-            cache_kv = (k_layer, v_layer)
+            attn_output = F.scaled_dot_product_attention(
+                query_states,
+                key_states,
+                value_states,
+                attn_mask=attention_mask,
+                is_causal=attention_mask is None,
+            )
+            attn_weights = None
+            # [batch_size, seq_len, num_heads, head_dim] => [ batch_size, seq_len, hidden_size]
+            attn_output = paddle.reshape(attn_output, [attn_output.shape[0], attn_output.shape[1], -1])
+            # [ batch_size, seq_len, hidden_size] = > [ seq_len, batch_size, hidden_size]
+            attn_output = paddle.transpose(attn_output, [1, 0, 2])
+            attn_output = self.dense(attn_output)
 
-        attention_scale_coeff = float(layer_id) + 1.0
-        if self.attention_scale:
-            # [s, b, n, h/n]
-            q_layer = q_layer / (math.sqrt(self.attention_head_size) * attention_scale_coeff)
-            q_layer = q_layer.astype(self.default_dtype)
-
-        # [b, n, s, s]
-        output_shape = [q_layer.shape[1], q_layer.shape[2], q_layer.shape[0], k_layer.shape[0]]
-
-        # [s, b * n, h/n]
-        q_layer = q_layer.reshape([output_shape[2], output_shape[0] * output_shape[1], -1])
-        k_layer = k_layer.reshape([output_shape[3], output_shape[0] * output_shape[1], -1])
-
-        # [b * n , s, s] = matmul([b * n, s, h/n],  [b * n, h/n, s])
-        attention_scores = paddle.matmul(q_layer.transpose([1, 0, 2]), k_layer.transpose([1, 2, 0]))
-        # [b, n, s, s]
-        attention_scores = attention_scores.reshape(output_shape)
-
-        if self.scale_mask_softmax:
-            self.scale_mask_softmax.scale = attention_scale_coeff
-            attention_probs = self.scale_mask_softmax(attention_scores, attention_mask)
+            output, cache_kv, attention_probs = attn_output, None, attn_weights
         else:
-            attention_scores = attention_scores + attention_mask
-            attention_scores = attention_scores.astype("float32")
-            attention_scores = attention_scores * attention_scale_coeff
-            attention_probs = F.softmax(attention_scores, axis=-1)
-            attention_probs = attention_probs.astype(self.default_dtype)
-            v_layer = v_layer.astype(self.default_dtype)
+            if cache is not None:
+                cache_k, cache_v = cache[0], cache[1]
+                # [s + c, b, n, h/n]
+                k_layer = paddle.concat([cache_k, k_layer], axis=0)
+                v_layer = paddle.concat([cache_v, v_layer], axis=0)
 
-        # [b, n, s, h/n]
-        output_shape = [v_layer.shape[1], v_layer.shape[2], q_layer.shape[0], v_layer.shape[3]]
-        # [s, b * n, h/n]
-        v_layer = v_layer.reshape([v_layer.shape[0], output_shape[0] * output_shape[1], -1])
-        # [b * n, s, s]
-        attention_probs = attention_probs.reshape([output_shape[0] * output_shape[1], output_shape[2], -1])
+            seq_length, batch_size, num_heads, hidden_size = k_layer.shape
 
-        # [b * n, s, h/n]
-        context_layer = paddle.bmm(attention_probs, v_layer.transpose([1, 0, 2]))
-        context_layer = context_layer.reshape(output_shape)
+            cache_kv = None
+            if use_cache:
+                cache_kv = (k_layer, v_layer)
 
-        # [s, b, n, h/n]
-        context_layer = context_layer.transpose([2, 0, 1, 3])
+            attention_scale_coeff = float(layer_id) + 1.0
+            if self.attention_scale:
+                # [s, b, n, h/n]
+                q_layer = q_layer / (math.sqrt(self.attention_head_size) * attention_scale_coeff)
+                q_layer = q_layer.astype(self.default_dtype)
 
-        # [s, b, h]
-        new_context_shape = context_layer.shape[:-2] + [self.num_attention_heads * self.attention_head_size]
-        context_layer = context_layer.reshape(new_context_shape)
+            # [b, n, s, s]
+            output_shape = [q_layer.shape[1], q_layer.shape[2], q_layer.shape[0], k_layer.shape[0]]
 
-        output = self.dense(context_layer)
+            # [s, b * n, h/n]
+            q_layer = q_layer.reshape([output_shape[2], output_shape[0] * output_shape[1], -1])
+            k_layer = k_layer.reshape([output_shape[3], output_shape[0] * output_shape[1], -1])
+
+            # [b * n , s, s] = matmul([b * n, s, h/n],  [b * n, h/n, s])
+            attention_scores = paddle.matmul(q_layer.transpose([1, 0, 2]), k_layer.transpose([1, 2, 0]))
+            # [b, n, s, s]
+            attention_scores = attention_scores.reshape(output_shape)
+
+            if self.scale_mask_softmax:
+                self.scale_mask_softmax.scale = attention_scale_coeff
+                attention_probs = self.scale_mask_softmax(attention_scores, attention_mask)
+            else:
+                attention_scores = attention_scores + attention_mask
+                attention_scores = attention_scores.astype("float32")
+                attention_scores = attention_scores * attention_scale_coeff
+                attention_probs = F.softmax(attention_scores, axis=-1)
+                attention_probs = attention_probs.astype(self.default_dtype)
+                v_layer = v_layer.astype(self.default_dtype)
+
+            # [b, n, s, h/n]
+            output_shape = [v_layer.shape[1], v_layer.shape[2], q_layer.shape[0], v_layer.shape[3]]
+            # [s, b * n, h/n]
+            v_layer = v_layer.reshape([v_layer.shape[0], output_shape[0] * output_shape[1], -1])
+            # [b * n, s, s]
+            attention_probs = attention_probs.reshape([output_shape[0] * output_shape[1], output_shape[2], -1])
+
+            # [b * n, s, h/n]
+            context_layer = paddle.bmm(attention_probs, v_layer.transpose([1, 0, 2]))
+            context_layer = context_layer.reshape(output_shape)
+
+            # [s, b, n, h/n]
+            context_layer = context_layer.transpose([2, 0, 1, 3])
+
+            # [s, b, h]
+            new_context_shape = context_layer.shape[:-2] + [self.num_attention_heads * self.attention_head_size]
+            context_layer = context_layer.reshape(new_context_shape)
+
+            output = self.dense(context_layer)
 
         return output, cache_kv, attention_probs
 

--- a/paddlenlp/transformers/chatglm/modeling.py
+++ b/paddlenlp/transformers/chatglm/modeling.py
@@ -281,7 +281,7 @@ class ChatGLMAttention(nn.Layer):
                 key_states,
                 value_states,
                 attn_mask=attention_mask,
-                is_causal=attention_mask is None,
+                is_causal=False,
             )
             attn_weights = None
             # [batch_size, seq_len, num_heads, head_dim] => [ batch_size, seq_len, hidden_size]

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -503,6 +503,7 @@ class PretrainedConfig:
         self.output_hidden_states = kwargs.pop("output_hidden_states", False)
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.use_cache = kwargs.pop("use_cache", False)
+        self.use_flash_attention = kwargs.pop("use_flash_attention", False)
 
         self.pruned_heads = kwargs.pop("pruned_heads", {})
         self.tie_word_embeddings = kwargs.pop(

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -504,7 +504,6 @@ class PretrainedConfig:
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.use_cache = kwargs.pop("use_cache", False)
         self.use_flash_attention = kwargs.pop("use_flash_attention", False)
-        self.is_causal = kwargs.pop("is_causal", True)
         self.quantization_config = kwargs.pop("quantization_config", None)
 
         self.pruned_heads = kwargs.pop("pruned_heads", {})

--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -504,6 +504,7 @@ class PretrainedConfig:
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.use_cache = kwargs.pop("use_cache", False)
         self.use_flash_attention = kwargs.pop("use_flash_attention", False)
+        self.is_causal = kwargs.pop("is_causal", True)
         self.quantization_config = kwargs.pop("quantization_config", None)
 
         self.pruned_heads = kwargs.pop("pruned_heads", {})

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -1253,7 +1253,7 @@ class LlamaModel(LlamaPretrainedModel):
         )  # [bs, 1, seq_len, seq_len]
         if self.config.use_flash_attention:
             is_casual = is_casual_mask(attention_mask)
-            if is_casual:
+            if is_casual and alibi is None:
                 attention_mask = None
         hidden_states = inputs_embeds
 

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -193,7 +193,7 @@ def scaled_dot_product_attention(
         # Paddle Flash Attention input [ bz, seqlen, nhead, head_dim]
         # Torch Flash Attention input [ bz, nhead, seqlen, head_dim]
         if alibi is not None:
-            raise ValueError("Flash Attention does not support ALiBi yet")
+            attention_mask = attention_mask.cast(alibi.dtype) + alibi
 
         # TODO: attention_mask is None is not reliable
         attn_output = F.scaled_dot_product_attention(

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -195,21 +195,13 @@ def scaled_dot_product_attention(
         if alibi is not None:
             raise ValueError("Flash Attention does not support ALiBi yet")
 
-        # attn_output, attn_weights = flash_attention(
-        #     query_states,
-        #     key_states,
-        #     value_states,
-        #     causal=is_causal and query_states.shape[1] != 1,
-        #     return_softmax=output_attentions,
-        # )
-        # print(attention_mask.shape)
-        # print(attention_mask)
+        # TODO: attention_mask is None is not reliable
         attn_output = F.scaled_dot_product_attention(
             query_states,
             key_states,
             value_states,
             attn_mask=attention_mask,
-            is_causal=False,
+            is_causal=attention_mask is None,
         )
         attn_weights = None
         if sequence_parallel:

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -195,13 +195,23 @@ def scaled_dot_product_attention(
         if alibi is not None:
             raise ValueError("Flash Attention does not support ALiBi yet")
 
-        attn_output, attn_weights = flash_attention(
+        # attn_output, attn_weights = flash_attention(
+        #     query_states,
+        #     key_states,
+        #     value_states,
+        #     causal=is_causal and query_states.shape[1] != 1,
+        #     return_softmax=output_attentions,
+        # )
+        # print(attention_mask.shape)
+        # print(attention_mask)
+        attn_output = F.scaled_dot_product_attention(
             query_states,
             key_states,
             value_states,
-            causal=is_causal and query_states.shape[1] != 1,
-            return_softmax=output_attentions,
+            attn_mask=attention_mask,
+            is_causal=False,
         )
+        attn_weights = None
         if sequence_parallel:
             attn_output = attn_output.reshape([bsz * q_len, head_dim * num_heads])
         else:
@@ -1478,7 +1488,6 @@ class LlamaForCausalLM(LlamaPretrainedModel):
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         outputs = self.llama(
             input_ids,  # [bs, seq_len]
             position_ids=position_ids,

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -194,14 +194,13 @@ def scaled_dot_product_attention(
         # Torch Flash Attention input [ bz, nhead, seqlen, head_dim]
         if alibi is not None:
             attention_mask = attention_mask.cast(alibi.dtype) + alibi
-
         # TODO: attention_mask is None is not reliable
         attn_output = F.scaled_dot_product_attention(
             query_states,
             key_states,
             value_states,
             attn_mask=attention_mask,
-            is_causal=attention_mask is None,
+            is_causal=config.is_causal,
         )
         attn_weights = None
         if sequence_parallel:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

####  TODO

+ [x] Attention is None is not reliable
+ [x] need to wait for flash attention2 PR merge

```
export CUDA_VISIBLE_DEVICES=4
python benchmark.py --model_name_or_path bigscience/bloomz-7b1-mt  \
    --num_train_epochs 1 --per_device_train_batch_size 2 \
    --lora \
    --use_flash_attention \
    --intokens \
    --intokens_length 1024 \
    --train_data_size 1000 \
    --evaluation_strategy no --save_strategy no \
    --fp16 --fp16_opt_level O2 \
    --logging_steps 50 --output_dir outputs


export CUDA_VISIBLE_DEVICES=4
python benchmark.py --model_name_or_path bigscience/bloomz-7b1-mt  \
    --num_train_epochs 1 --per_device_train_batch_size 2 \
    --lora \
    --use_flash_attention \
    --intokens \
    --intokens_length 1024 \
    --train_data_size 1000 \
    --evaluation_strategy no --save_strategy no \
    --bp16 --fp16_opt_level O2 \
    --logging_steps 50 --output_dir outputs
```
