### PR TITLE
Support setting allreduce_matmul_grad_overlapping and enable_send_recv_overlap in auto_config

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
+++ b/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
@@ -193,6 +193,12 @@ def process_strategy(config):
     amp.use_fp16_guard = amp_cfg.get("use_fp16_guard", False)
     amp.use_bf16_guard = amp_cfg.get("use_bf16_guard", False)
 
+    # mp_optimization config
+    mp_degree = config.Distributed.get("mp_degree", 1)
+    if mp_degree > 1:
+        mp_cfg = config.Distributed.get("mp_optimization", {})
+        strategy.mp_optimization.allreduce_matmul_grad_overlapping = mp_cfg.get("allreduce_matmul_grad_overlapping", False)
+
     # sharding config
     sharding_cfg = config.Distributed.get("sharding", {})
     sharding = strategy.sharding
@@ -210,11 +216,14 @@ def process_strategy(config):
     accumulate_steps = config.Engine.get("accumulate_steps", 1)
     if pp_degree > 1 and accumulate_steps > 1:
         # pipeline config
+        pipeline_cfg = config.Distributed.get("pipeline", {})
         pipeline = strategy.pipeline
         pipeline.enable = True
-        pipeline.schedule_mode = config.Distributed.get("schedule_mode", "1F1B")
+        pipeline.enable_send_recv_overlap = pipeline_cfg.get("enable_send_recv_overlap", False)
+        pipeline.schedule_mode = pipeline_cfg.get("schedule_mode", "1F1B")
         pipeline.micro_batch_size = config.Global.micro_batch_size
         pipeline.accumulate_steps = accumulate_steps
+        
     elif accumulate_steps > 1:
         # gradient merge config
         gradient_merge = strategy.gradient_merge


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
New features

### PR changes
Others

### Description
<!-- Describe what this PR does -->
1. 在auto.engine中适配框架allreduce_matmul_grad_overlapping和enable_send_recv_overlap优化开关，方便后续模型测试。框架相关PR：https://github.com/PaddlePaddle/Paddle/pull/58304 https://github.com/PaddlePaddle/Paddle/pull/58324
2. 将流水编排模式控制开关从`Distributed.schedule_mode`更改为`Distributed.pipeline.schedule_mode`，与框架auto_parallel.strategy对齐。