### PR TITLE
删除tipc中对于paddlemix的依赖

### DIFF
--- a/tests/test_tipc/benchmark/modules/stablediffusion.py
+++ b/tests/test_tipc/benchmark/modules/stablediffusion.py
@@ -26,9 +26,6 @@ from paddle.vision import BaseTransform, transforms
 from paddlenlp.transformers import CLIPTextModel, CLIPTokenizer
 from paddlenlp.utils.downloader import get_path_from_url_with_filelock
 from paddlenlp.utils.log import logger
-from ppdiffusers import AutoencoderKL, DDPMScheduler, UNet2DConditionModel
-from ppdiffusers.training_utils import main_process_first
-from ppdiffusers.utils import PPDIFFUSERS_CACHE
 
 from .model_base import BenchmarkBase
 
@@ -54,6 +51,8 @@ class Lambda(BaseTransform):
 class StableDiffusion(nn.Layer):
     def __init__(self, args):
         super().__init__()
+        from ppdiffusers import AutoencoderKL, DDPMScheduler, UNet2DConditionModel
+
         self.args = args
         self.unet = UNet2DConditionModel.from_pretrained(url_or_path_join(args.model_name_or_path, "unet"))
         self.vae = AutoencoderKL.from_pretrained(url_or_path_join(args.model_name_or_path, "vae"))
@@ -205,6 +204,9 @@ class StableDiffusionBenchmark(BenchmarkBase):
             examples["input_ids"] = tokenize_captions(examples)
 
             return examples
+
+        from ppdiffusers.training_utils import main_process_first
+        from ppdiffusers.utils import PPDIFFUSERS_CACHE
 
         file_path = get_path_from_url_with_filelock(
             "https://paddlenlp.bj.bcebos.com/models/community/junnyu/develop/pokemon-blip-captions.tar.gz",

--- a/tests/test_tipc/prepare.sh
+++ b/tests/test_tipc/prepare.sh
@@ -424,13 +424,5 @@ elif [ ${MODE} = "benchmark_train" ];then
     python -m pip install -e ../
     # python -m pip install paddlenlp    # PDC 镜像中安装失败
     python -m pip list
-    export http_proxy=${HTTP_PRO}
-    export https_proxy=${HTTPS_PRO}
-    # install develop paddlemix/ppdiffusers
-    git clone https://github.com/PaddlePaddle/PaddleMIX.git
-    unset http_proxy
-    unset https_proxy
-    cd PaddleMIX
-    python -m pip install -e ./ppdiffusers
     cd -
 fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
移出paddlemix的依赖，有关sd的tipc测试已经迁移到paddlemix中
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
