### PR TITLE
[AutoParallel] Sequence Parallel for Auto Mode

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/auto/pretrain_gpt_base.yaml
+++ b/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/auto/pretrain_gpt_base.yaml
@@ -35,7 +35,7 @@ Model:
   scale_qk_by_layer_num: True
   fused_softmax_with_triangular: True
   use_flash_attn: False
-
+  sequence_parallel: False # TODO make sequence_parallel as an independent parallel and be set id Distributed
 
 Data:
   Train:

--- a/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/auto/pretrain_gpt_debug_mp8.yaml
+++ b/model_zoo/gpt-3/ppfleetx/configs/nlp/gpt/auto/pretrain_gpt_debug_mp8.yaml
@@ -1,0 +1,31 @@
+_base_: ./pretrain_gpt_base.yaml
+
+Global:
+  global_batch_size: 
+  local_batch_size: 1
+  micro_batch_size: 1
+
+
+Model:
+  vocab_size: 50304
+  hidden_size: 1024
+  num_layers: 4
+  num_attention_heads: 16
+  ffn_hidden_size: 4096
+  hidden_dropout_prob: 0.1
+  attention_probs_dropout_prob: 0.1
+  max_position_embeddings: 1024
+  type_vocab_size: 16
+  initializer_range: 0.02
+  use_recompute: False
+  fuse_attn_qkv: True
+  sequence_parallel: False # TODO make sequence_parallel as an independent parallel and be set id Distributed
+
+
+Distributed:
+  dp_degree: 1
+  mp_degree: 8
+  pp_degree: 1
+  sharding:
+    sharding_degree: 1
+    sharding_stage: 1

--- a/model_zoo/gpt-3/ppfleetx/distributed/apis/auto_env.py
+++ b/model_zoo/gpt-3/ppfleetx/distributed/apis/auto_env.py
@@ -77,6 +77,11 @@ class Mesh:
     def mp_degree(self):
         return self._mp_degree
 
+    # TODO(JZ-LIANG) Support SP as an independent mesh axis
+    @property
+    def sp_degree(self):
+        return self._mp_degree
+
     @property
     def pp_degree(self):
         return self._pp_degree
@@ -87,6 +92,11 @@ class Mesh:
 
     @property
     def mp_dim(self):
+        return self._mp_dim
+
+    # TODO(JZ-LIANG) Support SP as an independent mesh axis
+    @property
+    def sp_dim(self):
         return self._mp_dim
 
     def __getitem__(self, idx):

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -761,10 +761,6 @@ class GPTModelAuto(nn.Layer):
             use_cache=use_cache,
             cache=cache,
         )
-
-        # we attach the allgather of SP into logit layer
-        # if self.sequence_parallel:
-        #     auto.shard_tensor(tgt, auto_env.get_mesh()[self.ipp], [None, None, None])
         
         return encoder_outputs
 

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -85,6 +85,7 @@ class MultiHeadAttention(nn.Layer):
         recompute_granularity="full",
         use_flash_attn=False,
         ipp=None,
+        sequence_parallel=False,
     ):
         super(MultiHeadAttention, self).__init__()
         self.embed_dim = embed_dim
@@ -99,6 +100,8 @@ class MultiHeadAttention(nn.Layer):
         self.recompute_granularity = recompute_granularity
         self.ipp = ipp
         self.use_flash_attn = use_flash_attn if flash_attention else None
+        self.sequence_parallel = sequence_parallel
+
 
         self.head_dim = embed_dim // num_heads
         assert self.head_dim * num_heads == self.embed_dim, "embed_dim[{}] must be divisible by num_heads[{}]".format(self.embed_dim, num_heads)
@@ -202,14 +205,31 @@ class MultiHeadAttention(nn.Layer):
             return self.Cache(key, value)
 
     def _flash_attention(self, q, k, v, attn_mask=None):
+
+        # if sequence_parallel, the activation is [s, b, h], but flash attention lib need [b, s, h]
+        # we revert it to be [b, s, h] before 
+        if self.sequence_parallel:
+            perm = [1, 0, 2, 3]
+            q = tensor.transpose(x=q, perm=perm)
+            k = tensor.transpose(x=k, perm=perm)
+            v = tensor.transpose(x=v, perm=perm)
+
         out, weights = flash_attention(
             q, k, v, self.dropout, causal=True, return_softmax=self.need_weights, training=self.training
         )
         out = tensor.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
+
+        # and convert it back to [s, b, h] after
+        if self.sequence_parallel:
+            perm = [1, 0, 2]
+            out = tensor.transpose(x=out, perm=perm)
+
         return (out, weights)
 
     def core_attn(self, q, k, v, attn_mask=None):
