### PR TITLE
Polish the setting of dist_strategy.

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -900,14 +900,16 @@ class Trainer:
                     )
                     optimizer_was_run = True
                     if self.do_grad_scaling:
-                        scale_before = self.scaler._scale.cpu().numpy()
+                        scale_before = paddle.assign(self.scaler._scale)
                         self.scaler.step(self.optimizer)
                         self.scaler.update()
-                        scale_after = self.scaler._scale.cpu().numpy()
+                        scale_after = self.scaler._scale
                         optimizer_was_run = not self.scaler._cache_founf_inf
                         if not optimizer_was_run:
+                            scale_before_value = scale_before.cpu().numpy()
+                            scale_after_value = scale_after.cpu().numpy()
                             logger.warning(
-                                f"optimizer not run, scale_before: {scale_before[0]}, scale_after: {scale_after[0]}"
+                                f"optimizer not run, scale_before: {scale_before_value[0]}, scale_after: {scale_after_value[0]}"
                             )
                     elif isinstance(self.optimizer, HybridParallelOptimizer):
                         self.optimizer._step(parameters_list)

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -225,6 +225,12 @@ class TrainingArguments:
             pipeline_parallel_degree means split all transformer layers to how many stages.
             default -1 for not use pipeline parallel.
             Note. this need model support in source code, see llama modeling_pp.py file
+        tensor_parallel_config (`str`, *optional*)(
+            Some additional configs which affect model parallel performance, we provide some option to config it.
+            following config is support:
+              enable_mp_async_allreduce, it supports all_reduce(dx) overlap with matmul(dw) in ColumnParallelLinear backward when it set True, which can accelerate model parallel performance.
+              enable_mp_skip_c_identity, it supports skip c_identity in ColumnParallelLinear and RowParallelLinear. It only works when set mp_async_allreduce is True. It can accelerate model parallel further.
+              enable_mp_fused_linear_param_grad_add, it supports fused_linear_param_grad_add in ColumnParallelLinear (cuda >= 11.6). It only works when mp_async_allreduce is true. It can accelerate model parallel further.
         pipeline_parallel_config (`str`, *optional*)(
             Some additional config it highly affect the useage of pipeline parallel, we provide some option to config it.
             following config is support:
@@ -997,22 +1003,21 @@ class TrainingArguments:
                                     f"accpet config is enable_stage1_tensor_fusion, enable_stage1_overlap, enable_stage2_overlap."
                                 )
                     try:
-                        if (
-                            "enable_stage1_tensor_fusion" in sharding_parallel_config
-                            or "enable_stage1_overlap" in sharding_parallel_config
-                        ):
-                            assert pipeline_parallel_degree == 1, (
+                        if pipeline_parallel_degree == 1:
+                            strategy.hybrid_configs["sharding_configs"].tensor_fusion = (
+                                True if "enable_stage1_tensor_fusion" in sharding_parallel_config else False
+                            )
+                            if "enable_stage1_overlap" in sharding_parallel_config:
+                                strategy.hybrid_configs["sharding_configs"].comm_overlap = True
+                                strategy.hybrid_configs[
+                                    "sharding_configs"
+                                ].accumulate_steps = self.gradient_accumulation_steps
+                        else:
+                            warnings.warn(
                                 "For pipeline parallel with sharding, the sharding overlap and tensor fusion "
                                 "should be configured in pipeline_parallel_config."
+                                '"enable_stage1_tensor_fusion" and "enable_stage1_overlap" in sharding_parallel_config will be ignored.'
                             )
-                        strategy.hybrid_configs["sharding_configs"].tensor_fusion = (
-                            True if "enable_stage1_tensor_fusion" in sharding_parallel_config else False
-                        )
-                        if "enable_stage1_overlap" in sharding_parallel_config:
-                            strategy.hybrid_configs["sharding_configs"].comm_overlap = True
-                            strategy.hybrid_configs[
-                                "sharding_configs"
-                            ].accumulate_steps = self.gradient_accumulation_steps
                     except KeyError:
                         warnings.warn(
                             "The enable_stage1_tensor_fusion or enable_stage1_overlap is not supported "

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -365,9 +365,11 @@ class LlamaRotaryEmbedding(nn.Layer):
 
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
+        cos = self.cos_cached[:, :, :seq_len, ...]
+        sin = self.sin_cached[:, :, :seq_len, ...]
         return (
-            self.cos_cached[:, :, :seq_len, ...].cast(x.dtype),
-            self.sin_cached[:, :, :seq_len, ...].cast(x.dtype),
+            cos.cast(x.dtype) if cos.dtype != x.dtype else cos,
+            sin.cast(x.dtype) if sin.dtype != x.dtype else sin,
         )
 
 
@@ -427,15 +429,14 @@ class LlamaDynamicNTKScalingRotaryEmbedding(LlamaRotaryEmbedding):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len > self.max_position_embeddings:
             scale_cos, scale_sin = self._scale_cos_sin(seq_len=seq_len)
-            return (
-                scale_cos[:, :, :seq_len, ...].cast(x.dtype),
-                scale_sin[:, :, :seq_len, ...].cast(x.dtype),
-            )
         else:
-            return (
-                self.cos_cached[:, :, :seq_len, ...].cast(x.dtype),
-                self.sin_cached[:, :, :seq_len, ...].cast(x.dtype),
-            )
+            scale_cos, scale_sin = self.cos_cached, self.sin_cached
+        cos = scale_cos[:, :, :seq_len, ...]
+        sin = scale_sin[:, :, :seq_len, ...]
+        return (
+            cos.cast(x.dtype) if cos.dtype != x.dtype else cos,
+            sin.cast(x.dtype) if sin.dtype != x.dtype else sin,
+        )
 
 
 def rotate_half(x):

--- a/tests/test_tipc/dygraph/hybrid_parallelism/llama/benchmark_common/run_benchmark.sh
+++ b/tests/test_tipc/dygraph/hybrid_parallelism/llama/benchmark_common/run_benchmark.sh
@@ -92,6 +92,10 @@ function _train(){
         use_fp16_cmd="--use_amp true"
     fi
 
+    if [ "${tensor_parallel_degree}" != "1" ]; then
+        export CUDA_DEVICE_MAX_CONNECTIONS=1
+    fi
+
     if [ "${pipeline_parallel_config}" != "" ]; then
         pipeline_parallel_config_args="--pipeline_parallel_config ${pipeline_parallel_config}"
     else


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- 优化一些分布式优化策略的配置方式。
- rope计算中，避免bf16 -> bf16的cast
- benchmark脚本中，对于`MP>1`时，设置`CUDA_DEVICE_MAX_CONNECTIONS`以更好地overlap：

单机性能自测结果如下：
| 测试配置 | 性能数据（tokens/s） |
|---|---|
| PaddleNLP_facebook-llama-13b_seqlen2048_pretrain_bs32_bf16_MP4-PP2-mbs1-acc32_dynamic |                  14373.920 -> 14501.49 -> 14892.46 |
| PaddleNLP_facebook-llama-13b_seqlen2048_pretrain_bs32_bf16_PP8-vpp5-mbs1-acc32-recompute_dynamic | 13351.530 -> 
| PaddleNLP_facebook-llama-13b_seqlen2048_pretrain_bs32_bf16_MP2-PP4-vpp5-mbs2-acc16-recompute_dynamic | 13193.750 -> 13329.99


QA测试结果如下：
<img width="1230" alt="bd9c0cfe7d188265fcf4127a31ebad3d" src="https://github.com/PaddlePaddle/PaddleNLP/assets/12538138/e6ed15b0-37bf-4ee2-9fd8-8e01756613b5">
