### PR TITLE
[Bug fixes] remove qwen 14b-chat special token testing

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -514,10 +514,6 @@ class ChatTemplate:
     system: str | None = None
     query: str = None
 
-    sep_token_id: int | None = None
-    eos_token_id: int | None = None
-    bos_token_id: int | None = None
-
     @staticmethod
     @lru_cache()
     def _compile_jinja_template(chat_template):
@@ -617,25 +613,6 @@ class ChatTemplate:
 
 class ChatTemplateMixin:
     chat_template: Optional[ChatTemplate] = None
-
-    @property
-    def chat_template_eos_token_id(self):
-        if self.chat_template.eos_token_id:
-            return self.chat_template.eos_token_id
-        return self.eos_token_id
-
-    @property
-    def chat_template_bos_token_id(self):
-        if self.chat_template.bos_token_id:
-            return self.chat_template.bos_token_id
-        return self.bos_token_id
-
-    @property
-    def chat_template_sep_token_id(self):
-        if self.chat_template.sep_token_id:
-            return self.chat_template.sep_token_id
-
-        return self.sep_token_id
 
     def apply_chat_template(
         self,

--- a/tests/transformers/test_chat_template.py
+++ b/tests/transformers/test_chat_template.py
@@ -151,16 +151,6 @@ class ChatTemplateIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(final_query, expected_query)
 
-        # 2. check the bos_token_id and eos_token_id
-        self.assertEqual(
-            tokenizer.convert_tokens_to_ids(["<|im_start|>"])[0],
-            tokenizer.chat_template_bos_token_id,
-        )
-        self.assertEqual(
-            tokenizer.convert_tokens_to_ids(["<|im_end|>"])[0],
-            tokenizer.chat_template_eos_token_id,
-        )
-
 
 @parameterized_class(
     ["model_name"],


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
移除掉 chat_template 中针对于自定义 eos_token_id 的支持

***

## chat系列模型为例描述问题

1. qwen-14b 模型作为预训练模型，eos_token_id 可能是</s>，可是 qwen-14b-chat 的模型作为 经过 instruction tuning 之后的模型，会存在对应的 special_token 来作为 eos-token-id，比如`<|im_end|>`，可是这个在 tokenizer 当中是不存在的，会通过一个`get_command` 的方法来强制塞一个token_id，本质上这个 `<|im_end|>` 在 vocab 当中是不存在的。
2. chatglm3 的模型存在多个不同的eos_token_id，具体可见：https://huggingface.co/THUDM/chatglm3-6b/blob/main/modeling_chatglm.py#L1033  这种理论上也是需要体现在配置文件当中的。


## 解决办法

* 针对于不同的 chat 类型模型，都要根据对应的官方示例代码来调整 generation_config.json 的eos_token_id 的字段内容，并且可以为 数组形式。

## 风险点

如果直接将 eos_token_id 设置为一个数组，可能会影响：`prepare_attention_mask_for_generation`  函数。