### PR TITLE
template.py AutoTemplate.load_from method read file with encoding utf8

### DIFF
--- a/paddlenlp/prompt/template.py
+++ b/paddlenlp/prompt/template.py
@@ -854,7 +854,7 @@ class AutoTemplate(object):
         template_config_file = os.path.join(data_path, TEMPLATE_CONFIG_FILE)
         if not os.path.isfile(template_config_file):
             raise ValueError("{} not found under {}".format(TEMPLATE_CONFIG_FILE, data_path))
-        with open(template_config_file, "r") as fp:
+        with open(template_config_file, "r", encoding="utf-8") as fp:
             config = [x.strip() for x in fp]
             prompt = json.loads(config[0])
             if len(config) > 1:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others 

### Description
because **Template.save** write to file with encoding utf-8, however AutoTemplate.load_from() read file with platform default encoding, So when the default encoding is GBK，AutoTemplate.load_from() will read a utf8 encoded file with gbk, this will throw error.

**Template.save()**
~~~python
    def save(self, save_path):
        if not os.path.exists(save_path):
            os.makedirs(save_path, exist_ok=True)
        template_config_file = os.path.join(save_path, TEMPLATE_CONFIG_FILE)
        template_class = self.__class__.__name__
        with open(template_config_file, "w", encoding="utf-8") as fp:
            fp.write(json.dumps(self._prompt, ensure_ascii=False) + "\n")
            fp.write(json.dumps({"class": template_class}, ensure_ascii=False) + "\n")
        template_param_file = os.path.join(save_path, TEMPLATE_PARAMETER_FILE)
~~~

**AutoTemplate.load_from()**
~~~python
    def load_from(
        cls, data_path: os.PathLike, tokenizer: PretrainedTokenizer, max_length: int, model: PretrainedModel = None
    ):
        template_config_file = os.path.join(data_path, TEMPLATE_CONFIG_FILE)
        if not os.path.isfile(template_config_file):
            raise ValueError("{} not found under {}".format(TEMPLATE_CONFIG_FILE, data_path))
        with open(template_config_file, "r") as fp:
            config = [x.strip() for x in fp]
            prompt = json.loads(config[0])
            if len(config) > 1:
                template_class = json.loads(config[1])["class"]
~~~