### PR TITLE
[Bug fixes]revert chatglm2 config

### DIFF
--- a/tests/test_tipc/llm/fixtures/predictor.yaml
+++ b/tests/test_tipc/llm/fixtures/predictor.yaml
@@ -15,3 +15,9 @@ chatglm:
   fused_model: true
   dtype: float16
   data_file: tests/fixtures/llm/zh_query.json
+
+chatglm2:
+  model_name: THUDM/chatglm2-6b
+  fused_model: true
+  dtype: float16
+  data_file: tests/fixtures/llm/zh_query.json


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Testing

### Description
<!-- Describe what this PR does -->
添加 chatglm2 的测试配置

* commit： https://github.com/PaddlePaddle/PaddleNLP/pull/7192/commits/d3435511d40fd89eefde5b2b147c9d9376118594
* comment：https://github.com/PaddlePaddle/PaddleNLP/pull/7192#discussion_r1376989735

在 CE 精度测试层面，已经支持了 chatglm2，可是当时只是给删除了，其实不应该要删除。