### PR TITLE
Set flash_attn mask to None in LlamaPretrainedModelAuto

### DIFF
--- a/paddlenlp/transformers/llama/modeling_auto.py
+++ b/paddlenlp/transformers/llama/modeling_auto.py
@@ -54,7 +54,6 @@ from .modeling import (
     apply_rotary_pos_emb,
     build_alibi_tensor,
     get_triangle_upper_mask,
-    is_casual_mask,
     repeat_kv,
     rms_norm_fused,
 )
@@ -823,9 +822,8 @@ class LlamaModelAuto(LlamaPretrainedModelAuto):
             attention_mask, (batch_size, seq_length), cache_length, inputs_embeds.dtype
         )  # [bs, 1, seq_len, seq_len]
         if self.config.use_flash_attention:
-            is_casual = is_casual_mask(attention_mask)
-            if is_casual and alibi is None:
-                attention_mask = None
+            # attention_mask in flash_attn is always None for pretrain
+            attention_mask = None
         hidden_states = inputs_embeds
 
         # decoder layers


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
<!-- Describe what this PR does -->
Llama预训练模型通过`is_casual_mask`函数判断flash_attn的`attention_mask`参数，这在组网中引入了控制流操作，导致静半新IR无法跑通（新IR控制流机制正在支持中...）。
由于预训练场景下并不需要`attention_mask`，相关判断逻辑是冗余的，本PR临时修改组网，直接将`attention_mask`设置为`None`，以在组网中消除控制流操作。