-        perm = [0, 2, 1, 3]
+        # input shape is [b, s, nhead, ndim] or [s, b, nhead, ndim] if sequence_parallel
+        # after transpose, [b, nhead, s, ndim] not matter sequence_parallel or not 
+        perm = [1, 2, 0, 3] if self.sequence_parallel else [0, 2, 1, 3]
         q = tensor.transpose(x=q, perm=perm)
         k = tensor.transpose(x=k, perm=perm)
         v = tensor.transpose(x=v, perm=perm)
@@ -233,7 +253,13 @@ class MultiHeadAttention(nn.Layer):
         out = paddle.matmul(weights, v)
 
         # combine heads
-        out = tensor.transpose(out, perm=[0, 2, 1, 3])
+        # before transpose, out is [b, nhead, s, ndim]
+        # after transpose, out need to be [b, s, nhead, ndim](not sp)  or  [s, b, nhead, ndim](not sp)
+        if self.sequence_parallel:
+            out = tensor.transpose(out, perm=[2, 0, 1, 3])
+        else:
+            out = tensor.transpose(out, perm=[0, 2, 1, 3])
+
         out = tensor.reshape(x=out, shape=[0, 0, -1])
 
         return out, weights
@@ -287,6 +313,7 @@ class TransformerDecoder(nn.Layer):
         hidden_size=None,
         use_recompute=False,
         recompute_granularity="full",
+        sequence_parallel=False,
     ):
         super(TransformerDecoder, self).__init__()
 
@@ -299,6 +326,7 @@ class TransformerDecoder(nn.Layer):
             self.norm = nn.LayerNorm(hidden_size, epsilon=1e-5)
         elif norm is not None:
             raise ValueError("Only support LayerNorm")
