### PR TITLE
fix qwen lm_head matrix dimmention alignment

### DIFF
--- a/paddlenlp/transformers/qwen/modeling.py
+++ b/paddlenlp/transformers/qwen/modeling.py
@@ -39,6 +39,7 @@ from .configuration import QWenConfig
 __all__ = [
     "QWenBlock",
     "QWenForCausalLM",
+    "QWenLMHeadModel",
     "QWenPretrainedModel",
     "QWenModel",
     "QWenLMHead",
@@ -495,7 +496,7 @@ class QWenPretrainedModel(PretrainedModel):
                 mapping[1] = "qwen." + mapping[1]
 
         if config.architectures is not None:
-            if "QWenForCausalLM" in config.architectures:
+            if "QWenForCausalLM" or "QWenLMHeadModel" in config.architectures:
                 mappings.extend(
                     [
                         [
@@ -1043,3 +1044,6 @@ class QWenRMSNorm(nn.Layer):
 
         output = self._norm(x.astype(paddle.float32)).astype(x.dtype)
         return output * self.weight
+
+
+QWenLMHeadModel = QWenForCausalLM


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
修复了qwen Torch2Paddle 参数自动转换 lm_head权重参数维度不对齐的问题