### PR TITLE
add scale dtype test for weight quantize

### DIFF
--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -24,8 +24,7 @@ from paddle.incubate.nn.functional import (
 )
 from paddle.nn import Layer
 from paddle.nn.initializer import Constant
-from paddle.nn.quant import weight_only_linear
-
+from paddle.nn.quant import weight_only_linear, weight_quantize
 from paddlenlp.utils.import_utils import is_paddlenlp_ops_available
 from paddlenlp.utils.log import logger
 
@@ -808,7 +807,11 @@ class FusedMultiTransformerWeightOnly(FusedMultiTransformerBase):
 
         assert self.weight_only_quant_bits != -1
         self.weight_dtype = "int" + str(self.weight_only_quant_bits)
-
+        # test for weight only quant scale
+        _, quant_weight_dtype_test_scale_tensor = weight_quantize(
+            paddle.ones(shape=[64,64], dtype='float16'), algo="weight_only_int" + str(self.weight_only_quant_bits)
+        )
+        self.weight_scale_dtype = quant_weight_dtype_test_scale_tensor.dtype
         self.qkv_weights_scale = []
         self.linear_weights_scale = []
         self.ffn1_weights_scale = []
@@ -824,28 +827,28 @@ class FusedMultiTransformerWeightOnly(FusedMultiTransformerBase):
             qkv_weight_scale = self.create_parameter(
                 shape=[(config.num_heads + 2 * config.kv_num_heads) * self.head_dim],
                 attr=qkv_weight_scale_attr,
-                dtype=paddle.float32,
+                dtype=self.weight_scale_dtype,
                 is_bias=False,
             )
 
             linear_weight_scale = self.create_parameter(
                 shape=[config.embed_dim],
                 attr=linear_weight_scale_attr,
-                dtype=paddle.float32,
+                dtype=self.weight_scale_dtype,
                 is_bias=False,
             )
 
             ffn1_weight_scale = self.create_parameter(
                 shape=[config.dim_feedforward * 2] if config.activation.endswith("glu") else [config.dim_feedforward],
                 attr=ffn1_weight_scale_attr,
-                dtype=paddle.float32,
+                dtype=self.weight_scale_dtype,
                 is_bias=False,
             )
 
             ffn2_weight_scale = self.create_parameter(
                 shape=[config.embed_dim],
                 attr=ffn2_weight_scale_attr,
-                dtype=paddle.float32,
+                dtype=self.weight_scale_dtype,
                 is_bias=False,
             )
 

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -25,6 +25,7 @@ from paddle.incubate.nn.functional import (
 from paddle.nn import Layer
 from paddle.nn.initializer import Constant
 from paddle.nn.quant import weight_only_linear, weight_quantize
+
 from paddlenlp.utils.import_utils import is_paddlenlp_ops_available
 from paddlenlp.utils.log import logger
 
@@ -809,7 +810,7 @@ class FusedMultiTransformerWeightOnly(FusedMultiTransformerBase):
         self.weight_dtype = "int" + str(self.weight_only_quant_bits)
         # test for weight only quant scale
         _, quant_weight_dtype_test_scale_tensor = weight_quantize(
-            paddle.ones(shape=[64,64], dtype='float16'), algo="weight_only_int" + str(self.weight_only_quant_bits)
+            paddle.ones(shape=[64, 64], dtype="float16"), algo="weight_only_int" + str(self.weight_only_quant_bits)
         )
         self.weight_scale_dtype = quant_weight_dtype_test_scale_tensor.dtype
         self.qkv_weights_scale = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Function optimization

### PR changes
Models

### Description
Add scale dtype test ofr weight quantize, support both float or half/bfloat for weight scale
