### PR TITLE
trainer支持Moe模型的训练以及存储

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -942,7 +942,8 @@ class Trainer:
                     elif args.recompute and availiable_no_sync:
                         fused_allreduce_gradients(list(model.parameters()), None)
 
-                    elif args.use_moe:
+                    elif args.use_moe and not args.use_hybrid_parallel:
+                        # dp grad reduce
                         fused_allreduce_gradients(
                             [p for p in model.parameters() if not getattr(p, "no_sync", False)], None
                         )
@@ -979,31 +980,31 @@ class Trainer:
                             # https://github.com/PaddlePaddle/Paddle/blob/ae2d8ba157540b39a4d7ab897c030217a33e82cb/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py#L359C14-L359C39
                             fused_allreduce_gradients(list(non_moe_parameters_list), self.optimizer._hcg)
 
-                        moe_parameters_list = [
-                            p
-                            for p in obtain_optimizer_parameters_list(self.optimizer._inner_opt)
-                            if getattr(p, "no_sync", False)
-                        ]
+                        # moe_parameters_list = [
+                        #     p
+                        #     for p in obtain_optimizer_parameters_list(self.optimizer._inner_opt)
+                        #     if getattr(p, "no_sync", False)
+                        # ]
 
-                        def grad_norm(p):
-                            return (
-                                p.main_grad.astype("float32").norm()
-                                if hasattr(p, "main_grad")
-                                else p.grad.astype("float32").norm()
-                            )
+                        # def grad_norm(p):
+                        #     return (
+                        #         p.main_grad.astype("float32").norm()
+                        #         if hasattr(p, "main_grad")
+                        #         else p.grad.astype("float32").norm()
+                        #     )
 
-                        moe_parameters_list = "\n".join(
-                            [
-                                f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
-                                for p in moe_parameters_list[:1]
-                            ]
-                        )
-                        non_moe_parameters_list = "\n".join(
-                            [
-                                f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
-                                for p in non_moe_parameters_list[10:11]
-                            ]
-                        )
+                        # moe_parameters_list = "\n".join(
+                        #     [
+                        #         f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
+                        #         for p in moe_parameters_list[:1]
+                        #     ]
+                        # )
+                        # non_moe_parameters_list = "\n".join(
+                        #     [
+                        #         f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
+                        #         for p in non_moe_parameters_list[10:11]
+                        #     ]
+                        # )
                         # logger.info(f"ppdp moe params: {moe_parameters_list}")
                         # logger.info(f"ppdp moe params: {non_moe_parameters_list}")
 
@@ -1030,6 +1031,8 @@ class Trainer:
                     )
                     optimizer_was_run = True
                     if self.do_grad_scaling:
+                        if self.args.use_hybrid_parallel:
+                            assert not self.args.use_moe, "pipline moe not work under fp16"
                         scale_before = self.scaler._scale.numpy()
                         self.scaler.step(self.optimizer)
                         self.scaler.update()

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -480,7 +480,7 @@ class Trainer:
             if self.args.bf16:
                 state_dict = self.recover_params_from_master_weights(state_dict)
         else:
-            if self.args.dataset_rank == 0:
+            if self.args.dataset_rank == 0 or self.args.use_moe:
                 state_dict = self.load_one_state_dict_from_checkpoint(
                     resume_from_checkpoint, self.args.old_weight_name_suffix
                 )
@@ -1961,7 +1961,7 @@ class Trainer:
         optimizer_name = _add_variant(OPTIMIZER_NAME, self.args.optimizer_name_suffix)
 
         if self.args.should_save:
-            if not self.args.use_hybrid_parallel:
+            if not self.args.use_hybrid_parallel and not self.args.use_moe:
                 self.save_func(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))
 
             # FIXME: manybe only save one copy

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -2065,7 +2065,7 @@ class Trainer:
                     with open(saved_signal_path, mode="w+") as f:
                         f.write("1")
 
