### PR TITLE
Hotfix recompute in PP for benchmark.

### DIFF
--- a/paddlenlp/transformers/llama/modeling_pp.py
+++ b/paddlenlp/transformers/llama/modeling_pp.py
@@ -127,8 +127,14 @@ class LlamaDecoderLayerPipe(LlamaDecoderLayer):
         hidden_states, attention_mask, position_ids = parse_args(args)
         has_gradient = not hidden_states.stop_gradient
         if self.enable_recompute and self.config.recompute_granularity == "full" and has_gradient:
+            # TODO(Xreki): support kwargs for recompute when use_reentrant is True.
+            position_ids = None
             hidden_states = recompute(
-                super().forward, hidden_states, attention_mask=attention_mask, use_reentrant=False
+                super().forward,
+                hidden_states,
+                position_ids,
+                attention_mask,
+                use_reentrant=self.config.recompute_use_reentrant,
             )
         else:
             hidden_states = super().forward(hidden_states, attention_mask=attention_mask)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
预训练的一些优化，如`linear_fused_grad_add`，只有`recompute(..., use_reentrant=True)`才能支持。由于`recompute(..., use_reentrant=True)`暂时不支持解析kwargs，https://github.com/PaddlePaddle/PaddleNLP/pull/7235 中强制设置了`use_reentrant=False`，引起的问题是：
- 使用最新的PaddleNLP develop代码，跑llama类模型预训练且需要开启recompute时，无法开启全部优化
- Benchmark平台上2个配置一直运行失败，无法起到监控性能的作用

本PR将`recompute`传参的方式改成参数列表的方式，不使用`name=value`这种键值对的方式。一方面，修复Benchmark，保证PaddleNLP代码能够开启全部优化；另一方面，框架中也会加强recompute支持kwargs参数，但此种修改方式能保证PaddleNLP代码最大程度的兼容。

-----

由于新增`alibi`参数，避免手动传入多个参数的默认值，改成`if-else`的方式，区分pretrain和sft训练。