### PR TITLE
[chatglm] Fix attention_score -nan bug

### DIFF
--- a/paddlenlp/transformers/chatglm/modeling.py
+++ b/paddlenlp/transformers/chatglm/modeling.py
@@ -320,9 +320,10 @@ class ChatGLMAttention(nn.Layer):
                 self.scale_mask_softmax.scale = attention_scale_coeff
                 attention_probs = self.scale_mask_softmax(attention_scores, attention_mask)
             else:
+                attention_scores = attention_scores * attention_scale_coeff
                 attention_scores = attention_scores + attention_mask
                 attention_scores = attention_scores.astype("float32")
-                attention_scores = attention_scores * attention_scale_coeff
+
                 attention_probs = F.softmax(attention_scores, axis=-1)
                 attention_probs = attention_probs.astype(self.default_dtype)
                 v_layer = v_layer.astype(self.default_dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

reproduce code

```
inputs  = paddle.to_tensor([0.0, 1,2,-100],dtype='float32')
attention_mask = paddle.to_tensor([1,3,2,paddle.finfo(inputs.dtype).min],dtype='float32')
res = (inputs + attention_mask) *2
print(res)
```
output:

```
Tensor(shape=[4], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [ 2.  ,  8.  ,  8.  , -inf.])
```