-        if self.args.use_moe and self.dp_group.rank > 0:
+        if self.args.use_moe and self.args.data_parallel_rank > 0:
             self._save_moe_weights(output_dir)
 
         # Maybe delete some older checkpoints.

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1926,13 +1926,17 @@ class Trainer:
         model.micro_batch_size, model.accumulate_steps = config_backup
         if model.is_pipeline_last_stage():
             buf = [
-                {k: v.item() if isinstance(v, paddle.Tensor) else v for k, v in model._layers._loss_fn.info.items()}
+                {
+                    k: (v.item() if isinstance(v, paddle.Tensor) else v) / self.args.gradient_accumulation_steps
+                    for k, v in model._layers._loss_fn.info.items()
+                }
             ]
         else:
             buf = [None]
         hcg = fleet.get_hybrid_communicate_group()
         dist.broadcast_object_list(buf, src=hcg._pp_comm_group.ranks[-1], group=hcg.get_pipe_parallel_group())
         info = buf[0]
+        model._layers._loss_fn.info = {}
         if isinstance(info, dict) and "loss" in info:
             loss = paddle.to_tensor(info.pop("loss"))
         return loss.detach(), info
@@ -1956,10 +1960,14 @@ class Trainer:
 
     def _save_moe_weights(self, output_dir):
         # save moe optimizer and model state # TODO 默认为冗余存储
-        self.save_func(self.model.state_dict(),
-                       os.path.join(output_dir, _add_variant(PADDLE_WEIGHT_FILE_NAME, self.args.weight_name_suffix)))
-        self.save_func(self.optimizer.state_dict(),
-                       os.path.join(output_dir, _add_variant(OPTIMIZER_NAME, self.args.optimizer_name_suffix)))
+        self.save_func(
+            self.model.state_dict(),
+            os.path.join(output_dir, _add_variant(PADDLE_WEIGHT_FILE_NAME, self.args.weight_name_suffix)),
+        )
+        self.save_func(
+            self.optimizer.state_dict(),
+            os.path.join(output_dir, _add_variant(OPTIMIZER_NAME, self.args.optimizer_name_suffix)),
+        )
 
     def _save_checkpoint(self, model, metrics=None):
         # assert unwrap_model(model) is self.model, "internal model should be a reference to self.model"

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -971,7 +971,7 @@ class Trainer:
                     enable_delay_scale_loss = "enable_delay_scale_loss" in pipeline_parallel_config
                     enable_dp_comm_overlap = "enable_dp_comm_overlap" in pipeline_parallel_config
 
-                    assert not availiable_no_sync, availiable_no_sync
+                    assert not args.use_moe or not availiable_no_sync
                     if isinstance(self.optimizer, HybridParallelOptimizer) and not self.do_grad_scaling:
                         parameters_list = obtain_optimizer_parameters_list(self.optimizer._inner_opt)
 

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -911,9 +911,9 @@ class Trainer:
                 if is_no_sync:
                     # Avoid unnecessary DDP synchronization since there will be no backward pass on this example.
                     with model.no_sync():
-                        tr_loss_step = self.training_step(model, inputs)
+                        tr_loss_step, outputs = self.training_step(model, inputs)
                 else:
-                    tr_loss_step = self.training_step(model, inputs)
+                    tr_loss_step, outputs = self.training_step(model, inputs)
 
                 tr_loss += tr_loss_step
 
@@ -1045,6 +1045,7 @@ class Trainer:
                     self.control = self.callback_handler.on_step_end(args, self.state, self.control)
                     self._maybe_log_save_evaluate(tr_loss, model, epoch, ignore_keys_for_eval, inputs=inputs)
                     self._print_timer()
+
                     step = 0
                 else:
                     self.control = self.callback_handler.on_substep_end(args, self.state, self.control)
@@ -1789,7 +1790,12 @@ class Trainer:
             self._past = outputs[self.args.past_index]
 
         # We don't use .loss here since the model may return tuples instead of ModelOutput.
-        loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+        if isinstance(outputs, dict):
+            loss = outputs["loss"]
+        elif len(outputs) == 2:
+            loss, outputs = outputs
+        else:
+            loss = outputs[0]
 
         return (loss, outputs) if return_outputs else loss
 
@@ -1818,8 +1824,7 @@ class Trainer:
         inputs = self._prepare_inputs(inputs)
 
         with self.autocast_smart_context_manager():
-            loss = self.compute_loss(model, inputs)
-
+            loss, outputs = self.compute_loss(model, inputs, return_outputs=True)
         if self.args.gradient_accumulation_steps > 1:
             loss = loss / self.args.gradient_accumulation_steps
 
@@ -1828,7 +1833,10 @@ class Trainer:
         else:
             loss.backward()
 
-        return loss.detach()
+        if isinstance(outputs, dict) and "loss" in outputs:
+            loss = outputs.pop("loss") / self.args.gradient_accumulation_steps
+
+        return loss.detach(), outputs
 
     def training_pipeline_step(self, model: nn.Layer, inputs: Dict[str, Union[paddle.Tensor, Any]]) -> paddle.Tensor:
         """

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -972,12 +972,7 @@ class Trainer:
                     enable_dp_comm_overlap = "enable_dp_comm_overlap" in pipeline_parallel_config
 
                     assert not availiable_no_sync, availiable_no_sync
-                    # logger.info(
-                    #     f"optimizer type:{type(self.optimizer)} sharding={self.optimizer._sharding_enable} dp={self.optimizer._dp_enable}"
-                    # )
-                    if isinstance(self.optimizer, HybridParallelOptimizer):
-                        if self.do_grad_scaling:
-                            assert not enable_dp_comm_overlap, "`dp_comm_overlap` not work under fp16"
+                    if isinstance(self.optimizer, HybridParallelOptimizer) and not self.do_grad_scaling:
                         parameters_list = obtain_optimizer_parameters_list(self.optimizer._inner_opt)
 
                         non_moe_parameters_list = [p for p in parameters_list if not getattr(p, "no_sync", False)]

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -958,14 +958,6 @@ class Trainer:
                         fused_allreduce_gradients(
                             [p for p in model.parameters() if not getattr(p, "no_sync", False)], None
                         )
-                        # moe_parameters_list = [p for p in model.parameters() if getattr(p, 'no_sync', False)]
-                        # non_moe_parameters_list = [p for p in model.parameters() if not getattr(p, 'no_sync', False)]
-
-                        # moe_parameters_list = "\n".join([f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{p.grad.astype("float32").norm()}' for p in moe_parameters_list[:1]])
-                        # non_moe_parameters_list = "\n".join([f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{p.grad.astype("float32").norm()}' for p in non_moe_parameters_list[-11:-10]])
-
-                        # logger.info(f'dp moe params: {moe_parameters_list}')
-                        # logger.info(f'dp non-moe params: {non_moe_parameters_list}')
 
                     pipeline_parallel_config = set(args.pipeline_parallel_config.split(" "))
                     enable_delay_scale_loss = "enable_delay_scale_loss" in pipeline_parallel_config
@@ -988,36 +980,7 @@ class Trainer:
                         ):  # moe下面，DataParallel会被魔改, 不会走reducer，需要手动reduce-grad
                             assert not enable_dp_comm_overlap
                             # 广播状态精心跳过moe参数
-                            # https://github.com/PaddlePaddle/Paddle/blob/ae2d8ba157540b39a4d7ab897c030217a33e82cb/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py#L359C14-L359C39
                             fused_allreduce_gradients(list(non_moe_parameters_list), self.optimizer._hcg)
-
-                        # moe_parameters_list = [
-                        #     p
-                        #     for p in obtain_optimizer_parameters_list(self.optimizer._inner_opt)
-                        #     if getattr(p, "no_sync", False)
-                        # ]
-
-                        # def grad_norm(p):
-                        #     return (
-                        #         p.main_grad.astype("float32").norm()
-                        #         if hasattr(p, "main_grad")
-                        #         else p.grad.astype("float32").norm()
-                        #     )
-
-                        # moe_parameters_list = "\n".join(
-                        #     [
-                        #         f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
-                        #         for p in moe_parameters_list[:1]
-                        #     ]
-                        # )
-                        # non_moe_parameters_list = "\n".join(
-                        #     [
-                        #         f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
-                        #         for p in non_moe_parameters_list[10:11]
-                        #     ]
-                        # )
-                        # logger.info(f"ppdp moe params: {moe_parameters_list}")
-                        # logger.info(f"ppdp moe params: {non_moe_parameters_list}")
 
                     # Case 3: hack dp with master_grad
                     if hack_dp_master_grad and not (args.recompute and availiable_no_sync):

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -966,18 +966,17 @@ class Trainer:
                         non_moe_parameters_list = [p for p in parameters_list if not getattr(p, "no_sync", False)]
                         if self.optimizer._sharding_enable:
                             assert isinstance(self.optimizer._inner_opt, DygraphShardingOptimizer)
-                            # 广播状态精心跳过moe参数
-                            # https://github.com/PaddlePaddle/Paddle/blob/ae2d8ba157540b39a4d7ab897c030217a33e82cb/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py#L359C14-L359C39
-                            self.optimizer._inner_opt._rank2params = {
-                                r: [pp for pp in p if not getattr(p, "no_sync", False)]
-                                for r, p in self.optimizer._inner_opt._rank2params.items()
-                            }
-                            self.optimizer._inner_opt.reduce_gradients(
-                                list(non_moe_parameters_list), self.optimizer._hcg
-                            )
+                            assert not args.use_moe, "moe not support sharding"
+                            # self.optimizer._inner_opt._rank2params = {
+                            #     r: [pp for pp in p if not getattr(p, "no_sync", False)]
+                            #     for r, p in self.optimizer._inner_opt._rank2params.items()
+                            # }
+                            self.optimizer._inner_opt.reduce_gradients(list(parameters_list), self.optimizer._hcg)
 
                         if self.optimizer._dp_enable:
                             assert not enable_dp_comm_overlap
+                            # 广播状态精心跳过moe参数
+                            # https://github.com/PaddlePaddle/Paddle/blob/ae2d8ba157540b39a4d7ab897c030217a33e82cb/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py#L359C14-L359C39
                             fused_allreduce_gradients(list(non_moe_parameters_list), self.optimizer._hcg)
 
                         moe_parameters_list = [
@@ -985,13 +984,28 @@ class Trainer:
                             for p in obtain_optimizer_parameters_list(self.optimizer._inner_opt)
                             if getattr(p, "no_sync", False)
                         ]
+
+                        def grad_norm(p):
+                            return (
+                                p.main_grad.astype("float32").norm()
+                                if hasattr(p, "main_grad")
+                                else p.grad.astype("float32").norm()
+                            )
+
                         moe_parameters_list = "\n".join(
                             [
-                                f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{p.grad.astype("float32").norm()}'
-                                for p in moe_parameters_list
+                                f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
+                                for p in moe_parameters_list[:1]
                             ]
                         )
-                        logger.info(f"sharding moe params: {moe_parameters_list}")
+                        non_moe_parameters_list = "\n".join(
+                            [
+                                f'{p.name}-pnorm:{p.astype("float32").norm()}-gnorm:{grad_norm(p)}'
+                                for p in non_moe_parameters_list[10:11]
+                            ]
+                        )
+                        # logger.info(f"ppdp moe params: {moe_parameters_list}")
+                        # logger.info(f"ppdp moe params: {non_moe_parameters_list}")
 
                     # Case 3: hack dp with master_grad
                     if hack_dp_master_grad and not (args.recompute and availiable_no_sync):
@@ -1861,7 +1875,7 @@ class Trainer:
             self._pp_data_buffer = []
         self._pp_data_buffer.append(inputs)
         if len(self._pp_data_buffer) != self.args.gradient_accumulation_steps:
-            return paddle.zeros([])
+            return paddle.zeros([]), {}
 
         # for v in self._pp_data_buffer[0].values():
         #     assert isinstance(v, paddle.Tensor), f"Only support tensor as pipeline mode input, got type {type(v)}"
@@ -1895,8 +1909,18 @@ class Trainer:
             loss = model.forward_backward_pipeline(inputs, self.scaler if self.do_grad_scaling else None)
 
         model.micro_batch_size, model.accumulate_steps = config_backup
-
-        return loss.detach()
+        if model.is_pipeline_last_stage():
+            buf = [
+                {k: v.item() if isinstance(v, paddle.Tensor) else v for k, v in model._layers._loss_fn.info.items()}
+            ]
+        else:
+            buf = [None]
+        hcg = fleet.get_hybrid_communicate_group()
+        dist.broadcast_object_list(buf, src=hcg._pp_comm_group.ranks[-1], group=hcg.get_pipe_parallel_group())
+        info = buf[0]
+        if isinstance(info, dict) and "loss" in info:
+            loss = paddle.to_tensor(info.pop("loss"))
+        return loss.detach(), info
 
     def save_model(
         self,

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -2065,7 +2065,7 @@ class Trainer:
                     with open(saved_signal_path, mode="w+") as f:
                         f.write("1")
 
-        if self.args.use_moe:
+        if self.args.use_moe and self.dp_group.rank > 0:
             self._save_moe_weights(output_dir)
 
         # Maybe delete some older checkpoints.

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -978,9 +978,10 @@ class TrainingArguments:
                 name.append(f"tp{self.tensor_parallel_rank:0>2d}")
             if self.pipeline_parallel_degree > 1:
                 name.append(f"pp{self.pipeline_parallel_rank:0>2d}")
-            if self.sharding_parallel_degree > 1 or self.use_moe:
+            if self.sharding_parallel_degree > 1:
                 name.append(f"shard{self.sharding_parallel_rank:0>2d}")
-
+            if self.use_moe:
+                name.append(f"moe{self.data_parallel_rank:0>2d}")
             return "_".join(name)
         else:
             if self.use_moe:
@@ -995,8 +996,12 @@ class TrainingArguments:
                 name.append(f"tp{self.tensor_parallel_rank:0>2d}")
             if self.pipeline_parallel_degree > 1:
                 name.append(f"pp{self.pipeline_parallel_rank:0>2d}")
+            if self.use_moe:
+                name.append(f"moe{self.data_parallel_rank:0>2d}")
             return "_".join(name)
         else:
+            if self.use_moe:
+                return f"moe{self.data_parallel_rank:0>2d}"
             return None
 
     @property
@@ -1007,8 +1012,10 @@ class TrainingArguments:
                 name.append(f"tp{self.tensor_parallel_rank:0>2d}")
             if self.pipeline_parallel_degree > 1:
                 name.append(f"pp{self.pipeline_parallel_rank:0>2d}")
-            if self.save_sharding_stage1_model or self.use_moe:
+            if self.save_sharding_stage1_model:
                 name.append(f"shard{self.sharding_parallel_rank:0>2d}")
+            if self.use_moe:
+                name.append(f"moe{self.data_parallel_rank:0>2d}")
             return "_".join(name)
         else:
             if self.use_moe:
@@ -1054,7 +1061,7 @@ class TrainingArguments:
             work for data parallel, tensor parallel
             not work for sharding
         """
