### PR TITLE
[Bug fixes] disable ir_optim under bfloat16

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -577,7 +577,7 @@ class StaticInferencePredictor(InferencePredictorMixin, BasePredictor):
 
         config = paddle.inference.Config(infer_model_path + ".pdmodel", infer_model_path + ".pdiparams")
 
-        config.switch_ir_optim(True)
+        config.switch_ir_optim(predictor_args.dtype != "bfloat16")
         device_id = int(os.environ.get("FLAGS_selected_gpus", 0))
         config.enable_use_gpu(100, device_id)
         # config.disable_glog_info()

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -578,7 +578,9 @@ class StaticInferencePredictor(InferencePredictorMixin, BasePredictor):
         config = paddle.inference.Config(infer_model_path + ".pdmodel", infer_model_path + ".pdiparams")
 
         config.switch_ir_optim(True)
-        config.delete_pass("gpu_cpu_map_matmul_v2_to_matmul_pass")
+        # remove `gpu_cpu_map_matmul_v2_to_matmul_pass` to avoid mapping matmul_v2 -> matmul op
+        if predictor_args.dtype == "bfloat16":
+            config.delete_pass("gpu_cpu_map_matmul_v2_to_matmul_pass")
 
         device_id = int(os.environ.get("FLAGS_selected_gpus", 0))
         config.enable_use_gpu(100, device_id)

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -577,7 +577,9 @@ class StaticInferencePredictor(InferencePredictorMixin, BasePredictor):
 
         config = paddle.inference.Config(infer_model_path + ".pdmodel", infer_model_path + ".pdiparams")
 
-        config.switch_ir_optim(predictor_args.dtype != "bfloat16")
+        config.switch_ir_optim(True)
+        config.delete_pass("gpu_cpu_map_matmul_v2_to_matmul_pass")
+
         device_id = int(os.environ.get("FLAGS_selected_gpus", 0))
         config.enable_use_gpu(100, device_id)
         # config.disable_glog_info()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
InferenceModel

### Description
<!-- Describe what this PR does -->
在 bfloat16 的模型下静态图推理，gpu_cpu_map_matmul_v2_to_matmul_pass 会将 matmul_v2 映射成 matmul。