### PR TITLE
fix(sec): upgrade paddlepaddle to 2.4.0

### DIFF
--- a/examples/semantic_indexing/requirements.txt
+++ b/examples/semantic_indexing/requirements.txt
@@ -3,7 +3,7 @@ hnswlib==0.6.2
 numpy==1.22.4
 paddle==1.0.2
 paddlenlp==2.3.4
-paddlepaddle==2.3.1
+paddlepaddle==2.5.0rc0
 regex==2022.7.25
 spacy==3.4.1
 tqdm==4.64.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in paddlepaddle 2.3.1
- [CVE-2022-46741](https://www.oscs1024.com/hd/CVE-2022-46741)


### What did I do？
Upgrade paddlepaddle from 2.3.1 to 2.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS