### PR TITLE
[Function optimization] predict with batch_size = 3 

### DIFF
--- a/tests/test_tipc/llm/fixtures/predictor.yaml
+++ b/tests/test_tipc/llm/fixtures/predictor.yaml
@@ -2,4 +2,5 @@ llama:
   model_name: linly-ai/chinese-llama-2-7b
   fused_model: true
   dtype: float16
+  batch_size: 3
   data_file: tests/fixtures/llm/zh_query.json


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
使用 batch_size=3 来监控batch_size 无法被数据集整除的情况，同时也是为了实现边缘测试。