### PR TITLE
[Llama] Support skip_post_init_weights for llama in dygraph mode

### DIFF
--- a/llm/llama/run_pretrain_auto.py
+++ b/llm/llama/run_pretrain_auto.py
@@ -453,7 +453,8 @@ def main():
         if training_args.bf16:
             dtype = "bfloat16"
 
-    model = model_class._from_config(config, dtype=dtype)
+    with paddle.LazyGuard():
+        model = model_class._from_config(config, dtype=dtype)
 
     if training_args.recompute:
 
@@ -500,9 +501,11 @@ def main():
     def loss_func(loss, outputs):
         return loss
 
-    total_train_batch_size = training_args.per_device_train_batch_size \
-                             * training_args.gradient_accumulation_steps \
-                             * training_args.data_parallel_degree
+    total_train_batch_size = (
+        training_args.per_device_train_batch_size
+        * training_args.gradient_accumulation_steps
+        * training_args.data_parallel_degree
+    )
     print_config(training_args)
 
     engine = auto.Engine(model, loss_func, optimizer, strategy=training_args.strategy)

--- a/paddlenlp/transformers/llama/modeling_auto.py
+++ b/paddlenlp/transformers/llama/modeling_auto.py
@@ -685,39 +685,6 @@ class LlamaPretrainedModelAuto(PretrainedModel):
 
         return mappings
 
-    def _init_weights(self, layer):
-        """Initialization hook"""
-        if isinstance(
-            layer,
-            (
-                nn.Linear,
-                nn.Embedding,
-                LlamaLMHeadAuto,
-            ),
-        ):
-            # In the dygraph mode, use the `set_value` to reset the parameter directly,
-            # and reset the `state_dict` to update parameter in static mode.
-            if isinstance(layer.weight, paddle.Tensor):
-                layer.weight.set_value(
-                    paddle.tensor.normal(
-                        mean=0.0,
-                        std=self.config.initializer_range
-                        if hasattr(self.config, "initializer_range")
-                        else self.llama.config.initializer_range,
-                        shape=layer.weight.shape,
-                    )
-                )
-        # Layer.apply is DFS https://github.com/PaddlePaddle/Paddle/blob/a6f5021fcc58b21f4414bae6bf4731ef6971582c/python/paddle/nn/layer/layers.py#L527-L530
-        # sublayer is init first
-        # scale RowParallelLinear weight
-        with paddle.no_grad():
-            if isinstance(layer, LlamaMLPAuto):
-                factor = 1 / math.sqrt(2 * self.config.num_hidden_layers)
-                layer.down_proj.weight.scale_(factor)
-            if isinstance(layer, LlamaAttentionAuto):
-                factor = 1 / math.sqrt(2 * self.config.num_hidden_layers)
-                layer.o_proj.weight.scale_(factor)
-
 
 @register_base_model
 class LlamaModelAuto(LlamaPretrainedModelAuto):
@@ -994,10 +961,9 @@ class LlamaForCausalLMAuto(LlamaPretrainedModelAuto):
         super().__init__(config)
         self.config = config
 
-        with paddle.LazyGuard():
-            self.llama = LlamaModelAuto(config)
-            self.lm_head = LlamaLMHeadAuto(config)
-            self.criterion = LlamaPretrainingCriterionAuto(config)
+        self.llama = LlamaModelAuto(config)
+        self.lm_head = LlamaLMHeadAuto(config)
+        self.criterion = LlamaPretrainingCriterionAuto(config)
 
     def get_input_embeddings(self):
         return self.llama.embed_tokens


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
[Llama] Support skip_post_init_weights for llama in dygraph mode

由于`PretrainedModel._init_weights`与半自动架构不适配，因此删掉了Llama静半组网中的`_init_weights`实现，并为动手Llama增加了`skip_post_init_weights`开关，开启后会跳过`PretrainedModel._init_weights`逻辑，采用框架原本的初始化参数；方便与半自动Llama对齐精度