-        if self.save_on_each_node:
+        if self.save_on_each_node and not (self.use_moe):
             return self.local_process_index == 0
         else:
             return self.process_index == 0

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -815,8 +815,9 @@ class TrainingArguments:
 
                 if tensor_parallel_degree > 1:
                     strategy.tensor_parallel_configs = {"tensor_init_seed": self.seed}
-
-                if tensor_parallel_degree == 1 and sharding_parallel_degree == 1:
+                if self.use_moe:
+                    order = ["sharding", "pp", "dp", "mp"]
+                elif tensor_parallel_degree == 1 and sharding_parallel_degree == 1:
                     order = ["pp", "dp", "sharding", "mp"]
                 else:
                     order = ["dp", "sharding", "pp", "mp"]
@@ -1061,7 +1062,7 @@ class TrainingArguments:
             work for data parallel, tensor parallel
             not work for sharding
         """
-        if self.save_on_each_node and not (self.use_moe):
+        if self.save_on_each_node:
             return self.local_process_index == 0
         else:
             return self.process_index == 0
@@ -1077,8 +1078,6 @@ class TrainingArguments:
             work for data parallel, tensor parallel
             not work for sharding
         """
-        if self.use_moe:
-            return True
         if self.save_on_each_node:
             return self.local_process_index == 0
         else:

--- a/paddlenlp/transformers/generation_utils.py
+++ b/paddlenlp/transformers/generation_utils.py
@@ -1151,6 +1151,7 @@ class GenerationMixin(object):
             else:
                 next_tokens = paddle.multinomial(probs)
 
+            #  paddle.distributed.broadcast(next_tokens, src=0)
             next_scores = paddle.index_sample(origin_probs, next_tokens)
 
             if eos_token_id is not None:

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -39,7 +39,6 @@ from huggingface_hub import (
 from huggingface_hub.utils import EntryNotFoundError
 from paddle import Tensor
 from paddle.nn import Embedding, Layer
-from paddle.distributed import fleet
 
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.utils.download import is_url
@@ -80,6 +79,7 @@ __all__ = [
     "register_base_model",
 ]
 
+
 def unwrap_optimizer(optimizer, optimizer_instances=()):
     if optimizer is None:
         return None
@@ -89,9 +89,11 @@ def unwrap_optimizer(optimizer, optimizer_instances=()):
         return optimizer
     return None
 
+
 def filter_sharded_params(state_dict, optimizer, sharding_rank):
-    from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer \
-        import DygraphShardingOptimizer
+    from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
+        DygraphShardingOptimizer,
+    )
 
     logger.info(f"filter sharded_params not placed in sharding_rank {sharding_rank} .")
 
