### PR TITLE
[Pretrain] Fix Qwen paddle.outer calculation

### DIFF
--- a/paddlenlp/transformers/qwen/modeling.py
+++ b/paddlenlp/transformers/qwen/modeling.py
@@ -982,7 +982,8 @@ class RotaryEmbedding(nn.Layer):
             self._seq_len_cached = max(2 * seqlen, 16)
             self._ntk_alpha_cached = ntk_alpha
             seq = paddle.arange(self._seq_len_cached)
-            freqs = paddle.outer(seq.astype(self.inv_freq.dtype), self.inv_freq)
+            with paddle.amp.auto_cast(enable=False):
+                freqs = paddle.outer(seq.astype(self.inv_freq.dtype), self.inv_freq)
             emb = paddle.concat([freqs, freqs], axis=-1)
             self.cos_cached = emb.cos()[None, :, None, :]
             self.sin_cached = emb.sin()[None, :, None, :]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Performance optimization

### PR changes
Others

### Description
Since `paddle.outer` is composed of `matmul`, and `matmul` is added to amp_white_list. When the two inputs are `float32` dtype, the calculation is still under amp, which may cause loss of accuracy.