### PR TITLE
[Bug fixes]disable chat-template in tipc

### DIFF
--- a/tests/test_tipc/llm/inference/run_predictor.sh
+++ b/tests/test_tipc/llm/inference/run_predictor.sh
@@ -28,7 +28,7 @@ data_file=${data_file:-"tests/fixtures/llm/zh_query.json"}
 benchmark=${benchmark:-"0"}
 
 common_arguments="--decode_strategy ${decode_strategy} --src_length 300 --max_length 200 --benchmark ${benchmark} --dtype ${dtype} --batch_size 3 --inference_model ${inference_model} "
-common_arguments+="--data_file ${data_file} --top_p ${top_p}"
+common_arguments+="--data_file ${data_file} --top_p ${top_p} --chat_template none"
 
 echo "pwd -> "
 

--- a/tests/test_tipc/llm/inference/run_predictor_precaches.sh
+++ b/tests/test_tipc/llm/inference/run_predictor_precaches.sh
@@ -28,7 +28,7 @@ common_arguments="--decode_strategy ${decode_strategy} --src_length 300 --max_le
 if [ $fused_model ]; then
     common_arguments+=" --inference_model "
 fi
-common_arguments+="--data_file ${data_file} --top_p ${top_p} --benchmark ${benchmark}"
+common_arguments+="--data_file ${data_file} --top_p ${top_p} --benchmark ${benchmark} --chat_template none"
 
 cd ..
 echo "precache ing"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Testing

### Description
<!-- Describe what this PR does -->
在predictor 当中禁用掉 chat_template，防止精度和之前的不匹配。