@@ -107,11 +109,20 @@ def filter_sharded_params(state_dict, optimizer, sharding_rank):
         filtered_state_dict[k] = v
     return filtered_state_dict
 
-def exlclude_paramters_in_state_dict(model_state_dict, param_names_in_master_weights, sharding_group, save_sharding_stage1_model=True):
+
+def exlclude_paramters_in_state_dict(
+    model_state_dict, param_names_in_master_weights, sharding_group, save_sharding_stage1_model=True
+):
     assert sharding_group is not None
-    assert isinstance(model_state_dict, dict) and isinstance(param_names_in_master_weights, (list, set)), "param_names_in_master_weights type:{}".format(type(param_names_in_master_weights))
-    state_param_names = [v.name for k,v in model_state_dict.items()]
-    logger.debug("param_names_in_master_weights:{}, state_param_names:{}".format(param_names_in_master_weights, state_param_names))
+    assert isinstance(model_state_dict, dict) and isinstance(
+        param_names_in_master_weights, (list, set)
+    ), "param_names_in_master_weights type:{}".format(type(param_names_in_master_weights))
+    state_param_names = [v.name for k, v in model_state_dict.items()]
+    logger.debug(
+        "param_names_in_master_weights:{}, state_param_names:{}".format(
+            param_names_in_master_weights, state_param_names
+        )
+    )
     if not save_sharding_stage1_model:
         # allgather parameter names in sharding group
         tmp = []
