### PR TITLE
[chatglm] Fix fp16 o1 bugs

### DIFF
--- a/paddlenlp/transformers/chatglm/modeling.py
+++ b/paddlenlp/transformers/chatglm/modeling.py
@@ -320,9 +320,9 @@ class ChatGLMAttention(nn.Layer):
                 self.scale_mask_softmax.scale = attention_scale_coeff
                 attention_probs = self.scale_mask_softmax(attention_scores, attention_mask)
             else:
+                attention_scores = attention_scores.astype("float32")
                 attention_scores = attention_scores * attention_scale_coeff
                 attention_scores = attention_scores + attention_mask
-                attention_scores = attention_scores.astype("float32")
 
                 attention_probs = F.softmax(attention_scores, axis=-1)
                 attention_probs = attention_probs.astype(self.default_dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

c = a +b 
其中c的类型会跟a一样，如果是O1的模式，Fp16的数+fp32的数，会超过fp16的表示范围，即有溢出的风险

```
>>> import paddle
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
>>> a1 = paddle.to_tensor([1,2,3],dtype='float16')
>>> b1 = paddle.to_tensor([1,2,paddle.finfo(paddle.float32).min])
>>> a1
Tensor(shape=[3], dtype=float16, place=Place(gpu:0), stop_gradient=True,
       [1., 2., 3.])
>>> b1
Tensor(shape=[3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [ 1.                                      ,
         2.                                      ,
        -340282346638528859811704183484516925440.])
>>> c1 = a1+b1
W1129 09:56:41.458557  9191 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 11.7
W1129 09:56:41.464223  9191 gpu_resources.cc:164] device: 0, cuDNN Version: 8.4.
>>> c1
Tensor(shape=[3], dtype=float16, place=Place(gpu:0), stop_gradient=True,
       [ 2.  ,  4.  , -inf.])
>>> d1 = b1 + a1
>>> d1
Tensor(shape=[3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [ 2.                                      ,
         4.                                      ,
        -340282346638528859811704183484516925440.])
>>> 
```