+        self.sequence_parallel = sequence_parallel
 
     def forward(self, tgt, memory, tgt_mask=None, memory_mask=None, use_cache=False, cache=None):
         r"""
@@ -372,6 +400,7 @@ class TransformerDecoderLayer(nn.Layer):
         use_flash_attn=False,
         use_fused_dropout_add=True,
         ipp=None,
+        sequence_parallel=False,
     ):
         self._config = locals()
         self._config.pop("self")
@@ -384,6 +413,8 @@ class TransformerDecoderLayer(nn.Layer):
         self.use_recompute = use_recompute
         self.recompute_granularity = recompute_granularity
         self.ipp = ipp
+        self.sequence_parallel = sequence_parallel
+
         if not FusedDropoutAdd:
             self.use_fused_dropout_add = False
         else:
@@ -406,6 +437,7 @@ class TransformerDecoderLayer(nn.Layer):
             recompute_granularity=recompute_granularity,
             use_flash_attn=use_flash_attn,
             ipp=ipp,
+            sequence_parallel=sequence_parallel,
         )
 
         self.linear1 = nn.Linear(d_model, dim_feedforward, weight_attrs[2], bias_attr=bias_attrs[2])
@@ -435,6 +467,10 @@ class TransformerDecoderLayer(nn.Layer):
         if self.normalize_before:
             tgt = self.norm1(tgt)
 
+        if self.sequence_parallel:
+            # TODO(JZ-LIANG) make sure unsharded annotation would not be changed
+            auto.shard_tensor(tgt, auto_env.get_mesh()[self.ipp], [None, None, None])
+
         if use_cache is False:
             if self.use_recompute and self.recompute_granularity == "full_attn":
                 tgt = auto.recompute(self.self_attn)(tgt, None, None, tgt_mask, use_cache, cache)
@@ -442,6 +478,11 @@ class TransformerDecoderLayer(nn.Layer):
                 tgt = self.self_attn(tgt, tgt, tgt, tgt_mask, use_cache, cache)
         else:
             tgt, incremental_cache = self.self_attn(tgt, tgt, tgt, tgt_mask, use_cache, cache)
+
+        if self.sequence_parallel:
+            # TODO(JZ-LIANG) make sure unsharded annotation would not be changed
+            auto.shard_tensor(tgt, auto_env.get_mesh()[self.ipp], [auto_env.get_mesh().sp_dim, None, None])
+
         if not self.use_fused_dropout_add:
             tgt = residual + self.dropout1(tgt)
         else:
@@ -454,11 +495,24 @@ class TransformerDecoderLayer(nn.Layer):
         if self.normalize_before:
             tgt = self.norm2(tgt)
 
-        if not self.use_fused_dropout_add:
-            tgt = self.dropout2(self.linear2(self.activation(self.linear1(tgt))))
-            tgt = residual + tgt
+        if self.sequence_parallel:
+            # Enter TP Region
+            auto.shard_tensor(tgt, auto_env.get_mesh()[0], [None, None, None])
+            tgt = self.linear2(self.activation(self.linear1(tgt)))
+            # Enter SP Region
+            auto.shard_tensor(tgt, auto_env.get_mesh()[0], [auto_env.get_mesh().sp_dim, None, None])
+            if not self.use_fused_dropout_add:
+                tgt = self.dropout2(tgt)
+                tgt = residual + tgt
+            else:
+                tgt = self.fused_dropout_add2(tgt, residual)
         else:
-            tgt = self.fused_dropout_add2(self.linear2(self.activation(self.linear1(tgt))), residual)
+            # Mixed SP and TP Region
+            if not self.use_fused_dropout_add:
+                tgt = self.dropout2(self.linear2(self.activation(self.linear1(tgt))))
+                tgt = residual + tgt
+            else:
+                tgt = self.fused_dropout_add2(self.linear2(self.activation(self.linear1(tgt))), residual)
 
         if not self.normalize_before:
             tgt = self.norm2(tgt)
@@ -484,8 +538,10 @@ class GPTEmbeddings(nn.Layer):
         type_vocab_size=16,
         initializer_range=0.02,
         freeze_embedding=False,
+        sequence_parallel=False,
     ):
         super(GPTEmbeddings, self).__init__()
+        self.sequence_parallel = sequence_parallel
         self.word_embeddings = nn.Embedding(
             vocab_size,
             hidden_size,
@@ -515,6 +571,13 @@ class GPTEmbeddings(nn.Layer):
         input_embedings = self.word_embeddings(input_ids)
         position_embeddings = self.position_embeddings(position_ids)
         embeddings = input_embedings + position_embeddings
+
+        # [b, s, h] -> [s, b, h] 
+        if self.sequence_parallel:
+            embeddings = paddle.transpose(embeddings, perm=[1, 0, 2])
+            # TODO (JZ-LIANG) only constrain the sharding of seq axis propagate forward from here but not backward.
+            auto.shard_tensor(embeddings, auto_env.get_mesh()[0], [auto_env.get_mesh().sp_dim, None, None])
+
         embeddings = self.dropout(embeddings)
         return embeddings
 
@@ -541,6 +604,7 @@ class GPTModelAuto(nn.Layer):
         use_flash_attn=False,
         fused_softmax_with_triangular=False,
         use_fused_dropout_add=True,
+        sequence_parallel=False,
     ):
 
         super(GPTModelAuto, self).__init__()
@@ -549,6 +613,7 @@ class GPTModelAuto(nn.Layer):
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
         self.fused_softmax_with_triangular = fused_softmax_with_triangular
+        self.sequence_parallel = sequence_parallel
 
         if not auto_env.get_mesh():
             raise RuntimeError(
@@ -570,6 +635,7 @@ class GPTModelAuto(nn.Layer):
             type_vocab_size,
             self.initializer_range,
             freeze_embedding,
+            sequence_parallel=sequence_parallel,
         )
 
         layer_per_stage = num_layers // auto_env.get_mesh().pp_degree
@@ -601,6 +667,7 @@ class GPTModelAuto(nn.Layer):
                     use_fused_dropout_add=use_fused_dropout_add,
                     use_flash_attn=use_flash_attn,
                     ipp=layer_to_pipe[i],
+                    sequence_parallel=sequence_parallel,
                 )
             )
 
@@ -611,6 +678,7 @@ class GPTModelAuto(nn.Layer):
             hidden_size=hidden_size,
             use_recompute=use_recompute,
             recompute_granularity=recompute_granularity,
+            sequence_parallel=sequence_parallel,
         )
 
     def forward(self, input_ids, position_ids=None, attention_mask=None, use_cache=False, cache=None):
@@ -657,6 +725,10 @@ class GPTModelAuto(nn.Layer):
             cache=cache,
         )
 
+        # we attach the allgather of SP into logit layer
+        # if self.sequence_parallel:
+        #     auto.shard_tensor(tgt, auto_env.get_mesh()[self.ipp], [None, None, None])
+        
         return encoder_outputs
 
 
@@ -673,6 +745,7 @@ class GPTForPretrainingAuto(nn.Layer):
     def __init__(self, gpt):
         super(GPTForPretrainingAuto, self).__init__()
         self.gpt = gpt
+        self.sequence_parallel = gpt.sequence_parallel
 
     def forward(
         self, input_ids, position_ids=None, attention_mask=None, masked_positions=None, use_cache=False, cache=None
@@ -685,6 +758,10 @@ class GPTForPretrainingAuto(nn.Layer):
             encoder_outputs, cached_kvs = outputs[:2]
         else:
             encoder_outputs = outputs
+
+        # FIXME should we force the encoder_outputs mesh is the last stage ? 
+        if self.sequence_parallel:
+            auto.shard_tensor(encoder_outputs, auto_env.get_mesh()[-1], [None, None, None])
 
         x_dims_mapping = [auto_env.get_mesh().dp_dim] + [None] * (len(encoder_outputs.shape) - 1)
         w_dims_mapping = [auto_env.get_mesh().mp_dim, None]
@@ -702,9 +779,10 @@ class GPTPretrainingCriterionAuto(nn.Layer):
     Criterion for GPT. It calculates the final loss.
     """
 