@@ -124,6 +135,7 @@ def exlclude_paramters_in_state_dict(model_state_dict, param_names_in_master_wei
             non_parameters_state_dict.pop(k)
 
     return non_parameters_state_dict
+
 
 def prune_linear_layer(layer: nn.Linear, index: paddle.Tensor, dim: int = 0) -> nn.Linear:
     """
@@ -1001,7 +1013,10 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
 
             # find the weight file with the above two branch: `bert-base-uncased.pdparams`, `model_state.pdparams`
             weight_file_path = _find_weight_file_path(
-                cache_dir=cache_dir, model_class=cls, resource_uri=pretrained_model_name_or_path, config=config,
+                cache_dir=cache_dir,
+                model_class=cls,
+                resource_uri=pretrained_model_name_or_path,
+                config=config,
             )
 
             return weight_file_path
@@ -1500,8 +1515,14 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 # WEIGHTS_NAME = _add_variant(WEIGHTS_NAME, variant)
 
         if is_bf16 and save_sharding_stage1_model:
-            state_dict_to_save = exlclude_paramters_in_state_dict(state_dict_to_save, param_names_in_master_weights, sharding_group)
-            logger.info("param_names_in_master_weights len:{}, bf16 state_dict_to_save len:{}, :{}".format(len(param_names_in_master_weights), len(state_dict_to_save), state_dict_to_save))
+            state_dict_to_save = exlclude_paramters_in_state_dict(
+                state_dict_to_save, param_names_in_master_weights, sharding_group
+            )
+            logger.info(
+                "param_names_in_master_weights len:{}, bf16 state_dict_to_save len:{}, :{}".format(
+                    len(param_names_in_master_weights), len(state_dict_to_save), state_dict_to_save
+                )
+            )
 
         if is_main_process:
             # Attach architecture to the config

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -399,6 +399,10 @@ def weight_name_suffix():
             name.append(f"tp{hcg.get_model_parallel_rank():0>2d}")
         if hcg.get_pipe_parallel_world_size() > 1:
             name.append(f"pp{hcg.get_stage_id():0>2d}")
+        if hcg.get_sharding_parallel_world_size() > 1:
+            name.append(f"shard{hcg.get_sharding_parallel_rank():0>2d}")
+        if True:
+            name.append(f"moe{hcg.get_sharding_parallel_rank():0>2d}")
         return "_".join(name)
     else:
         return None

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -406,4 +406,7 @@ def weight_name_suffix(config=None):
             name.append(f"moe{dp_group.rank:0>2d}")
         return "_".join(name)
     else:
+        if config and config.moe_num_experts > 0:
+            rank = paddle.distributed.get_rank()
+            return f"moe{rank:0>2d}"
         return None

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -391,7 +391,7 @@ def optimizer_name_suffix():
         return None
 
 
-def weight_name_suffix():
+def weight_name_suffix(config=None):
     hcg = use_hybrid_parallel()
     if hcg is not None:
         name = []
@@ -401,8 +401,9 @@ def weight_name_suffix():
             name.append(f"pp{hcg.get_stage_id():0>2d}")
         if hcg.get_sharding_parallel_world_size() > 1:
             name.append(f"shard{hcg.get_sharding_parallel_rank():0>2d}")
-        if True:
-            name.append(f"moe{hcg.get_sharding_parallel_rank():0>2d}")
+        if config and config.moe_num_experts > 0:
+            dp_group = hcg.get_data_parallel_group()
+            name.append(f"moe{dp_group.rank:0>2d}")
         return "_".join(name)
     else:
         return None

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -399,8 +399,6 @@ def weight_name_suffix(config=None):
             name.append(f"tp{hcg.get_model_parallel_rank():0>2d}")
         if hcg.get_pipe_parallel_world_size() > 1:
             name.append(f"pp{hcg.get_stage_id():0>2d}")
-        if hcg.get_sharding_parallel_world_size() > 1:
-            name.append(f"shard{hcg.get_sharding_parallel_rank():0>2d}")
         if config and getattr(config, "moe_num_experts", 0):
             dp_group = hcg.get_data_parallel_group()
             name.append(f"moe{dp_group.rank:0>2d}")

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -401,12 +401,12 @@ def weight_name_suffix(config=None):
             name.append(f"pp{hcg.get_stage_id():0>2d}")
         if hcg.get_sharding_parallel_world_size() > 1:
             name.append(f"shard{hcg.get_sharding_parallel_rank():0>2d}")
-        if config and config.moe_num_experts > 0:
+        if config and getattr(config, "moe_num_experts", 0):
             dp_group = hcg.get_data_parallel_group()
             name.append(f"moe{dp_group.rank:0>2d}")
         return "_".join(name)
     else:
-        if config and config.moe_num_experts > 0:
+        if config and getattr(config, "moe_num_experts", 0):
             rank = paddle.distributed.get_rank()
             return f"moe{rank:0>2d}"
         return None


### PR DESCRIPTION
# 计划给refactor分支，增加的moe的功能， 
支持： 纯dp + moe , pp/mp/dp/sharding + moe

目前moe的通信组和dp的通信组绑定（目前没有开辟通信组，dp多少路，expert就有多少路）。

主要涉及到：
1. trainer 主循环修改（梯度同步跳过带有no_sync属性的weight）
2. trainer save/load， model.from_pretrained 逻辑的修改（非dp0节点，需要保留moe参数，并支持1键加载模型）
3. moe 情况下的pp/mp/dp 调整了一下 通信组的顺序（让 moe/dp 组放在中间，pp最外面）

