### PR TITLE
[LLM] Unify pipeline model with PretrainModelPipe

### DIFF
--- a/llm/finetune_generation.py
+++ b/llm/finetune_generation.py
@@ -109,9 +109,9 @@ def main():
     if training_args.pipeline_parallel_degree > 1:
         if data_args.eval_with_do_generation and training_args.do_eval:
             raise ValueError("Plese set eval_with_do_generation to false in pipeline parallel mode.")
-        from llama.modeling_pp import LlamaForCausalLMPipe
+        from paddlenlp.transformers import AutoModelForCausalLMPipe
 
-        model = LlamaForCausalLMPipe.from_pretrained(
+        model = AutoModelForCausalLMPipe.from_pretrained(
             model_args.model_name_or_path,
             tensor_parallel_output=False,
             tensor_parallel_degree=training_args.tensor_parallel_degree,

--- a/llm/gpt-3/README.md
+++ b/llm/gpt-3/README.md
@@ -24,7 +24,7 @@ mv gpt_en_dataset_300m_idx.npz ./data
 
 注意：
 1. 需要paddle develop版本训练，需要安装`pip install tool_helpers visualdl==2.5.3`等相关缺失whl包
-2. `use_flash_attention` 需要在A100机器开启，否则loss可能不正常（很快变成0.00x,非常小不正常）。建议使用cuda11.8环境。
+2. `use_flash_attention` 需要在A100机器开启。建议使用cuda11.8环境。
 
 使用下面脚本,即可在gpt2-medium-en的基础上,继续训练.
 ```shell
@@ -35,7 +35,7 @@ log_dir="log"
 rm -rf $log_dir
 
 python -u  -m paddle.distributed.launch \
-    --gpus "0" \
+    --gpus "0,1,2,3,4,5,6,7" \
     --log_dir ${log_dir} \
     run_pretrain.py \
     --model_type "gpt" \
@@ -49,7 +49,7 @@ python -u  -m paddle.distributed.launch \
     --per_device_eval_batch_size 1 \
     --tensor_parallel_degree 1 \
     --pipeline_parallel_degree 1 \
-    --fuse_attention_qkv 1 \
+    --fuse_attention_qkv 0 \
     --use_flash_attention 0 \
     --fp16  \
     --fp16_opt_level "O2"  \
@@ -62,6 +62,7 @@ python -u  -m paddle.distributed.launch \
     --warmup_ratio 0.01 \
     --max_grad_norm 1.0 \
     --logging_steps 1\
+    --continue_training \
     --dataloader_num_workers 1 \
     --sharding "stage2" \
     --eval_steps 1000 \

--- a/llm/gpt-3/finetune_generation.py
+++ b/llm/gpt-3/finetune_generation.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, field
 from functools import partial
 
 import paddle
-from modeling_pp import GPTForCausalLMPipe
 from utils import (
     DataCollatorForSupervisedDataset,
     GPTTrainer,
@@ -34,7 +33,12 @@ from paddlenlp.trainer import (
     get_last_checkpoint,
     set_seed,
 )
-from paddlenlp.transformers import AutoTokenizer, GPTConfig, GPTForCausalLM
+from paddlenlp.transformers import (
+    AutoTokenizer,
+    GPTConfig,
+    GPTForCausalLM,
+    GPTForCausalLMPipe,
+)
 from paddlenlp.utils.log import logger
 
 MODEL_CLASSES = {

--- a/llm/gpt-3/run_pretrain.py
+++ b/llm/gpt-3/run_pretrain.py
@@ -424,9 +424,6 @@ def main():
         data_args, training_args, data_file, tokenizer
     )
 
-    # for i,x in enumerate(train_dataset):
-    #     print(i, x.keys())
-
     trainer = PretrainingTrainer(
         model=model,
         args=training_args,

--- a/llm/gpt-3/run_pretrain.py
+++ b/llm/gpt-3/run_pretrain.py
@@ -125,6 +125,16 @@ class ModelArguments:
     )
     output_attentions: bool = field(default=False, metadata={"help": "Whether output attention weights"})
     use_flash_attention: bool = field(default=False, metadata={"help": "Whether to use flash attention"})
+    virtual_pp_degree: int = field(
+        default=1,
+        metadata={"help": "virtual_pp_degree"},
+    )
+    continue_training: bool = field(
+        default=False,
+        metadata={
+            "help": "Pre-training from existing paddlenlp model weights. Default False and model will train from scratch. If set True, the model_name_or_path argument must exist in the paddlenlp models."
+        },
+    )
     fused_linear: bool = field(
         default=False,
         metadata={"help": "gpt, whether to fuse linear projection"},
@@ -343,7 +353,16 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name_or_path)
 
     config = config_class.from_pretrained(model_args.model_name_or_path)
+    # There are some technique extend RotaryEmbedding context. so don't change max_position_embeddings
+    if not model_args.continue_training:
+        config.max_position_embeddings = max(config.max_position_embeddings, data_args.max_seq_length)
+
+    if not model_args.continue_training:
+        config.vocab_size = max(config.vocab_size, ((tokenizer.vocab_size - 1) // 128 + 1) * 128)
+        logger.info(f"Reset vocab size to {config.vocab_size} for batter amp peformance.")
+
     config.output_attentions = model_args.output_attentions
+    config.virtual_pp_degree = model_args.virtual_pp_degree
     config.max_position_embeddings = max(config.max_position_embeddings, data_args.max_seq_length)
     config.hidden_dropout_prob = model_args.hidden_dropout_prob
     config.attention_probs_dropout_prob = model_args.attention_probs_dropout_prob
@@ -368,12 +387,14 @@ def main():
     if training_args.pipeline_parallel_degree > 1:
         model_class = GPTForCausalLMPipe
 
-    model = model_class.from_pretrained(
-        model_args.model_name_or_path,
-        config=config,
-        dtype=dtype,
-        load_state_as_np=True,
-    )
+    if model_args.continue_training:
+        model = model_class.from_pretrained(
+            model_args.model_name_or_path,
+            config=config,
+            dtype=dtype,
+        )
+    else:
+        model = model_class._from_config(config, dtype=dtype)
 
     # Create the learning_rate sheduler and optimizer
     if training_args.decay_steps is None:
@@ -403,6 +424,9 @@ def main():
         data_args, training_args, data_file, tokenizer
     )
 
+    # for i,x in enumerate(train_dataset):
+    #     print(i, x.keys())
+
     trainer = PretrainingTrainer(
         model=model,
         args=training_args,
@@ -418,7 +442,6 @@ def main():
         checkpoint = training_args.resume_from_checkpoint
     elif last_checkpoint is not None:
         checkpoint = last_checkpoint
-    checkpoint = None
 
     # Training
     if training_args.do_train:

--- a/llm/gpt-3/run_pretrain.py
+++ b/llm/gpt-3/run_pretrain.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import paddle
-from modeling_pp import GPTForCausalLMPipe
 
 from paddlenlp.trainer import (
     PdArgumentParser,
@@ -36,6 +35,7 @@ from paddlenlp.transformers import (
     CosineAnnealingWithWarmupDecay,
     GPTConfig,
     GPTForCausalLM,
+    GPTForCausalLMPipe,
     LinearAnnealingWithWarmupDecay,
 )
 from paddlenlp.utils.batch_sampler import DistributedBatchSampler

--- a/llm/llama/benchmark.py
+++ b/llm/llama/benchmark.py
@@ -25,7 +25,6 @@ from benchmark_utils import (
     compute_metrics,
     compute_metrics_not_do_generation,
 )
-from modeling_pp import LlamaForCausalLMPipe
 
 from paddlenlp.data import DataCollatorForSeq2Seq
 from paddlenlp.datasets import load_dataset
@@ -37,7 +36,11 @@ from paddlenlp.trainer import (
     get_last_checkpoint,
     set_seed,
 )
-from paddlenlp.transformers import AutoModelForCausalLM, AutoTokenizer
+from paddlenlp.transformers import (
+    AutoModelForCausalLM,
+    AutoModelForCausalLMPipe,
+    AutoTokenizer,
+)
 from paddlenlp.utils.log import logger
 
 
@@ -207,7 +210,7 @@ def main():
     if training_args.pipeline_parallel_degree > 1:
         if model_args.eval_with_do_generation and training_args.do_eval:
             raise ValueError("Plese set eval_with_do_generation to false in pipeline parallel mode.")
-        model_class = LlamaForCausalLMPipe
+        model_class = AutoModelForCausalLMPipe
 
     # Load the pretrained language model.
     model = model_class.from_pretrained(

--- a/llm/llama/run_pretrain.py
+++ b/llm/llama/run_pretrain.py
@@ -38,6 +38,7 @@ from paddlenlp.transformers import (
     LinearAnnealingWithWarmupDecay,
     LlamaConfig,
     LlamaForCausalLM,
+    LlamaForCausalLMPipe,
     register_sequence_parallel_allreduce_hooks,
 )
 from paddlenlp.utils.batch_sampler import DistributedBatchSampler
@@ -50,8 +51,6 @@ MODEL_CLASSES = {
     ),
 }
 
-from fused_layers import mock_layers
-from modeling_pp import LlamaForCausalLMPipe
 
 from paddlenlp.data.causal_dataset import build_train_valid_test_datasets, print_rank_0
 
@@ -371,6 +370,8 @@ def main():
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
     if training_args.enable_linear_fused_grad_add:
+        from fused_layers import mock_layers
+
         mock_layers()
 
     if model_args.tokenizer_name_or_path is None:

--- a/llm/llama/run_pretrain.py
+++ b/llm/llama/run_pretrain.py
@@ -466,7 +466,6 @@ def main():
             model_args.model_name_or_path,
             config=config,
             dtype=dtype,
-            load_state_as_np=True,
         )
     else:
         model = model_class._from_config(config, dtype=dtype)

--- a/llm/llama/tests/test_pipeline_parallel.py
+++ b/llm/llama/tests/test_pipeline_parallel.py
@@ -17,10 +17,9 @@ import unittest
 import numpy as np
 import paddle
 import paddle.distributed.fleet as fleet
-from modeling_pp import LlamaForCausalLMPipe
 from paddle.distributed.fleet.meta_parallel.pipeline_parallel import PipelineParallel
 
-from paddlenlp.transformers import LlamaForCausalLM
+from paddlenlp.transformers import LlamaForCausalLM, LlamaForCausalLMPipe
 
 
 class TestLlama(unittest.TestCase):

--- a/llm/llama/tests/test_sequence_parallel.py
+++ b/llm/llama/tests/test_sequence_parallel.py
@@ -17,10 +17,9 @@ import unittest
 import numpy as np
 import paddle
 import paddle.distributed.fleet as fleet
-from modeling_pp import LlamaForCausalLMPipe
 from paddle.distributed.fleet.meta_parallel.pipeline_parallel import PipelineParallel
 
-from paddlenlp.transformers import LlamaConfig, LlamaForCausalLM
+from paddlenlp.transformers import LlamaConfig, LlamaForCausalLM, LlamaForCausalLMPipe
 
 
 class TestLlama(unittest.TestCase):

--- a/paddlenlp/transformers/__init__.py
+++ b/paddlenlp/transformers/__init__.py
@@ -47,9 +47,7 @@ from .bert.tokenizer import *
 from .bert.configuration import *
 
 # isort: split
-from .gpt.modeling import *
-from .gpt.tokenizer import *
-from .gpt.configuration import *
+from .gpt import *
 from .roberta.modeling import *
 from .roberta.tokenizer import *
 from .roberta.configuration import *

--- a/paddlenlp/transformers/__init__.py
+++ b/paddlenlp/transformers/__init__.py
@@ -120,9 +120,7 @@ from .fnet.configuration import *
 from .funnel.modeling import *
 from .funnel.tokenizer import *
 from .funnel.configuration import *
-from .llama.configuration import *
-from .llama.modeling import *
-from .llama.tokenizer import *
+from .llama import *
 from .layoutlm.configuration import *
 from .layoutlm.modeling import *
 from .layoutlm.tokenizer import *

--- a/paddlenlp/transformers/auto/modeling.py
+++ b/paddlenlp/transformers/auto/modeling.py
@@ -43,6 +43,7 @@ __all__ = [
     "AutoModelForMultipleChoice",
     "AutoModelForMaskedLM",
     "AutoModelForCausalLM",
+    "AutoModelForCausalLMPipe",
     "AutoEncoder",
     "AutoDecoder",
     "AutoGenerator",
@@ -140,6 +141,7 @@ MAPPING_TASKS = OrderedDict(
         ("ForMultipleChoice", "AutoModelForMultipleChoice"),
         ("ForMaskedLM", "AutoModelForMaskedLM"),
         ("ForCausalLM", "AutoModelForCausalLM"),
+        ("ForCausalLMPipe", "AutoModelForCausalLMPipe"),
         ("Encoder", "AutoEncoder"),
         ("Decoder", "AutoDecoder"),
         ("Generator", "AutoGenerator"),
@@ -243,17 +245,22 @@ class _BaseAutoModelClass:
             model_class = getattr(import_class, init_class)
             return model_class
         except AttributeError as err:
-            logger.error(err)
-            all_model_classes = import_class.__all__
-            all_tasks = {get_task_name(m) for m in all_model_classes if get_task_name(m) is not None}
-            raise AttributeError(
-                f"module '{import_class.__name__}' only supports the following classes: "
-                + ", ".join(m for m in all_model_classes)
-                + "\n"
-                "Hint: you can use interface "
-                + " or ".join(task + ".from_pretrained" for task in all_tasks)
-                + f" to load '{pretrained_model_name_or_path}'\n"
-            )
+            try:
+                new_import_class = importlib.import_module(f"paddlenlp.transformers.{class_name}")
+                model_class = getattr(new_import_class, init_class)
+                return model_class
+            except AttributeError:
+                logger.error(err)
+                all_model_classes = import_class.__all__
+                all_tasks = {get_task_name(m) for m in all_model_classes if get_task_name(m) is not None}
+                raise AttributeError(
+                    f"module '{import_class.__name__}' only supports the following classes: "
+                    + ", ".join(m for m in all_model_classes)
+                    + "\n"
+                    "Hint: you can use interface "
+                    + " or ".join(task + ".from_pretrained" for task in all_tasks)
+                    + f" to load '{pretrained_model_name_or_path}'\n"
+                )
 
     @classmethod
     def _from_pretrained(
@@ -816,6 +823,20 @@ class AutoModelForCausalLM(_BaseAutoModelClass):
                 print(type(model))
                 # <class 'paddlenlp.transformers.gpt.modeling.GPTLMHeadModel'>
         """
+        return cls._from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
+
+
+class AutoModelForCausalLMPipe(_BaseAutoModelClass):
+    """
+    Pipeline model for AutoModelForCausalLM.
+    """
+
+    CONFIGURATION_MODEL_MAPPING = get_init_configurations()
+    _pretrained_model_dict = CONFIGURATION_MODEL_MAPPING
+    _name_mapping = get_name_mapping("ForCausalLMPipe")
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         return cls._from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
 
 

--- a/paddlenlp/transformers/auto/modeling.py
+++ b/paddlenlp/transformers/auto/modeling.py
@@ -320,17 +320,23 @@ class _BaseAutoModelClass:
                         try:
                             model_class = getattr(import_class, init_class)
                         except AttributeError as err:
-                            logger.error(err)
-                            all_model_classes = import_class.__all__
-                            all_tasks = {get_task_name(m) for m in all_model_classes if get_task_name(m) is not None}
-                            raise AttributeError(
-                                f"module '{import_class.__name__}' only supports the following classes: "
-                                + ", ".join(m for m in all_model_classes)
-                                + "\n"
-                                "Hint: you can use interface "
-                                + " or ".join(task + ".from_pretrained" for task in all_tasks)
-                                + f" to load '{pretrained_model_name_or_path}'\n"
-                            )
+                            try:
+                                import_class2 = importlib.import_module(f"paddlenlp.transformers.{class_name}")
+                                model_class = getattr(import_class2, init_class)
+                            except AttributeError:
+                                logger.error(err)
+                                all_model_classes = import_class.__all__
+                                all_tasks = {
+                                    get_task_name(m) for m in all_model_classes if get_task_name(m) is not None
+                                }
+                                raise AttributeError(
+                                    f"module '{import_class.__name__}' only supports the following classes: "
+                                    + ", ".join(m for m in all_model_classes)
+                                    + "\n"
+                                    "Hint: you can use interface "
+                                    + " or ".join(task + ".from_pretrained" for task in all_tasks)
+                                    + f" to load '{pretrained_model_name_or_path}'\n"
+                                )
                         logger.info(f"We are using {model_class} to load '{pretrained_model_name_or_path}'.")
                         return model_class.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
         # From local dir path

--- a/paddlenlp/transformers/gpt/__init__.py
+++ b/paddlenlp/transformers/gpt/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .configuration import *
+from .modeling import *
+from .modeling_pp import *
+from .tokenizer import *

--- a/paddlenlp/transformers/gpt/configuration.py
+++ b/paddlenlp/transformers/gpt/configuration.py
@@ -325,11 +325,12 @@ class GPTConfig(PretrainedConfig):
         output_attentions: bool = False,
         ignore_index: int = 0,
         use_flash_attention: bool = False,
+        use_fused_dropout_add: bool = False,
         fused_linear: bool = False,
         fuse_attention_qkv=False,
         enable_fuse_transformer: bool = False,
-        use_fused_dropout_add: bool = False,
         fused_softmax_with_triangular: bool = False,
+        virtual_pp_degree: int = 1,
         **kwargs
     ):
         super().__init__(pad_token_id=pad_token_id, **kwargs)
@@ -366,3 +367,4 @@ class GPTConfig(PretrainedConfig):
         self.enable_fuse_transformer = enable_fuse_transformer
         self.use_fused_dropout_add = use_fused_dropout_add
         self.fused_softmax_with_triangular = fused_softmax_with_triangular
+        self.virtual_pp_degree = virtual_pp_degree

--- a/paddlenlp/transformers/llama/__init__.py
+++ b/paddlenlp/transformers/llama/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .configuration import *
+from .modeling import *
+from .modeling_pp import *
+from .tokenizer import *

--- a/paddlenlp/transformers/llama/configuration.py
+++ b/paddlenlp/transformers/llama/configuration.py
@@ -153,18 +153,19 @@ class LlamaConfig(PretrainedConfig):
         pp_recompute_interval=1,
         no_recompute_layers=None,
         fuse_attention_qkv=False,
-        use_flash_attention=False,
         fuse_attention_ffn=False,
+        use_flash_attention=False,
         use_fused_rms_norm=False,
+        use_fused_rope=False,
         tensor_parallel_output=True,
         sequence_parallel=False,
         fuse_sequence_parallel_allreduce=False,
+        virtual_pp_degree=1,
         pad_token_id=0,
         bos_token_id=1,
         eos_token_id=2,
         tie_word_embeddings=False,
         alibi=False,
-        use_fused_rope=False,
         rope_scaling_factor=1.0,
         rope_scaling_type=None,
         **kwargs,
@@ -196,6 +197,7 @@ class LlamaConfig(PretrainedConfig):
         self.tensor_parallel_output = tensor_parallel_output
         self.sequence_parallel = sequence_parallel
         self.fuse_sequence_parallel_allreduce = fuse_sequence_parallel_allreduce
+        self.virtual_pp_degree = virtual_pp_degree
 
         self.pad_token_id = pad_token_id
         self.bos_token_id = bos_token_id

--- a/paddlenlp/transformers/llama/modeling_pp.py
+++ b/paddlenlp/transformers/llama/modeling_pp.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pass
 import paddle
 import paddle.distributed.fleet as fleet
 import paddle.nn as nn
 from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
 
-from paddlenlp.transformers import PretrainedModel
-from paddlenlp.transformers.llama.modeling import (
+from paddlenlp.transformers.model_utils import PipelinePretrainedModel
+
+from .modeling import (
     LlamaConfig,
     LlamaDecoderLayer,
     LlamaLMHead,
@@ -30,8 +30,15 @@ from paddlenlp.transformers.llama.modeling import (
 )
 
 
-def get_hcg():
-    return fleet.get_hybrid_communicate_group()
+def __repr__(self):
+    return self.layer_func.__name__
+
+
+LayerDesc.__repr__ = __repr__
+
+__all__ = [
+    "LlamaForCausalLMPipe",
+]
 
 
 def parse_args(args):
@@ -126,79 +133,6 @@ class LlamaRMSNormPipe(LlamaRMSNorm):
         return super().forward(hidden_states)
 
 
-class PipelinePretrainedModel(PretrainedModel):
-    _sequential_layers = []
-    _pipeline_name_mapping = None
-
-    def __init__(self, config, *args, **kwargs):
-        super().__init__(config, *args, **kwargs)
-
-    def add_sequential_layer(self, layer_desc, name_prefix=""):
-        self._sequential_layers.append({"layer": layer_desc, "name_prefix": name_prefix})
-
-    def get_sequential_layers(self):
-        return [x["layer"] for x in self._sequential_layers]
-
-    def get_sequential_name_prefixs(self):
-        return {str(index): x["name_prefix"] for index, x in enumerate(self._sequential_layers)}
-
-    def _set_pipeline_name_mapping(self, mappings=None):
-        if mappings is not None:
-            self._pipeline_name_mapping = mappings
-        else:
-            mapping = {}
-            state_dict_keys = list(super().state_dict().keys())
-            first_key = state_dict_keys[0].split(".")
-            # if use virtual pp_degree, the prefix is like 0.0.xxx
-            # else it will be like 0.xxx
-            use_virtual_pp_degree = first_key[0].isdigit() and first_key[1].isdigit()
-
-            prefixs = self.get_sequential_name_prefixs()
-            for k in state_dict_keys:
-                name_splited = k.split(".")
-                if use_virtual_pp_degree:
-                    idx = str(int(name_splited[0]) + int(name_splited[1]))
-                    single_name = [prefixs[idx]]
-                    single_name.extend(name_splited[2:])
-                else:
-                    idx = name_splited[0]
-                    single_name = [prefixs[idx]]
-                    single_name.extend(name_splited[1:])
-                mapping[".".join(single_name)] = k
-
-            self._pipeline_name_mapping = mapping
-
-        return self._pipeline_name_mapping
-
-    def state_dict(self, *args, **kwargs):
-        state_dict = super().state_dict(*args, **kwargs)
-
-        if self._pipeline_name_mapping is None:
-            self._set_pipeline_name_mapping()
-        assert len(self._pipeline_name_mapping) > 0, "The pipeline stage must have parameters!"
-        pp_to_single_mapping = {v: k for k, v in self._pipeline_name_mapping.items()}
-
-        for k in list(state_dict.keys()):
-            v = state_dict.pop(k)
-            state_dict[pp_to_single_mapping[k]] = v
-
-        return state_dict
-
-    def set_state_dict(self, state_dict, *args, **kwargs):
-        if self._pipeline_name_mapping is None:
-            self._set_pipeline_name_mapping()
-        assert len(self._pipeline_name_mapping) > 0, "The pipeline stage must have parameters!"
-
-        for k in list(state_dict.keys()):
-            v = state_dict.pop(k)
-            if k not in self._pipeline_name_mapping:
-                continue
-            state_dict[self._pipeline_name_mapping[k]] = v
-
-        ret = super().set_state_dict(state_dict, *args, **kwargs)
-        return ret
-
-
 class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
     """LlamaForPretraining adapted for pipeline parallelism.
 
@@ -210,15 +144,12 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
 
     _get_tensor_parallel_mappings = LlamaPretrainedModel._get_tensor_parallel_mappings
     _init_weights = LlamaPretrainedModel._init_weights
+    _keys_to_ignore_on_load_unexpected = LlamaPretrainedModel._keys_to_ignore_on_load_unexpected
 
-    # NO base_model_prefix !!!!
+    # DONOT Add base_model_prefix !!!!
 
-    def __init__(
-        self,
-        config,
-        # scale_qk_by_layer_num=True,
-        # virtual_pp_degree=4,
-    ):
+    def __init__(self, config):
+        LayerDesc.__repr__ = __repr__
         self.config = config
 
         self.use_recompute = self.config.use_recompute
@@ -228,13 +159,16 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
         if self.recompute_granularity == "full":
             assert len(self.no_recompute_layers) == 0, "for pp with full recompute, no_recompute_layers is not support"
 
-        # virtual_pp_degree = self.config.virtual_pp_degree
         virtual_pp_degree = getattr(self.config, "virtual_pp_degree", 1)
+
+        def get_hcg():
+            return fleet.get_hybrid_communicate_group()
 
         hcg = get_hcg()
         tensor_parallel_degree = max(hcg.get_model_parallel_world_size(), 1)
         tensor_parallel_rank = max(hcg.get_model_parallel_rank(), 0)
 
+        # TODO: fix tensor_parallel_degree rewrite in here
         config.tensor_parallel_degree = tensor_parallel_degree
         config.tensor_parallel_rank = tensor_parallel_rank
 
@@ -244,7 +178,6 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
                 LayerDesc(LlamaDecoderLayerPipe, config=config, layerwise_recompute=i not in self.no_recompute_layers),
                 f"llama.layers.{i}",
             )
-
         self.add_sequential_layer(LayerDesc(LlamaRMSNormPipe, config=config), "llama.norm")
         self.add_sequential_layer(LayerDesc(LlamaLMHead, config=config), "lm_head")
 
@@ -273,6 +206,7 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
             },
             num_virtual_pipeline_stages=virtual_pp_degree,
         )
+        # You should call init here, since there is a  diamond inheritance problem
         self.apply(self._init_weights)
         # DON'T init PipelinePretrainedModel
         # PipelinePretrainedModel.__init__(self.super(), config=config)

--- a/paddlenlp/transformers/llama/modeling_pp.py
+++ b/paddlenlp/transformers/llama/modeling_pp.py
@@ -34,6 +34,7 @@ def __repr__(self):
     return self.layer_func.__name__
 
 
+# hack LayerDesc for showing to much config
 LayerDesc.__repr__ = __repr__
 
 __all__ = [
@@ -149,7 +150,6 @@ class LlamaForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
     # DONOT Add base_model_prefix !!!!
 
     def __init__(self, config):
-        LayerDesc.__repr__ = __repr__
         self.config = config
 
         self.use_recompute = self.config.use_recompute

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1759,7 +1759,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                     pre_tensor_parallel_split = True
                     assert loaded_keys is not None, "loaded_keys is not None."
                     tp_actions = cls.get_tensor_parallel_convert_actions(config, loaded_keys)
-
+                # Here we use expected_keys to optimize weights loading for pipeline model. Only works for safetensors
                 state_dict = load_state_dict(
                     shard_file, tp_actions if pre_tensor_parallel_split else None, set(expected_keys)
                 )
@@ -2302,7 +2302,6 @@ class PipelinePretrainedModel(PretrainedModel):
 
             prefixs = self.get_sequential_name_prefixs()
             for k in state_dict_keys:
-                print(k)
                 name_splited = k.split(".")
                 if use_virtual_pp_degree:
                     if name_splited[0].isdigit():

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1529,7 +1529,8 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                             f"{pretrained_model_name_or_path} does not appear to have a file named"
                             f" {_add_variant(PADDLE_WEIGHTS_NAME, variant)}."
                         )
-                except Exception:
+                except Exception as e:
+                    logger.info(e)
                     # For any other exception, we throw a generic error.
                     raise EnvironmentError(
                         f"Can't load the model for '{pretrained_model_name_or_path}'. If you were trying to load it"
@@ -2266,7 +2267,8 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
 
 class PipelinePretrainedModel(PretrainedModel):
     _sequential_layers = []
-    _pipeline_name_mapping = None
+    _single_to_pp_mapping = None
+    _pp_to_single_mapping = None
 
     def __init__(self, config, *args, **kwargs):
         super().__init__(config, *args, **kwargs)
@@ -2282,56 +2284,94 @@ class PipelinePretrainedModel(PretrainedModel):
 
     def _set_pipeline_name_mapping(self, mappings=None):
         if mappings is not None:
-            self._pipeline_name_mapping = mappings
+            self._single_to_pp_mapping = mappings
         else:
-            mapping = {}
+            single_to_pp_mapping = {}
+            pp_to_single_mapping = {}
+
             state_dict_keys = list(super().state_dict().keys())
-            first_key = state_dict_keys[0].split(".")
+            first_key = ""
+            for k in state_dict_keys:
+                if "shared_layers" not in k:
+                    first_key = k
+                    break
+            first_key = first_key.split(".")
             # if use virtual pp_degree, the prefix is like 0.0.xxx
             # else it will be like 0.xxx
             use_virtual_pp_degree = first_key[0].isdigit() and first_key[1].isdigit()
 
             prefixs = self.get_sequential_name_prefixs()
             for k in state_dict_keys:
+                print(k)
                 name_splited = k.split(".")
                 if use_virtual_pp_degree:
-                    idx = str(int(name_splited[0]) + int(name_splited[1]))
-                    single_name = [prefixs[idx]]
-                    single_name.extend(name_splited[2:])
+                    if name_splited[0].isdigit():
+                        if name_splited[1].isdigit():
+                            idx = str(int(name_splited[0]) + int(name_splited[1]))
+                            single_name = [prefixs[idx]]
+                            single_name.extend(name_splited[2:])
+                        else:
+                            single_name = [prefixs[str(len(prefixs) - 1)]]
+                            single_name.extend(name_splited[2:])
+                            logger.warning(
+                                f"Please check! we treat this key as last layer, get {k}, set origin name as {'.'.join(single_name)}"
+                            )
+                    elif name_splited[0] == "shared_layers":
+                        # TODO: it treat shared_layers as first layer
+                        single_name = [prefixs["0"]]
+                        single_name.extend(name_splited[2:])
+                        logger.warning(
+                            f"Please check! we treat shared_layers as first layer, get {k}, set origin name as {'.'.join(single_name)}"
+                        )
+                    else:
+                        raise ValueError(f"Unexpected key: {k} for pp layer.")
                 else:
                     idx = name_splited[0]
-                    single_name = [prefixs[idx]]
-                    single_name.extend(name_splited[1:])
-                mapping[".".join(single_name)] = k
+                    # for normal pp layer
+                    if idx.isdigit():
+                        single_name = [prefixs[idx]]
+                        single_name.extend(name_splited[1:])
+                    elif idx == "shared_layers":
+                        # TODO: it treat shared_layers as first layer
+                        single_name = [prefixs["0"]]
+                        single_name.extend(name_splited[2:])
+                        logger.warning(
+                            f"Please check! we treat shared_layers as first layer, get {k}, set origin name as {'.'.join(single_name)}"
+                        )
+                    else:
+                        raise ValueError(f"Unexpected key: {k} for pp layer.")
 
-            self._pipeline_name_mapping = mapping
+                single_to_pp_mapping[".".join(single_name)] = k
+                pp_to_single_mapping[k] = ".".join(single_name)
 
-        return self._pipeline_name_mapping
+            self._single_to_pp_mapping = single_to_pp_mapping
+            self._pp_to_single_mapping = pp_to_single_mapping
+
+        return self._single_to_pp_mapping
 
     def state_dict(self, *args, **kwargs):
         state_dict = super().state_dict(*args, **kwargs)
 
-        if self._pipeline_name_mapping is None:
+        if self._single_to_pp_mapping is None:
             self._set_pipeline_name_mapping()
-        assert len(self._pipeline_name_mapping) > 0, "The pipeline stage must have parameters!"
-        pp_to_single_mapping = {v: k for k, v in self._pipeline_name_mapping.items()}
+        assert len(self._single_to_pp_mapping) > 0, "The pipeline stage must have parameters!"
 
         for k in list(state_dict.keys()):
             v = state_dict.pop(k)
-            state_dict[pp_to_single_mapping[k]] = v
+            state_dict[self._pp_to_single_mapping[k]] = v
 
         return state_dict
 
     def set_state_dict(self, state_dict, *args, **kwargs):
-        if self._pipeline_name_mapping is None:
+        if self._single_to_pp_mapping is None:
             self._set_pipeline_name_mapping()
-        assert len(self._pipeline_name_mapping) > 0, "The pipeline stage must have parameters!"
+        assert len(self._single_to_pp_mapping) > 0, "The pipeline stage must have parameters!"
 
         for k in list(state_dict.keys()):
             v = state_dict.pop(k)
-            if k not in self._pipeline_name_mapping:
+            if k not in self._single_to_pp_mapping:
                 continue
-            state_dict[self._pipeline_name_mapping[k]] = v
+            state_dict[self._single_to_pp_mapping[k]] = v
 
         ret = super().set_state_dict(state_dict, *args, **kwargs)
         return ret


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Unify pipeline model with PretrainModelPipe

```python
import paddle
import paddle.distributed.fleet as fleet
from paddlenlp.transformers import AutoModelForCausalLMPipe, AutoModelForCausalLM

world_size = paddle.distributed.get_world_size()

pp_degree = 2
tp_degree = world_size/2

strategy = fleet.DistributedStrategy()
strategy.hybrid_configs = {
    "dp_degree": 1,
    "mp_degree": tp_degree,
    "pp_degree": pp_degree,
    "sharding_degree": 1,
}
fleet.init(is_collective=True, strategy=strategy)
hcg = fleet.get_hybrid_communicate_group()

if pp_degree > 1:
    model_class = AutoModelForCausalLMPipe
else:
    model_class = AutoModelForCausalLM

model_name_or_path = "facebook/llama-7b"
# model_name_or_path = "__internal_testing__/tiny-random-llama"
model = model_class.from_pretrained(
    model_name_or_path,
    tensor_parallel_degree=tp_degree,
    tensor_parallel_rank=hcg.get_model_parallel_rank(),
    tensor_parallel_output=False,
)

model.eval()
```