### PR TITLE
[CLIP] 确保CLIP静态图导出的时候使用的是1D tensor

### DIFF
--- a/paddlenlp/transformers/clip/modeling.py
+++ b/paddlenlp/transformers/clip/modeling.py
@@ -827,7 +827,10 @@ class CLIPTextTransformer(nn.Layer):
                 paddle.stack(
                     [
                         paddle.arange(last_hidden_state.shape[0], dtype="int32"),
-                        (input_ids == self.eos_token_id).cast("int32").argmax(axis=-1, dtype="int32"),
+                        # make sure we have 1D tensor, not 0D tensor
+                        (input_ids == paddle.to_tensor([self.eos_token_id], dtype=input_ids.dtype))
+                        .cast("int32")
+                        .argmax(axis=-1, dtype="int32"),
                     ],
                     axis=-1,
                 )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
```python
self.eos_token_id = 2
# 下面的这个代码，静态图导出时候会导出0D tensor。因此需要确保将其转为1D tensor
input_ids == self.eos_token_id
```