### PR TITLE
[Bug fixes][LLM] fix sharded file state dict load

### DIFF
--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -676,6 +676,8 @@ class LlamaForCausalLMInferenceModel(GenerationInferenceModel, LlamaPretrainedMo
     """
 
     _keys_to_ignore_on_load_missing = [r"lm_head.weight"]
+    _ignore_fliter_dict_keys_check = True
+    _need_set_full_state_dict = True
 
     def __init__(self, config):
         super().__init__(config)

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1872,7 +1872,9 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 state_dict = load_state_dict(
                     shard_file,
                     tp_actions if pre_tensor_parallel_split else None,
-                    None if config.quantization_config.is_weight_quantize() or cls._ignore_fliter_dict_keys_check else set(expected_keys),
+                    None
+                    if config.quantization_config.is_weight_quantize() or cls._ignore_fliter_dict_keys_check
+                    else set(expected_keys),
                 )
                 if config.quantization_config.is_weight_quantize():
                     state_dict = convert_to_quantize_state_dict(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

#### 问题描述
* 有的模型权重采用sharded file的方式来存储的，在当前sharded file load state dict的逻辑中，只支持权重state_dict和模型state_dict的key一致的前提的加载

<div align=center>
<img width="300" alt="image" src="https://github.com/PaddlePaddle/PaddleNLP/assets/77946882/39094673-d6a6-4583-bf98-e7ec6a9c74e9">
</div>

* 在llm inference model中，加载sharded file权重时，inference model的state_dict与它需要加载的权重的state_dict的key不一致，所以会发生报错
    * https://github.com/PaddlePaddle/PaddleNLP/blob/develop/paddlenlp/experimental/transformers/llama/modeling.py#L426
    * 之前这些权重都是单个文件，而不是sharded file

* 在llm inference model中，重写了set_state_dict方法，只支持完整的state_dict一次性set，而不支持shard state dict分次set

<div align=center>
<img width="400" alt="image" src="https://github.com/PaddlePaddle/PaddleNLP/assets/77946882/addc4463-e77f-4aa9-8b9d-8cc85826bebd">
</div>

#### 解决方案
* 本PR提供了一种修复方式，在PretrainedModel中提供了_ignore_fliter_dict_keys_check和_need_set_full_state_dict两个参数
    * _ignore_fliter_dict_keys_check控制在loaded state dict的时候，是否根据expected_keys（即model.state_dict().keys()）对加载的权重进行过滤
    * _need_set_full_state_dict控制在sharded file权重时，选择使用sharded_state_dict还是full_state_dict进行权重加载
        * 在inference_model中，因为对set_state_dict方法进行了重写，所以需要full_state_dict
        * 在一般的模型中的set_state_dict封装了一层try catch，所以对sharded_state_dict也可以加载，https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/nn/layer/layers.py#L2078
