### PR TITLE
Use set_dynamic_shape api to set dynamic shape in GPT generation model

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -1080,7 +1080,7 @@ class GPTForGenerationAuto(nn.Layer):
 
         attn_mask = model_kwargs["attention_mask"]
         # make the shape of attention_mask = (-1, -1, -1, -1) in dy2static.
-        model_kwargs["attention_mask"] = paddle.reshape(attn_mask, paddle.shape(attn_mask))
+        paddle.jit.dy2static.utils_helper.set_dynamic_shape(model_kwargs["attention_mask"], [-1, -1, -1, -1])
         model_kwargs["cache"] = outputs[1] if isinstance(outputs, tuple) else None
         max_length = paddle.to_tensor(max_length)
         while cur_len < max_length:

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -1457,7 +1457,7 @@ class GPTForGenerationHybrid(nn.Layer):
 
         attn_mask = model_kwargs["attention_mask"]
         # make the shape of attention_mask = (-1, -1, -1, -1) in dy2static.
-        model_kwargs["attention_mask"] = paddle.reshape(attn_mask, paddle.shape(attn_mask))
+        paddle.jit.dy2static.utils_helper.set_dynamic_shape(model_kwargs["attention_mask"], [-1, -1, -1, -1])
         model_kwargs["cache"] = outputs[1] if isinstance(outputs, tuple) else None
         while cur_len < max_length:
             # Note(GuoxiaWang): Remove outputs = _forward_(**model_kwargs)

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -1077,7 +1077,7 @@ class GPTForGeneration(nn.Layer):
 
         attn_mask = model_kwargs["attention_mask"]
         # make the shape of attention_mask = (-1, -1, -1, -1) in dy2static.
-        model_kwargs["attention_mask"] = paddle.reshape(attn_mask, paddle.shape(attn_mask))
+        paddle.jit.dy2static.utils_helper.set_dynamic_shape(model_kwargs["attention_mask"], [-1, -1, -1, -1])
         model_kwargs["cache"] = outputs[1] if isinstance(outputs, tuple) else None
         if hasattr(paddle.framework, "_no_check_dy2st_diff"):
             # TODO(wanghuancoder): _no_check_dy2st_diff is used to turn off the checking of behavior


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Replace 'reshape' with 'set_dynamic_shape' api to set dynamic shape to a tensor.
To support dynamic shape in dy2static, GPTGeneration model use a confusing operation 'x=paddle.reshape(x, paddle.shape(x))' to set dynamic shape for x. Now replace it with 'set_dynamic_shape' api.