### PR TITLE
[llm]support chatglmv2 in fined FT

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -397,7 +397,7 @@ class InferencePredictorMixin:
             pre_caches_length=pre_caches_length,
         )
 
-        if "chatglm" in self.architectures:
+        if "chatglmforcausallm" == self.architectures.lower():
             if inputs["input_ids"].shape[0] < self.config.batch_size:
                 self.tgt_pos = self.tgt_pos[: inputs["input_ids"].shape[0]]
             for i in range(inputs["input_ids"].shape[0]):
@@ -750,7 +750,21 @@ def create_predictor(
                     predictor_args.model_name_or_path, config=config, dtype=predictor_args.dtype
                 )
                 model.eval()
-            elif "chatglm" in config.architectures[0].lower():
+
+            elif "chatglmv2forcausallm" in config.architectures[0].lower():
+                from paddlenlp.experimental.transformers import (
+                    ChatGLMv2ForCausalLMInferenceModel as Model,
+                )
+
+                config.quant_bits = -1
+                if predictor_args.quant_type.startswith("weight_only_int"):
+                    quant_bits = int(predictor_args.quant_type[-1])
+                    config.quant_bits = quant_bits
+                model = Model.from_pretrained(
+                    predictor_args.model_name_or_path, config=config, dtype=predictor_args.dtype
+                )
+                model.eval()
+            elif "chatglmforcausallm" in config.architectures[0].lower():
                 from paddlenlp.experimental.transformers import (
                     ChatGLMForCausalLMInferenceModel,
                 )

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -713,6 +713,11 @@ def create_predictor(
             config.tensor_parallel_degree = tensor_parallel_degree
             config.tensor_parallel_rank = tensor_parallel_rank
 
+            config.quant_bits = -1
+            if predictor_args.quant_type.startswith("weight_only_int"):
+                quant_bits = int(predictor_args.quant_type[-1])
+                config.quant_bits = quant_bits
+
             if "llama" in config.architectures[0].lower():
                 if model_args.model_type == "llama-img2txt":
                     # we use llama for img2txt.
@@ -723,13 +728,6 @@ def create_predictor(
                     from paddlenlp.experimental.transformers import (
                         LlamaForCausalLMInferenceModel as LlamaInferenceModel,
                     )
-
-                    config.quant_bits = -1
-
-                    if predictor_args.quant_type.startswith("weight_only_int"):
-                        quant_bits = int(predictor_args.quant_type[-1])
-                        config.quant_bits = quant_bits
-
                 model = LlamaInferenceModel.from_pretrained(
                     predictor_args.model_name_or_path, config=config, dtype=predictor_args.dtype
                 )
@@ -756,10 +754,6 @@ def create_predictor(
                     ChatGLMv2ForCausalLMInferenceModel as Model,
                 )
 
-                config.quant_bits = -1
-                if predictor_args.quant_type.startswith("weight_only_int"):
-                    quant_bits = int(predictor_args.quant_type[-1])
-                    config.quant_bits = quant_bits
                 model = Model.from_pretrained(
                     predictor_args.model_name_or_path, config=config, dtype=predictor_args.dtype
                 )

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -396,7 +396,7 @@ def dybatch_preprocess(
 ):
     """Pre-process generation inputs."""
     inputs = {}
-    if "chatglm" in architectures:
+    if "chatglmforcausallm" == architectures.lower():
         input_ids = []
         position_ids = []
 

--- a/paddlenlp/experimental/transformers/chatglm_v2/__init__.py
+++ b/paddlenlp/experimental/transformers/chatglm_v2/__init__.py
@@ -12,10 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .bloom import *
-from .chatglm import *
-from .chatglm_v2 import *
-from .fused_transformer_layers import *
-from .gpt import *
-from .llama import *
-from .opt import *
+from .modeling import *

--- a/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
@@ -300,7 +300,7 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
             for i in state_dict.keys():
                 if i.find(name) >= 0:
                     result_list.append(i)
-            assert len(result_list) == 1
+            assert len(result_list) == 1, name + " must be only one in state_dict"
             return result_list[0]
 
         self.embedding.word_embeddings.weight.set_value(state_dict.pop(key("embedding.word_embeddings.weight")))

--- a/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
@@ -256,8 +256,8 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
         else:
             rotary_pos_emb = rotary_pos_emb[None, :seq_length]
 
-        ones = paddle.ones([batch_size, seq_length, 32], dtype=paddle.get_default_dtype())
-        zeros = paddle.zeros([batch_size, seq_length, 32], dtype=paddle.get_default_dtype())
+        ones = paddle.ones([batch_size, seq_length, self.head_size // 4], dtype=paddle.get_default_dtype())
+        zeros = paddle.zeros([batch_size, seq_length, self.head_size // 4], dtype=paddle.get_default_dtype())
         # make it to be [2, batch, seq_len, rotary_dim]
         rotary_pos_emb = rotary_pos_emb.transpose([3, 0, 1, 2])
         # The following code is for consistency with PaddleNLP/csrc/generation/encode_rotary_qk.cu, so boring.
@@ -266,7 +266,9 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
         cos = paddle.concat([cos, ones], axis=-1)
         sin = paddle.concat([sin, zeros], axis=-1)
         rotary_pos_emb = paddle.stack([cos, sin], axis=0)
-        rotary_pos_emb = rotary_pos_emb.unsqueeze(-1).tile([1, 1, 1, 1, 2]).reshape([2, batch_size, seq_length, 128])
+        rotary_pos_emb = (
+            rotary_pos_emb.unsqueeze(-1).tile([1, 1, 1, 1, 2]).reshape([2, batch_size, seq_length, self.head_size])
+        )
 
         # Run encoder.
         seq_lens = seq_len_decoder if is_decoder else seq_len_encoder
@@ -292,19 +294,28 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
 
     @paddle.no_grad()
     def set_state_dict(self, state_dict):
-        self.embedding.word_embeddings.weight.set_value(state_dict.pop("embedding.word_embeddings.weight"))
-        self.final_layernorm.weight.set_value(state_dict.pop("encoder.final_layernorm.weight"))
-        self.output_layer.weight.set_value(state_dict.pop("output_layer.weight"))
+        # find the real name.
+        def key(name):
+            result_list = []
+            for i in state_dict.keys():
+                if i.find(name) >= 0:
+                    result_list.append(i)
+            assert len(result_list) == 1
+            return result_list[0]
+
+        self.embedding.word_embeddings.weight.set_value(state_dict.pop(key("embedding.word_embeddings.weight")))
+        self.final_layernorm.weight.set_value(state_dict.pop(key("encoder.final_layernorm.weight")))
+        self.output_layer.weight.set_value(state_dict.pop(key("output_layer.weight")))
 
         for i in range(self.num_layers):
-            ln_scale = state_dict.pop("encoder.layers.{}.input_layernorm.weight".format(i))
+            ln_scale = state_dict.pop(key("encoder.layers.{}.input_layernorm.weight".format(i)))
 
-            q_weight = state_dict.pop("encoder.layers.{}.self_attention.query.weight".format(i))
-            k_weight = state_dict.pop("encoder.layers.{}.self_attention.key.weight".format(i))
-            v_weight = state_dict.pop("encoder.layers.{}.self_attention.value.weight".format(i))
-            q_bias = state_dict["encoder.layers.{}.self_attention.query.bias".format(i)]
-            k_bias = state_dict["encoder.layers.{}.self_attention.key.bias".format(i)]
-            v_bias = state_dict["encoder.layers.{}.self_attention.value.bias".format(i)]
+            q_weight = state_dict.pop(key("encoder.layers.{}.self_attention.query.weight".format(i)))
+            k_weight = state_dict.pop(key("encoder.layers.{}.self_attention.key.weight".format(i)))
+            v_weight = state_dict.pop(key("encoder.layers.{}.self_attention.value.weight".format(i)))
+            q_bias = state_dict.pop(key("encoder.layers.{}.self_attention.query.bias".format(i)))
+            k_bias = state_dict.pop(key("encoder.layers.{}.self_attention.key.bias".format(i)))
+            v_bias = state_dict.pop(key("encoder.layers.{}.self_attention.value.bias".format(i)))
 
             k_weight = k_weight.reshape([self.hidden_size, self.multi_query_group_num, 1, self.head_size])
             k_bias = k_bias.reshape([self.multi_query_group_num, 1, self.head_size])
@@ -329,16 +340,16 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
             concated_qkv_bias = concated_qkv_bias.reshape([3 * self.hidden_size])
             concated_qkv_bias = paddle.to_tensor(concated_qkv_bias)
 
-            out_proj_weight = state_dict.pop("encoder.layers.{}.self_attention.dense.weight".format(i))
+            out_proj_weight = state_dict.pop(key("encoder.layers.{}.self_attention.dense.weight".format(i)))
 
-            ffn_ln_scale = state_dict.pop("encoder.layers.{}.post_attention_layernorm.weight".format(i))
+            ffn_ln_scale = state_dict.pop(key("encoder.layers.{}.post_attention_layernorm.weight".format(i)))
 
             # shuffle the column of ffn1's weight for fine grained FM
-            ffn1_weight = state_dict.pop("encoder.layers.{}.mlp.dense_h_to_4h.weight".format(i))
+            ffn1_weight = state_dict.pop(key("encoder.layers.{}.mlp.dense_h_to_4h.weight".format(i)))
             ffn1_weight_0 = ffn1_weight[..., 0::2]
             ffn1_weight_1 = ffn1_weight[..., 1::2]
             ffn1_weight = paddle.concat([ffn1_weight_0, ffn1_weight_1], axis=-1)
-            ffn2_weight = state_dict.pop("encoder.layers.{}.mlp.dense_4h_to_h.weight".format(i))
+            ffn2_weight = state_dict.pop(key("encoder.layers.{}.mlp.dense_4h_to_h.weight".format(i)))
 
             self.transformer_block.ln_scales[i].set_value(ln_scale)
 
@@ -499,3 +510,7 @@ class ChatGLMv2ForCausalLMInferenceModel(GenerationInferenceModel, ChatGLMv2Pret
         lm_logits = self.chatglm_v2.output_layer(hidden_states)
         output = (lm_logits,) + transformer_outputs[1:]
         return output
+
+    @paddle.no_grad()
+    def set_state_dict(self, state_dict):
+        self.chatglm_v2.set_state_dict(state_dict)

--- a/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
@@ -1,0 +1,503 @@
+# Copyright (c) 2023 ChatGLM2-6B Model Team and PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Optional
+
+import paddle
+import paddle.distributed.fleet as fleet
+import paddle.nn as nn
+from paddle.nn.quant import weight_quantize
+from paddlenlp_ops import get_padding_offset
+
+from paddlenlp.experimental.transformers.fused_transformer_layers import (
+    FusedMultiTransformerBase,
+    FusedMultiTransformerConfig,
+    FusedMultiTransformerWeightOnly,
+)
+from paddlenlp.experimental.transformers.generation_utils import (
+    GenerationInferenceModel,
+)
+from paddlenlp.transformers import ChatGLMv2Config, ChatGLMv2PretrainedModel
+from paddlenlp.transformers.chatglm_v2.modeling import (
+    Embedding,
+    RMSNorm,
+    RotaryEmbedding,
+)
+from paddlenlp.transformers.model_utils import (
+    dy2st_nocheck_guard_context,
+    register_base_model,
+)
+
+__all__ = [
+    "ChatGLMv2ForCausalLMInferenceModel",
+]
+
+
+@register_base_model
+class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
+    def __init__(self, config: ChatGLMv2Config, empty_init=True):
+        super().__init__(config)
+        self.embedding = Embedding(config)
+
+        # Rotary positional embeddings
+        self.max_sequence_length = config.max_sequence_length
+        rotary_dim = (
+            config.hidden_size // config.num_attention_heads if config.kv_channels is None else config.kv_channels
+        )
+        self.rotary_pos_emb = RotaryEmbedding(rotary_dim // 2)
+
+        if config.tensor_parallel_degree > 1:
+            if config.tensor_parallel_degree > 2:
+                raise ValueError(
+                    "ChatGLM2 does not support `tensor_parallel_degree` > 2. Consider using Sharding stage 3"
+                )
+            self.output_layer = fleet.meta_parallel.ColumnParallelLinear(
+                config.hidden_size,
+                config.padded_vocab_size,
+                has_bias=False,
+                gather_output=not config.tensor_parallel_output,
+            )
+        else:
+            self.output_layer = nn.Linear(config.hidden_size, config.padded_vocab_size, bias_attr=False)
+
+        self.num_layers = config.num_hidden_layers
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_size = self.hidden_size // self.num_heads
+        self.multi_query_group_num = config.multi_query_group_num
+
+        self.use_weight_only = False
+        self.quant_bits = config.quant_bits
+        self.quant_algo = "weight_only_int" + str(self.quant_bits)
+        if self.quant_bits != -1:
+            self.use_weight_only = True
+
+        if self.use_weight_only:
+            assert (
+                self.quant_algo == "weight_only_int8" or self.quant_algo == "weight_only_int4"
+            ), "Expected quant_algo equal to 'weight_only_int8' or 'weight_only_int4', but received {}".format(
+                self.quant_algo
+            )
+
+        ln_scale_attrs = [
+            paddle.ParamAttr(name="encoder.layers.{}.input_layernorm.weight".format(i))
+            for i in range(config.num_hidden_layers)
+        ]
+
+        qkv_weight_attrs = [
+            paddle.ParamAttr(
+                name="encoder.layers.{}.qkv_weight".format(i), initializer=paddle.nn.initializer.Constant(value=0)
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+        qkv_bias_attrs = [
+            paddle.ParamAttr(name="encoder.layers.{}.qkv_bias".format(i)) for i in range(config.num_hidden_layers)
+        ]
+
+        out_proj_weight_attrs = [
+            paddle.ParamAttr(
+                name="encoder.layers.{}.self_attention.dense.weight".format(i),
+                initializer=paddle.nn.initializer.Constant(value=0),
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+
+        ffn_ln_scale_attrs = [
+            paddle.ParamAttr(name="encoder.layers.{}.post_attention_layernorm.weight".format(i))
+            for i in range(config.num_hidden_layers)
+        ]
+
+        ffn1_weight_attrs = [
+            paddle.ParamAttr(
+                name="encoder.layers.{}.mlp.dense_h_to_4h.weight".format(i),
+                initializer=paddle.nn.initializer.Constant(value=0),
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+
+        ffn2_weight_attrs = [
+            paddle.ParamAttr(
+                name="encoder.layers.{}.mlp.dense_4h_to_h.weight".format(i),
+                initializer=paddle.nn.initializer.Constant(value=0),
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+
+        qkv_weight_scale_attrs = None
+        out_proj_weight_scale_attrs = None
+        ffn1_weight_scale_attrs = None
+        ffn2_weight_scale_attrs = None
+        if self.use_weight_only:
+            qkv_weight_scale_attrs = [
+                paddle.ParamAttr(name="encoder.layers.{}.qkv_weight_scale".format(i)) for i in range(self.num_layers)
+            ]
+            out_proj_weight_scale_attrs = [
+                paddle.ParamAttr(name="encoder.layers.{}.self_attention.dense.weight_scale".format(i))
+                for i in range(self.num_layers)
+            ]
+            ffn1_weight_scale_attrs = [
+                paddle.ParamAttr(name="encoder.layers.{}.mlp.dense_h_to_4h.weight_scale".format(i))
+                for i in range(self.num_layers)
+            ]
+            ffn2_weight_scale_attrs = [
+                paddle.ParamAttr(name="encoder.layers.{}.mlp.dense_4h_to_h.weight_scale".format(i))
+                for i in range(self.num_layers)
+            ]
+        transformer_config = FusedMultiTransformerConfig(
+            config.hidden_size,
+            config.num_attention_heads,
+            config.ffn_hidden_size,
+            dropout_rate=0.0,
+            quant_bits=self.quant_bits,
+            activation="swiglu",
+            normalize_before=True,
+            num_layers=config.num_hidden_layers,
+            nranks=1,
+            ring_id=-1,
+            ln_scale_attrs=ln_scale_attrs,
+            qkv_weight_attrs=qkv_weight_attrs,
+            qkv_weight_scale_attrs=qkv_weight_scale_attrs,
+            qkv_bias_attrs=qkv_bias_attrs,
+            linear_weight_attrs=out_proj_weight_attrs,
+            linear_weight_scale_attrs=out_proj_weight_scale_attrs,
+            ffn_ln_scale_attrs=ffn_ln_scale_attrs,
+            ffn1_weight_attrs=ffn1_weight_attrs,
+            ffn1_weight_scale_attrs=ffn1_weight_scale_attrs,
+            ffn2_weight_attrs=ffn2_weight_attrs,
+            ffn2_weight_scale_attrs=ffn2_weight_scale_attrs,
+            epsilon=config.layernorm_epsilon,
+            norm_type="rmsnorm",
+        )
+
+        if self.use_weight_only:
+            self.transformer_block = FusedMultiTransformerWeightOnly(transformer_config)
+        else:
+            self.transformer_block = FusedMultiTransformerBase(transformer_config)
+
+        self.post_layer_norm = config.post_layer_norm
+        if self.post_layer_norm:
+            LayerNormFunc = RMSNorm if config.rmsnorm else nn.LayerNorm
+            # Final layer norm before output.
+            self.final_layernorm = LayerNormFunc(config.hidden_size, epsilon=config.layernorm_epsilon)
+
+    def get_input_embeddings(self):
+        return self.embedding.word_embeddings
+
+    def set_input_embeddings(self, value):
+        self.embedding.word_embeddings = value
+
+    def remove_padding(self, input_ids, seq_lens_this_time):
+        cum_offsets_now = paddle.cumsum(paddle.max(seq_lens_this_time) - seq_lens_this_time)
+        token_num = paddle.sum(seq_lens_this_time)
+        ids_remove_padding, cum_offsets, padding_offset = get_padding_offset(
+            input_ids, cum_offsets_now, token_num, seq_lens_this_time
+        )
+        return ids_remove_padding, padding_offset, cum_offsets
+
+    def forward(
+        self,
+        input_ids=None,
+        position_ids: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[paddle.Tensor] = None,
+        inputs_embeds=None,
+        use_cache=None,
+        cache_kvs=None,
+        seq_len_encoder=None,
+        seq_len_decoder=None,
+        past_key_values=None,
+        output_attentions=False,
+        output_hidden_states=None,
+        return_dict=False,
+        **kwargs,
+    ):
+
+        # kwargs["cache"] is used used to distinguish between encoder and decoder phase.
+        past_key_values = kwargs.get("cache", None)
+        is_decoder = past_key_values is not None
+
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if not is_decoder:
+            ids_remove_padding, padding_offset, cum_offsets = self.remove_padding(input_ids, seq_len_encoder)
+        else:
+            ids_remove_padding = input_ids
+            padding_offset = None
+            cum_offsets = None
+
+        batch_size, seq_length = input_ids.shape
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embedding.word_embeddings(ids_remove_padding)
+        hidden_states = inputs_embeds
+
+        # Rotary positional embeddings
+        # 32768
+        rotary_pos_emb = self.rotary_pos_emb(self.max_sequence_length)
+
+        if position_ids is not None:
+            rotary_pos_emb = rotary_pos_emb[position_ids]
+            rotary_pos_emb = rotary_pos_emb[:, :seq_length, :, :]
+        else:
+            rotary_pos_emb = rotary_pos_emb[None, :seq_length]
+
+        ones = paddle.ones([batch_size, seq_length, 32], dtype=paddle.get_default_dtype())
+        zeros = paddle.zeros([batch_size, seq_length, 32], dtype=paddle.get_default_dtype())
+        # make it to be [2, batch, seq_len, rotary_dim]
+        rotary_pos_emb = rotary_pos_emb.transpose([3, 0, 1, 2])
+        # The following code is for consistency with PaddleNLP/csrc/generation/encode_rotary_qk.cu, so boring.
+        cos = rotary_pos_emb[0]
+        sin = rotary_pos_emb[1]
+        cos = paddle.concat([cos, ones], axis=-1)
+        sin = paddle.concat([sin, zeros], axis=-1)
+        rotary_pos_emb = paddle.stack([cos, sin], axis=0)
+        rotary_pos_emb = rotary_pos_emb.unsqueeze(-1).tile([1, 1, 1, 1, 2]).reshape([2, batch_size, seq_length, 128])
+
+        # Run encoder.
+        seq_lens = seq_len_decoder if is_decoder else seq_len_encoder
+        with dy2st_nocheck_guard_context():
+            hidden_states, _ = self.transformer_block(
+                input_ids,
+                hidden_states,
+                cum_offsets=cum_offsets,
+                padding_offset=padding_offset,
+                attn_mask=paddle.cast(attention_mask, dtype=hidden_states.dtype),
+                caches=cache_kvs,
+                pre_caches=None,
+                pre_caches_length=0,
+                seq_lens=seq_lens,
+                rotary_embs=paddle.cast(rotary_pos_emb, "float32"),
+                rotary_emb_dims=1,
+                time_step=paddle.increment(paddle.shape(attention_mask)[-1], -1) if is_decoder else None,
+            )
+
+        hidden_states = self.final_layernorm(hidden_states)
+
+        return tuple(v for v in [hidden_states, None, None, None] if v is not None)
+
+    @paddle.no_grad()
+    def set_state_dict(self, state_dict):
+        self.embedding.word_embeddings.weight.set_value(state_dict.pop("embedding.word_embeddings.weight"))
+        self.final_layernorm.weight.set_value(state_dict.pop("encoder.final_layernorm.weight"))
+        self.output_layer.weight.set_value(state_dict.pop("output_layer.weight"))
+
+        for i in range(self.num_layers):
+            ln_scale = state_dict.pop("encoder.layers.{}.input_layernorm.weight".format(i))
+
+            q_weight = state_dict.pop("encoder.layers.{}.self_attention.query.weight".format(i))
+            k_weight = state_dict.pop("encoder.layers.{}.self_attention.key.weight".format(i))
+            v_weight = state_dict.pop("encoder.layers.{}.self_attention.value.weight".format(i))
+            q_bias = state_dict["encoder.layers.{}.self_attention.query.bias".format(i)]
+            k_bias = state_dict["encoder.layers.{}.self_attention.key.bias".format(i)]
+            v_bias = state_dict["encoder.layers.{}.self_attention.value.bias".format(i)]
+
+            import numpy as np
+
+            k_weight = k_weight.reshape([self.hidden_size, self.multi_query_group_num, 1, self.head_size])
+            k_bias = k_bias.reshape([self.multi_query_group_num, 1, self.head_size])
+            v_weight = v_weight.reshape([self.hidden_size, self.multi_query_group_num, 1, self.head_size])
+            v_bias = v_bias.reshape([self.multi_query_group_num, 1, self.head_size])
+
+            k_weight = np.tile(k_weight, [1, 1, self.num_heads // self.multi_query_group_num, 1])
+            v_weight = np.tile(v_weight, [1, 1, self.num_heads // self.multi_query_group_num, 1])
+            k_bias = np.tile(k_bias, [1, self.num_heads // self.multi_query_group_num, 1])
+            v_bias = np.tile(v_bias, [1, self.num_heads // self.multi_query_group_num, 1])
+            k_weight = k_weight.reshape([self.hidden_size, self.hidden_size])
+            k_bias = k_bias.reshape([self.hidden_size])
+            v_weight = v_weight.reshape([self.hidden_size, self.hidden_size])
+            v_bias = v_bias.reshape([self.hidden_size])
+
+            concated_qkv_weight = np.concatenate([q_weight, k_weight, v_weight], axis=-1)
+            concated_qkv_weight = concated_qkv_weight.transpose(1, 0)
+            concated_qkv_weight = concated_qkv_weight.reshape([3 * self.hidden_size, self.hidden_size])
+            concated_qkv_weight = paddle.to_tensor(concated_qkv_weight)
+
+            concated_qkv_bias = np.concatenate([q_bias, k_bias, v_bias], axis=-1)
+            concated_qkv_bias = concated_qkv_bias.reshape([3 * self.hidden_size])
+            concated_qkv_bias = paddle.to_tensor(concated_qkv_bias)
+
+            out_proj_weight = state_dict.pop("encoder.layers.{}.self_attention.dense.weight".format(i))
+
+            ffn_ln_scale = state_dict.pop("encoder.layers.{}.post_attention_layernorm.weight".format(i))
+
+            # shuffle the column of ffn1's weight for fine grained FM
+            ffn1_weight = state_dict.pop("encoder.layers.{}.mlp.dense_h_to_4h.weight".format(i))
+            ffn1_weight_0 = ffn1_weight[..., 0::2]
+            ffn1_weight_1 = ffn1_weight[..., 1::2]
+            ffn1_weight = paddle.concat([ffn1_weight_0, ffn1_weight_1], axis=-1)
+            ffn2_weight = state_dict.pop("encoder.layers.{}.mlp.dense_4h_to_h.weight".format(i))
+
+            self.transformer_block.ln_scales[i].set_value(ln_scale)
+
+            if self.use_weight_only:
+                qkv_weight_tensor = paddle.to_tensor(concated_qkv_weight)
+                qkv_weight_tensor = paddle.transpose(qkv_weight_tensor, perm=[1, 0])
+                qkv_quanted_weight_tensor, qkv_weight_scale_tensor = weight_quantize(
+                    qkv_weight_tensor, algo=self.quant_algo
+                )
+                self.transformer_block.qkv_weights[i].set_value(qkv_quanted_weight_tensor)
+                self.transformer_block.qkv_weights_scale[i].set_value(qkv_weight_scale_tensor)
+            else:
+                self.transformer_block.qkv_weights[i].set_value(concated_qkv_weight)
+
+            self.transformer_block.qkv_biases[i].set_value(concated_qkv_bias)
+
+            if self.use_weight_only:
+                linear_quanted_weight_tensor, linear_weight_scale_tensor = weight_quantize(
+                    out_proj_weight, algo=self.quant_algo
+                )
+                self.transformer_block.linear_weights[i].set_value(linear_quanted_weight_tensor)
+                self.transformer_block.linear_weights_scale[i].set_value(linear_weight_scale_tensor)
+            else:
+                self.transformer_block.linear_weights[i].set_value(out_proj_weight)
+
+            self.transformer_block.ffn_ln_scales[i].set_value(ffn_ln_scale)
+
+            if self.use_weight_only:
+                ffn1_quanted_weight_tensor, ffn1_weight_scale_tensor = weight_quantize(
+                    ffn1_weight, algo=self.quant_algo
+                )
+                self.transformer_block.ffn1_weights[i].set_value(ffn1_quanted_weight_tensor)
+                self.transformer_block.ffn1_weights_scale[i].set_value(ffn1_weight_scale_tensor)
+            else:
+                self.transformer_block.ffn1_weights[i].set_value(ffn1_weight)
+
+            if self.use_weight_only:
+                ffn2_quanted_weight_tensor, ffn2_weight_scale_tensor = weight_quantize(
+                    ffn2_weight, algo=self.quant_algo
+                )
+                self.transformer_block.ffn2_weights[i].set_value(ffn2_quanted_weight_tensor)
+                self.transformer_block.ffn2_weights_scale[i].set_value(ffn2_weight_scale_tensor)
+            else:
+                self.transformer_block.ffn2_weights[i].set_value(ffn2_weight)
+
+
+class ChatGLMv2ForCausalLMInferenceModel(GenerationInferenceModel, ChatGLMv2PretrainedModel):
+    def __init__(self, config: ChatGLMv2Config):
+        super().__init__(config)
+        self.max_sequence_length = config.max_sequence_length
+        self.chatglm_v2 = ChatGLMv2InferenceModel(config)
+
+    @classmethod
+    def get_cache_kvs_shape(cls, config: ChatGLMv2Config, max_batch_size: int = None, max_length: int = None):
+        """get cache_kvs tensor for opt model
+
+        Args:
+            max_batch_size (int): the max batch size
+            max_length (int | None, optional): the max_length of cache_kvs. Defaults to None.
+
+        Returns:
+            list[paddle.Tensor]: the list tensor shape for cache
+        """
+
+        if max_length is None:
+            max_length = config.max_sequence_length
+
+        cache_kvs = []
+        for _ in range(config.num_hidden_layers):
+            cache_kvs.append(
+                [
+                    2,
+                    max_batch_size,
+                    config.num_attention_heads // max(config.tensor_parallel_degree, 1),
+                    max_length,
+                    config.hidden_size // config.num_attention_heads,
+                ]
+            )
+        return cache_kvs
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        cache_kvs,
+        seq_len_encoder,
+        seq_len_decoder,
+        tgt_ids,
+        tgt_pos,
+        tgt_generation_mask,
+        **kwargs,
+    ):
+        position_ids = kwargs.get("position_ids", None)
+        attention_mask = kwargs.get("attention_mask", None)
+        cache = kwargs.get("cache", None)
+        pre_caches = kwargs.get("pre_caches", None)
+        inputs_embeds = kwargs.get("inputs_embeds", None)
+        if cache is not None:
+            input_ids = tgt_ids
+            position_ids = tgt_pos
+            attention_mask = (tgt_generation_mask - 1) * 1e4
+            # make inputs_embeds be none in decoder phase.
+            # in forward function, it will be assigned according to input_ids.
+            inputs_embeds = None
+        else:
+            attention_mask = (attention_mask - 1) * 1e4
+        model_inputs = {
+            "input_ids": input_ids,
+            "inputs_embeds": inputs_embeds,
+            "position_ids": position_ids,
+            "attention_mask": attention_mask,
+            "cache_kvs": cache_kvs,
+            "seq_len_encoder": seq_len_encoder,
+            "seq_len_decoder": seq_len_decoder,
+            "cache": cache,
+            "pre_caches": pre_caches,
+        }
+        return model_inputs
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        attention_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        use_cache=False,
+        cache=None,
+        cache_kvs=None,
+        pre_caches=None,
+        seq_len_encoder=None,
+        seq_len_decoder=None,
+        past_key_values=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        transformer_outputs = self.chatglm_v2(
+            input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache=cache,
+            cache_kvs=cache_kvs,
+            seq_len_encoder=seq_len_encoder,
+            seq_len_decoder=seq_len_decoder,
+            past_key_values=past_key_values,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        hidden_states = transformer_outputs[0]
+
+        lm_logits = self.chatglm_v2.output_layer(hidden_states)
+        output = (lm_logits,) + transformer_outputs[1:]
+        return output

--- a/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/experimental/transformers/chatglm_v2/modeling.py
@@ -15,6 +15,7 @@
 
 from typing import Optional
 
+import numpy as np
 import paddle
 import paddle.distributed.fleet as fleet
 import paddle.nn as nn
@@ -247,7 +248,6 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
         hidden_states = inputs_embeds
 
         # Rotary positional embeddings
-        # 32768
         rotary_pos_emb = self.rotary_pos_emb(self.max_sequence_length)
 
         if position_ids is not None:
@@ -305,8 +305,6 @@ class ChatGLMv2InferenceModel(ChatGLMv2PretrainedModel):
             q_bias = state_dict["encoder.layers.{}.self_attention.query.bias".format(i)]
             k_bias = state_dict["encoder.layers.{}.self_attention.key.bias".format(i)]
             v_bias = state_dict["encoder.layers.{}.self_attention.value.bias".format(i)]
-
-            import numpy as np
 
             k_weight = k_weight.reshape([self.hidden_size, self.multi_query_group_num, 1, self.head_size])
             k_bias = k_bias.reshape([self.multi_query_group_num, 1, self.head_size])

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -466,7 +466,8 @@ class FusedMultiTransformerBase(Layer):
     def compute_qkv_linear(self, ln_out, i):
         if float(paddle.version.cuda()) < 11.6:
             qkv_out = paddle.matmul(ln_out, self.qkv_weights[i], False, True)
-            qkv_out = paddle.add(qkv_out, self.qkv_biases[i])
+            if self.qkv_biases[i] is not None:
+                qkv_out = paddle.add(qkv_out, self.qkv_biases[i])
             return qkv_out
         else:
             # This method requires CUDA version >= 11.6.

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -110,7 +110,8 @@ class GenerationInferenceModel(GenerationMixin):
             config.get("logits_processors", None),
             precache_input_spec,
         ]
-        if self.config["model_type"] and "chatglm" in self.config.model_type:
+        # use "==" to distingusih between chatglm and chatglm_v2.
+        if self.config["model_type"] and "chatglm" == self.config.model_type.lower():
             input_spec[2] = paddle.static.InputSpec(
                 shape=[None, None, None], dtype="int64", name="position_ids"
             )  # position_ids

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -22,6 +22,7 @@ from paddlenlp.transformers import (
     AutoTokenizer,
     BloomForCausalLM,
     ChatGLMForCausalLM,
+    ChatGLMv2ForCausalLM,
     LlamaForCausalLM,
 )
 from paddlenlp.utils.downloader import (
@@ -39,6 +40,7 @@ from .testing_utils import LLMTest
         ["__internal_testing__/tiny-random-llama", LlamaForCausalLM],
         ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
+        ["__internal_testing__/tiny-random-chatglm2", ChatGLMv2ForCausalLM],
     ],
 )
 class PredictorTest(LLMTest, unittest.TestCase):

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -18,10 +18,9 @@ import unittest
 
 from parameterized import parameterized_class
 
-from paddlenlp.transformers import (
+from paddlenlp.transformers import (  # ChatGLMForCausalLM,
     AutoTokenizer,
     BloomForCausalLM,
-    ChatGLMForCausalLM,
     ChatGLMv2ForCausalLM,
     LlamaForCausalLM,
 )
@@ -39,7 +38,7 @@ from .testing_utils import LLMTest
     [
         ["__internal_testing__/tiny-random-llama", LlamaForCausalLM],
         ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
-        ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
+        # ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm2", ChatGLMv2ForCausalLM],
     ],
 )

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -40,7 +40,7 @@ from .testing_utils import LLMTest
         ["__internal_testing__/tiny-random-llama", LlamaForCausalLM],
         ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
-        ["__internal_testing__/tiny-random-chatglm2", ChatGLMv2ForCausalLM],
+        ["__internal_testing__/tiny-fused-chatglm2", ChatGLMv2ForCausalLM],
     ],
 )
 class PredictorTest(LLMTest, unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

用户可用下面命令执行细粒度组网的动态图推理，

`python3.8 predictor.py     --model_name_or_path /root/.paddlenlp/models/THUDM/chatglm2-6b     --batch_size 2 --dtype "float16"     --mode "dynamic"  --inference_model `


可用下面命令导出fp16静态图

`python3.8  export_model.py      --model_name_or_path /root/.paddlenlp/models/THUDM/chatglm2-6b      --output_path /zhoukangkang/2023-06-06minigpt/whole_part/chatglmv2_by_zkk_infer_cuda11_2/      --dtype float16 --inference_model  --model_prefix=chatglm_v2 `


可用下面命令导出weight only int8静态图

`python3.8  export_model.py      --model_name_or_path /root/.paddlenlp/models/THUDM/chatglm2-6b      --output_path /zhoukangkang/2023-06-06minigpt/whole_part/chatglmv2_by_zkk_infer_cuda11_2_int8/      --dtype float16 --inference_model  --model_prefix=chatglm_v2  --quant_type=weight_only_int8  `






