### PR TITLE
Fix shared weights sync for PipelineLayer

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -939,12 +939,12 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             self.init_weights()
 
         # Note:
-        # 1. PipelineLayer will create parameters for each layers and
-        # call _synchronize_shared_weights() to synchronize the shared parameters.
-        # 2. When set model state_dict, the _synchronize_shared_weights will be called to
+        # 1. PipelineLayer will create parameters for each layer and
+        # call `_synchronize_shared_weights()` to synchronize the shared parameters.
+        # 2. When setting the model `state_dict`, `_synchronize_shared_weights` will be called to
         # synchronize the shared parameters.
-        # However, self._init_weights will re-initialize the parameters and
-        # without synchronize the shared parameters. If the following step will not load checkpoint,
+        # However, `self._init_weights` will re-initialize the parameters without
+        # synchronizing the shared parameters. If the following step does not load a checkpoint,
         # the shared parameters will be different.
 
         if isinstance(self, PipelineLayer):

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -42,7 +42,10 @@ from huggingface_hub import (
 )
 from huggingface_hub.utils import EntryNotFoundError
 from paddle import Tensor
-from paddle.distributed.fleet.meta_parallel.parallel_layers import SharedLayerDesc
+from paddle.distributed.fleet.meta_parallel.parallel_layers import (
+    PipelineLayer,
+    SharedLayerDesc,
+)
 from paddle.nn import Embedding, Layer
 
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
@@ -934,6 +937,18 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             and self.__class__.init_weights is PretrainedModel.init_weights
         ):
             self.init_weights()
+
+        # Note:
+        # 1. PipelineLayer will create parameters for each layers and
+        # call _synchronize_shared_weights() to synchronize the shared parameters.
+        # 2. When set model state_dict, the _synchronize_shared_weights will be called to
+        # synchronize the shared parameters.
+        # However, self._init_weights will re-initialize the parameters and
+        # without synchronize the shared parameters. If the following step will not load checkpoint,
+        # the shared parameters will be different.
+
+        if isinstance(self, PipelineLayer):
+            self._synchronize_shared_weights()
 
     def _init_weights(self, layer):
         """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. PipelineLayer will create parameters for each layer and call `_synchronize_shared_weights()` to synchronize the shared parameters.
2. When setting the model `state_dict`, `_synchronize_shared_weights` will be called to synchronize the shared parameters. However, `self._init_weights` will re-initialize the parameters without synchronizing the shared parameters. If the following step does not load a checkpoint, the shared parameters will be different.