### PR TITLE
fix benchmark compute statistics

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -799,8 +799,8 @@ def benchmark(predictor, predictor_args, model_args):
     batch_benchmark_texts = batchfy_text(benchmark_texts, predictor_args.batch_size)
     print("***********Start Benchmark**********")
 
-    warmup_time = 1
-    test_time = 10
+    warmup_time = 10
+    test_time = 100
 
     print("***********Start Warmup**********")
     for _ in range(warmup_time):

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -741,7 +741,6 @@ def create_predictor(
                     LlamaForCausalLMInferenceModel,
                 )
 
-                predictor = StaticInferencePredictor(predictor_args, cache_kvs_shape, tokenizer=tokenizer)
                 cache_kvs_shape = LlamaForCausalLMInferenceModel.get_cache_kvs_shape(config, predictor_args.batch_size, total_max_length)
             elif "chatglm" in config.architectures[0].lower():
                 from paddlenlp.experimental.transformers import (

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -85,6 +85,10 @@ class PredictorArgument:
             "help": "If benchmark set as `True`, we will force model decode to max_length, which is helpful to compute throughput. "
         },
     )
+    enable_memory_optim: bool = field(
+        default=True,
+        metadata={"help": "whether use `enable_memory_optim` in inference predictor"},
+    )
 
     @property
     def total_max_length(self):
@@ -528,7 +532,8 @@ class StaticInferencePredictor(InferencePredictorMixin, BasePredictor):
         device_id = int(os.environ.get("FLAGS_selected_gpus", 0))
         config.enable_use_gpu(100, device_id)
         # config.disable_glog_info()
-        config.enable_memory_optim()
+        if predictor_args.enable_memory_optim:
+            config.enable_memory_optim()
 
         # Note(zhengzekang): Force to use fleet executor
         if self.tensor_parallel_degree >= 1:

--- a/tests/llm/testing_utils.py
+++ b/tests/llm/testing_utils.py
@@ -58,6 +58,7 @@ class LLMTest:
 
     def run_predictor(self, config_params=None):
         config_params = config_params or {}
+        config_params.update("enable_memory_optim", False)
         # to avoid the same parameter
         self.disable_static()
         predict_config = load_test_config(self.config_path, "inference-predict")

--- a/tests/llm/testing_utils.py
+++ b/tests/llm/testing_utils.py
@@ -42,6 +42,7 @@ class LLMTest:
         shutil.rmtree(self.output_dir)
         shutil.rmtree(self.inference_output_dir)
         self.disable_static()
+        paddle.device.cuda.empty_cache()
 
     def disable_static(self):
         paddle.utils.unique_name.switch()
@@ -57,8 +58,12 @@ class LLMTest:
         return result
 
     def run_predictor(self, config_params=None):
-        config_params = config_params or {}
-        config_params.update("enable_memory_optim", False)
+        if config_params is None:
+            config_params = {}
+
+        config_params["init_fleet_worker"] = False
+        config_params["enable_memory_optim"] = False
+
         # to avoid the same parameter
         self.disable_static()
         predict_config = load_test_config(self.config_path, "inference-predict")
@@ -100,9 +105,6 @@ class LLMTest:
             predict()
 
         self.disable_static()
-
-        if not config_params["inference_model"]:
-            return
 
         predict_result = self._read_result(predict_config["output_file"])
         infer_result = self._read_result(config["output_file"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
- fix args.benchmark 
- fix compute statistics
- 目前单卡naive executor显存占用较多，因此更改为强行走fleet executor
- 修复cachekv shape，根据所需的src_length + max_length 来申请
