### PR TITLE
[Bug fixes]fix pyyaml installing under py310

### DIFF
--- a/scripts/regression/requirements_ci.txt
+++ b/scripts/regression/requirements_ci.txt
@@ -4,7 +4,7 @@ protobuf==3.20.2
 regex
 attrdict==2.0.1
 easydict==1.10.0
-PyYAML==5.4.1
+PyYAML
 subword_nmt==0.3.7
 visualdl
 pandas


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Testing

### Description
<!-- Describe what this PR does -->
python310 下面没办法安装 PyYAML==5.4.1，所以这里直接安装最新的版本。