### PR TITLE
add to_static for electra

### DIFF
--- a/model_zoo/electra/run_pretrain.py
+++ b/model_zoo/electra/run_pretrain.py
@@ -344,8 +344,8 @@ def create_input_specs():
     token_type_ids = None
     position_ids = None
     attention_mask = None
-    raw_input_ids = paddle.static.InputSpec(name="raw_input_ids", shape=[-1, -1], dtype="float32")
-    generator_labels = paddle.static.InputSpec(name="generator_labels", shape=[-1, -1], dtype="float32")
+    raw_input_ids = paddle.static.InputSpec(name="raw_input_ids", shape=[-1, -1], dtype="int64")
+    generator_labels = paddle.static.InputSpec(name="generator_labels", shape=[-1, -1], dtype="int64")
     return [input_ids, token_type_ids, position_ids, attention_mask, raw_input_ids, generator_labels]
 
 

--- a/model_zoo/electra/run_pretrain.py
+++ b/model_zoo/electra/run_pretrain.py
@@ -471,10 +471,6 @@ def do_train(args):
                 continue
             global_step += 1
             input_ids, raw_input_ids, gen_labels = batch
-            # print('batch')
-            # print(input_ids.shape)
-            # print(raw_input_ids.shape)
-            # print(gen_labels.shape)
             if args.use_amp:
                 with paddle.amp.auto_cast():
                     gen_logits, disc_logits, disc_labels, attention_mask = model(

--- a/model_zoo/electra/run_pretrain.py
+++ b/model_zoo/electra/run_pretrain.py
@@ -24,6 +24,7 @@ import time
 import numpy as np
 import paddle
 
+from paddlenlp.trainer.argparser import strtobool
 from paddlenlp.transformers import (
     ElectraForTotalPretraining,
     ElectraPretrainingCriterion,
@@ -121,6 +122,8 @@ def parse_args():
         choices=["cpu", "gpu"],
         help="The device to select to train the model, is must be cpu/gpu.",
     )
+    parser.add_argument("--to_static", type=strtobool, default=False, help="Enable training under @to_static.")
+
     args = parser.parse_args()
     return args
 
@@ -336,6 +339,16 @@ def create_dataloader(dataset, mode="train", batch_size=1, use_gpu=True, data_co
     return dataloader
 
 
+def create_input_specs():
+    input_ids = paddle.static.InputSpec(name="input_ids", shape=[-1, -1], dtype="int64")
+    token_type_ids = None
+    position_ids = None
+    attention_mask = None
+    raw_input_ids = paddle.static.InputSpec(name="raw_input_ids", shape=[-1, -1], dtype="float32")
+    generator_labels = paddle.static.InputSpec(name="generator_labels", shape=[-1, -1], dtype="float32")
+    return [input_ids, token_type_ids, position_ids, attention_mask, raw_input_ids, generator_labels]
+
+
 def do_train(args):
     paddle.enable_static() if not args.eager_run else None
     paddle.set_device(args.device)
@@ -383,6 +396,11 @@ def do_train(args):
     criterion = ElectraPretrainingCriterion(config)
     if paddle.distributed.get_world_size() > 1:
         model = paddle.DataParallel(model)
+    # decorate @to_static for benchmark, skip it by default.
+    if args.to_static:
+        specs = create_input_specs()
+        model = paddle.jit.to_static(model, input_spec=specs)
+        logger.info("Successfully to apply @to_static to the whole model with specs: {}.".format(specs))
 
     # Loads dataset.
     tic_load_data = time.time()
@@ -453,6 +471,10 @@ def do_train(args):
                 continue
             global_step += 1
             input_ids, raw_input_ids, gen_labels = batch
+            # print('batch')
+            # print(input_ids.shape)
+            # print(raw_input_ids.shape)
+            # print(gen_labels.shape)
             if args.use_amp:
                 with paddle.amp.auto_cast():
                     gen_logits, disc_logits, disc_labels, attention_mask = model(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/community/pull/751

## 为 electra 模型接入动转静



**训练环境**

  ```shell
  cd model_zoo/electra
  export CUDA_VISIBLE_DEVICES="0"
  export DATA_DIR=./BookCorpus/
  ```

**训练结果**
- 动态图

  运行命令
  ```shell
  python -u ./run_pretrain.py \
      --model_type electra \
      --model_name_or_path electra-small \
      --input_dir $DATA_DIR \
      --output_dir ./pretrain_model/ \
      --train_batch_size 8 \
      --learning_rate 5e-4 \
      --max_seq_length 128 \
      --weight_decay 1e-2 \
      --adam_epsilon 1e-6 \
      --warmup_steps 10000 \
      --num_train_epochs 4 \
      --logging_steps 100 \
      --save_steps 10000 \
      --max_steps -1 \
      --device gpu

  ```
  运行结果
  ![image](https://github.com/PaddlePaddle/PaddleNLP/assets/99723454/3d130b1c-7ace-410f-b4b7-9d053125d16e)

- 静态图 SOT模式
  运行命令
  ```shell
  export GRAPH_SIZE=0 COST_MODEL=False ENABLE_FALL_BACK=True
  python -u ./run_pretrain.py \
      --model_type electra \
      --model_name_or_path electra-small \
      --input_dir $DATA_DIR \
      --output_dir ./pretrain_model/ \
      --train_batch_size 8 \
      --learning_rate 5e-4 \
      --max_seq_length 128 \
      --weight_decay 1e-2 \
      --adam_epsilon 1e-6 \
      --warmup_steps 10000 \
      --num_train_epochs 4 \
      --logging_steps 100 \
      --save_steps 10000 \
      --max_steps -1 \
      --device gpu \
      --to_static True
  ```
  运行结果
  ![image](https://github.com/PaddlePaddle/PaddleNLP/assets/99723454/df313c53-32f2-4d45-959e-aac1d353bd4f)


- 静态图 AST模式
   运行命令
  ```shell
  export COST_MODEL=False ENABLE_FALL_BACK=False
  python -u ./run_pretrain.py \
      --model_type electra \
      --model_name_or_path electra-small \
      --input_dir $DATA_DIR \
      --output_dir ./pretrain_model/ \
      --train_batch_size 8 \
      --learning_rate 5e-4 \
      --max_seq_length 128 \
      --weight_decay 1e-2 \
      --adam_epsilon 1e-6 \
      --warmup_steps 10000 \
      --num_train_epochs 4 \
      --logging_steps 100 \
      --save_steps 10000 \
      --max_steps -1 \
      --device gpu \
      --to_static True
  ```
  运行结果
  ![image](https://github.com/PaddlePaddle/PaddleNLP/assets/99723454/dbf3f228-facc-4f6f-8faa-98eb6d46c443)

