### PR TITLE
fix(sec): upgrade aiohttp to 3.8.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 
 urllib3==1.26.2    # fix urllib3 version dependency: https://github.com/psf/requests/issues/6432#issuecomment-1537221990
 scipy==1.9.1
-aiohttp==3.8.4
+aiohttp==3.8.5
 numpy<1.27.0,>=1.19.5
 h11<0.13,>=0.11
 jinja2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in aiohttp 3.8.4
- [CVE-2023-37276](https://www.oscs1024.com/hd/CVE-2023-37276)


### What did I do？
Upgrade aiohttp from 3.8.4 to 3.8.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS