### PR TITLE
group null judge fix

### DIFF
--- a/paddlenlp/data/dist_dataloader.py
+++ b/paddlenlp/data/dist_dataloader.py
@@ -165,7 +165,7 @@ class DistDataLoader(paddle.io.DataLoader):
 
         # broadcast data keys name
         if self._data_keys is None:
-            if self.mp_group is not None and self.pp_rank == 0:
+            if self.mp_group.rank > -1 and self.pp_rank == 0:
                 paddle.distributed.broadcast_object_list(data_keys, src=self.mp_src_rank, group=self.mp_group)
             if self._pp_data_group is not None:
                 paddle.distributed.broadcast_object_list(
@@ -176,7 +176,7 @@ class DistDataLoader(paddle.io.DataLoader):
         # broadcast data
         if not self._need_data:
             data_list = [None for i in range(self._data_keys_size)]
-        if self.mp_group is not None and self.pp_rank == 0:
+        if self.mp_group.rank > -1 and self.pp_rank == 0:
             data_list = broadcast_data_list(data_list, paddle.int64, self.mp_rank, self.mp_group, self.mp_src_rank)
 
         if self._pp_data_group is not None:

--- a/paddlenlp/data/dist_dataloader.py
+++ b/paddlenlp/data/dist_dataloader.py
@@ -152,7 +152,7 @@ class DistDataLoader(paddle.io.DataLoader):
         # broadcast data keys size
         data_keys_size = paddle.to_tensor(data_keys_size)
         if self._data_keys_size is None:
-            if self.mp_group is not None and self.pp_rank == 0:
+            if self.mp_group.rank > -1 and self.pp_rank == 0:
                 paddle.distributed.broadcast(data_keys_size, src=self.mp_src_rank, group=self.mp_group)
             if self._pp_data_group is not None:
                 paddle.distributed.broadcast(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
According to the api(paddle/distributed/communication/group.py:67:

```
def is_member(self):
    if self.rank < 0:
        return False
    if self.nranks < 2:
        return False
    return True
```
and the group build code:
```
if size > 1 and global_rank in ranks:
    rank = 0 if backend == 'heter' else ranks.index(global_rank)
    pg = _new_process_group_impl(
        backend,
        _default_store,
        rank,
        size,
        group_name,
        pg_options=None,
        group_id=gid,
    )
else:
    rank = -1
    pg = None
```
The code in PaddleNLP/paddlenlp/data/dist_dataloader.py, egg line 155:
`if self.mp_group is not None and self.pp_rank == 0:`
can not determine the existence of 'mp_group' correctly.

If there is no model_parallel, mp_group will be:
`rank: -1, nranks: 1, id: 12, ranks: 0; name: _default_pg12`
The broadcast_data_list() will cased error:

```
Traceback (most recent call last):
  File "run_pretrain.py", line 567, in <module>
    main()
  File "run_pretrain.py", line 549, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/workspace/PaddleNLP/paddlenlp/trainer/trainer.py", line 738, in train
    for step, inputs in enumerate(epoch_iterator):
  File "/workspace/PaddleNLP/paddlenlp/data/dist_dataloader.py", line 181, in __next__
    data_list = broadcast_data_list(data_list, paddle.int64, self.mp_rank, self.mp_group, self.mp_src_rank)
  File "/workspace/PaddleNLP/paddlenlp/data/dist_dataloader.py", line 210, in broadcast_data_list
    paddle.distributed.broadcast(size_cuda, src_rank, group=comm_group).wait()
AttributeError: 'NoneType' object has no attribute 'wait'
```