### PR TITLE
【LLama Config】Add refined-recompute config in Llama model

### DIFF
--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -609,6 +609,10 @@ class TrainingArguments:
             "Only support for networks with transformer blocks."
         },
     )
+    sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
+    refined_ops_patterns: Optional[List[str]] = field(
+        default=None, metadata={"help": "The pattern of refined recompute."}
+    )
 
     scale_loss: float = field(default=2**15, metadata={"help": "The value of initial scale_loss for fp16."})
 
@@ -1169,6 +1173,11 @@ class TrainingArguments:
             if self.recompute:
                 recompute = strategy.recompute
                 recompute.enable = True
+                recompute.sr = self.sr if self.sr is not None else 0
+                recompute.refined_ops_patterns = []
+                if self.refined_ops_patterns is not None:
+                    for pattern in self.refined_ops_patterns:
+                        recompute.refined_ops_patterns.append(eval(pattern))
 
             self.strategy = strategy
             logger.info(self.strategy)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Add refined-recompute config in Llama model
You can config the refined-recompute as follows:
```
--sr 0 \
--refined_ops_patterns "{\"main_ops\":[\"matmul_v2\", \"reshape2\", \"matmul_v2\", \"reshape2\", \"matmul_v2\", \"reshape2\"], \"num\": -1, \"pre_ops\":[\"elementwise_mul\"], \"suf_ops\":[\"slice\",\"slice\"]}" \
                        "{\"main_ops\":[\"matmul_v2\"], \"num\": -1, \"pre_ops\":[\"transpose2\", \"reshape2\"], \"suf_ops\":[\"elementwise_add\"]}" \
                        "{\"main_ops\":[\"matmul_v2\",\"silu\",\"matmul_v2\"], \"num\": -1, \"pre_ops\":[\"elementwise_mul\",\"elementwise_mul\"], \"suf_ops\":[\"elementwise_mul\",\"matmul_v2\"]}" \
                        "{\"main_ops\":[\"matmul_v2\"], \"num\": -1, \"pre_ops\":[\"matmul_v2\",\"silu\",\"matmul_v2\"], \"suf_ops\":[\"elementwise_add\"]}"\
```
⚠️When you config the `refined_ops_patterns`, every dictionary has a blank space at the end because `refined_ops_patterns` is a List of Dict