### PR TITLE
[llm] 当cuda < 11.6，self.linear 回退到matmul+add

### DIFF
--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -464,7 +464,13 @@ class FusedMultiTransformerBase(Layer):
         return ln_out
 
     def compute_qkv_linear(self, ln_out, i):
-        return self.linear(ln_out, self.qkv_weights[i], self.qkv_biases[i], transpose_weight=True)
+        if float(paddle.version.cuda()) < 11.6:
+            qkv_out = paddle.matmul(ln_out, self.qkv_weights[i], False, True)
+            qkv_out = paddle.add(qkv_out, self.qkv_biases[i])
+            return qkv_out
+        else:
+            # This method requires CUDA version >= 11.6.
+            return self.linear(ln_out, self.qkv_weights[i], self.qkv_biases[i], transpose_weight=True)
 
     def compute_qkv(self, src, residual_input, i):
         ln_out = self.compute_layernorm_before_qkv(src, i)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

https://github.com/PaddlePaddle/Paddle/blob/973f6d09fed597e809daced8480844c31ec6b241/python/paddle/incubate/nn/functional/fused_matmul_bias.py#L26C19-L26C19

- 当cuda < 11.6时，回退到matmul+add
