### PR TITLE
fix error in dropout of hybrid_model

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -626,7 +626,7 @@ class TransformerDecoderLayer(nn.Layer):
 
         with get_rng_state_tracker().rng_state(current_seed):
             if not self.use_fused_dropout_add:
-                tgt = residual + self.linear2(F.gelu(self.linear1(tgt), approximate=True))
+                tgt = residual + self.dropout2(self.linear2(F.gelu(self.linear1(tgt), approximate=True)))
             else:
                 tgt = self.fused_dropout_add2(self.linear2(F.gelu(self.linear1(tgt), approximate=True)), residual)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
Fix the bug in `hybrid_model.py` in the case of 'not self.use_fused_dropout_add'.
Fixed the bug, test the hybrid_model using pp4-mp2. After 10 steps the losses are as follow:
|  scene   | loss  |
|  ----  | ----  |
| use_fused_dropout_add  | 11.255878448 |
| not use_fused_dropout_add(fixed bug)  | 11.255878448 |
| not use_fused_dropout_add(origin)  | 11.210844040 |