### PR TITLE
[Bug fixes] fix tokenizer decode-tokens

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -1712,7 +1712,8 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
             # from byte fallback tokenization.
             # If it's in the middle, it's probably a real invalid id generated
             # by the model
-            new_text = new_text[len(prefix_text) :]
+            prefix_index = new_text.index(prefix_text)
+            new_text = new_text[prefix_index + len(prefix_text) :]
             return new_text, read_offset, len(all_input_ids)
         else:
             return "", prefix_offset, read_offset


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Tokenizer

### Description
<!-- Describe what this PR does -->
在流式输出的过程中，部分 tokenizer 会在文本的前面添加空格，比如：


prefix_token="提问"
new_text=" 提问</s>"

此时就导致文本截断出现问题。
