### PR TITLE
[Dist Dataloader] Fix dist dataloader sampler

### DIFF
--- a/paddlenlp/data/dist_dataloader.py
+++ b/paddlenlp/data/dist_dataloader.py
@@ -16,7 +16,6 @@ import numpy as np
 import paddle
 from paddle.distributed import fleet
 
-from paddlenlp.utils.batch_sampler import DistributedBatchSampler
 from paddlenlp.utils.log import logger
 
 _MAX_DATA_DIM = 64
@@ -58,7 +57,6 @@ class DistDataLoader(paddle.io.DataLoader):
 
         if dataset is None:
             dataset = DummyDataset()
-            batch_sampler = DistributedBatchSampler(dataset, 1)
             logger.info("rank has no data, use Dummpy dataset")
 
         super().__init__(dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn, num_workers=num_workers)

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1104,10 +1104,7 @@ class Trainer:
                 num_workers=self.args.dataloader_num_workers,
             )
 
-        if self.args.should_load_dataset:
-            train_sampler = self._get_train_sampler()
-        else:
-            train_sampler = None
+        train_sampler = self._get_train_sampler()
 
         if self.args.distributed_dataloader:
             logger.info("Training using DistDataLoader.")
@@ -1184,10 +1181,7 @@ class Trainer:
                 num_workers=self.args.dataloader_num_workers,
             )
 
-        if self.args.should_load_dataset:
-            eval_sampler = self._get_eval_sampler(eval_dataset)
-        else:
-            eval_sampler = None
+        eval_sampler = self._get_eval_sampler(eval_dataset)
 
         if self.args.distributed_dataloader:
             logger.info("Eval using DistDataLoader.")
@@ -1237,10 +1231,7 @@ class Trainer:
                 num_workers=self.args.dataloader_num_workers,
             )
 
-        if self.args.should_load_dataset:
-            test_sampler = self._get_eval_sampler(test_dataset)
-        else:
-            test_sampler = None
+        test_sampler = self._get_eval_sampler(test_dataset)
 
         if self.args.distributed_dataloader:
             logger.info("Test using DistDataLoader.")

--- a/paddlenlp/utils/batch_sampler.py
+++ b/paddlenlp/utils/batch_sampler.py
@@ -106,7 +106,10 @@ class DistributedBatchSampler(paddle.io.BatchSampler):
         self.epoch = 0
 
         self.consumed_samples = consumed_samples
-        self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.nranks))
+        if self.dataset is None:
+            self.num_samples = 1
+        else:
+            self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.nranks))
         self.total_size = self.num_samples * self.nranks
 
     def get_start_end_idx(self):

--- a/paddlenlp/utils/batch_sampler.py
+++ b/paddlenlp/utils/batch_sampler.py
@@ -107,7 +107,8 @@ class DistributedBatchSampler(paddle.io.BatchSampler):
 
         self.consumed_samples = consumed_samples
         if self.dataset is None:
-            self.num_samples = 1
+            # In pre-training mode when using distributed dataloader, the input dataset can be None. We should handle this situation.
+            self.num_samples = 0
         else:
             self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.nranks))
         self.total_size = self.num_samples * self.nranks


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
To ensure when using distributed dataloader, no matter the process has dataset or not, the type of train_sampler is the same.