-    def __init__(self):
+    def __init__(self, sequence_parallel=False):
         super(GPTPretrainingCriterionAuto, self).__init__()
         self.loss_func = paddle.nn.CrossEntropyLoss(reduction="none")
+        self.sequence_parallel = sequence_parallel
 
     def forward(self, prediction_scores, masked_lm_labels, loss_mask):
         """
@@ -730,6 +808,10 @@ class GPTPretrainingCriterionAuto(nn.Layer):
         auto.shard_tensor(
             loss_mask, auto_env.get_mesh()[-1], [auto_env.get_mesh().dp_dim] + [None] * (len(loss_mask.shape) - 1)
         )
+        if self.sequence_parallel:
+            # [b, s, h] --> [s, b, h]
+            masked_lm_labels = masked_lm_labels.transpose([1, 0])
+            loss_mask = loss_mask.transpose([1, 0])
 
         masked_lm_loss = self.loss_func(prediction_scores, masked_lm_labels.unsqueeze(2))
 

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_module.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_module.py
@@ -142,7 +142,7 @@ class GPTModuleAuto(LanguageModuleAuto):
         return model
 
     def get_loss_fn(self):
-        return gpt.GPTPretrainingCriterionAuto()
+        return gpt.GPTPretrainingCriterionAuto(sequence_parallel=self.configs.Model.sequence_parallel)
 
 
 class GPTGenerationModuleAuto(BasicModule):

--- a/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
+++ b/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
@@ -70,7 +70,7 @@ def process_global_configs(config):
     # pp_degree = config["Distributed"]["pp_degree"]
     # sharding_degree = config["Distributed"]["sharding"]["sharding_degree"]
 
-    # TODO: support partial_send_recv and sequence_parallel
+    # TODO: support partial_send_recv
     # config["Global"]["enable_partial_send_recv"] = True
     # if config.get("Model", None) is not None and "sequence_parallel" in config["Model"] and pp_degree > 1:
     #     if config["Model"]["sequence_parallel"]:

--- a/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
+++ b/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
@@ -16,6 +16,8 @@ import argparse
 import os
 import sys
 
+from sympy import sequence
+
 import paddle
 import paddle.distributed as dist
 import paddle.distributed.auto_parallel as auto
@@ -41,6 +43,15 @@ def process_dist_configs(config):
 
     mp_degree = configs.setdefault("mp_degree", 1)
     pp_degree = configs.setdefault("pp_degree", 1)
+
+    # disenable sequence parallel is mp_degree < 2.
+    sequence_parallel = config["Model"]["sequence_parallel"]
+    if mp_degree < 2 and sequence_parallel:
+        config["Model"]["sequence_parallel"] = False
+        logger.warning(
+            "sequence_parallel is turn off since mp_degree < 2."
+        )
+
 
     # sharding default
     sharding_config = configs["sharding"]

--- a/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
+++ b/model_zoo/gpt-3/ppfleetx/utils/auto_config.py
@@ -16,8 +16,6 @@ import argparse
 import os
 import sys
 
-from sympy import sequence
-
 import paddle
 import paddle.distributed as dist
 import paddle.distributed.auto_parallel as auto


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Function optimization

### PR changes
Models

### Description
Sequence Parallel for Auto Mode
受限于当前标记补全模块的问题，有3处地方的标记不够直观，未来可以更完善：

1. 用户接口处暂不支持 SP 独立维度和通信组，SP 绑定 TP (和动态图 config 对齐)
2. row linear matmul 的标记： shard_op 不支持 linear 等(module)，此处的标记需要调用paddle framework 内部函数
3. transfermer layer input 的标记： SP 标记需要考虑DP 的标记防止冲突，出于较保守精度对齐考虑的，DP 在跨mesh 时需要重新标记但这影响了SP 信息的 propagation