### PR TITLE
[Tokenizer] fix _decode

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -24,6 +24,7 @@ import unicodedata
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import six
 from paddle.utils import try_import
 
@@ -1440,6 +1441,8 @@ class PretrainedTokenizer(PretrainedTokenizerBase):
         spaces_between_special_tokens: bool = True,
         **kwargs
     ) -> str:
+        if isinstance(token_ids, np.ndarray):
+            token_ids = token_ids.tolist()
         self._decode_use_source_tokenizer = kwargs.pop("use_source_tokenizer", False)
         filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=skip_special_tokens)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
* bugs:
`sentencepiece` cannot process `numpy.ndarray`. 
Thus, when the data type of `token_ids`  is `numpy.ndarray`, tokenizer cannot decode it.

* solution:
`PretrainedTokenizer._decode`  requires `token_ids:List[int]` , thus `token_ids` will convert to list in `_decode`.

```python
class PretrainedTokenizer
    def _decode(
        self,
        token_ids: List[int],
        skip_special_tokens: bool = False,
        clean_up_tokenization_spaces: bool = True,
        spaces_between_special_tokens: bool = True,
        **kwargs
    ) -> str:
  
        if isinstance(token_ids, np.ndarray):
            token_ids = token_ids.tolist()
```
* fix issue #7172 