### PR TITLE
change log print

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1171,6 +1171,10 @@ class Trainer:
                 )
             )
 
+            if paddle.device.is_compiled_with_cuda():
+                logs["max_mem_reserved"] = paddle.device.cuda.max_memory_reserved()
+                logs["max_mem_allocated"] = paddle.device.cuda.max_memory_allocated()
+
             self._total_loss_scalar += tr_loss_scalar
             self._globalstep_last_logged = self.state.global_step
             self._globalstep_last_start_time = time.time()

--- a/paddlenlp/trainer/trainer_callback.py
+++ b/paddlenlp/trainer/trainer_callback.py
@@ -530,7 +530,7 @@ class PrinterCallback(TrainerCallback):
         _ = logs.pop("total_flos", None)
         if state.is_local_process_zero:
             if type(logs) is dict:
-                logger.info(", ".join(f"{k}: {v}" for k, v in logs.items()))
+                logger.info(" , ".join(f"{k}: {v}" for k, v in logs.items()))
             else:
                 logger.info(logs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
before
<img width="1309" alt="47167fe6727998b173d4f273808a5d00" src="https://github.com/PaddlePaddle/PaddleNLP/assets/137985359/bb42a8b2-e467-4333-bdfe-0b6f210b6977">
after
<img width="1304" alt="1ac115dbe60e7c101bea2f9b13d259b9" src="https://github.com/PaddlePaddle/PaddleNLP/assets/137985359/117ea146-8745-48d5-8357-e535115088d1">
为了性能数据打印方式符合benchmark框架规范，数值和逗号之间增加了空格，增加了max_mem_reserved、max_mem_allocated