### PR TITLE
[LLM] Fix v100 csrc building

### DIFF
--- a/csrc/generation/dequant_int8.cu
+++ b/csrc/generation/dequant_int8.cu
@@ -106,8 +106,10 @@ std::vector<paddle::Tensor> LaunchDequantInt8(const paddle::Tensor& input,
 
     if (dtype == "float32")
         data_type = paddle::DataType::FLOAT32;
+#ifdef CUDA_ENABLE_BF16
     else if (dtype == "bfloat16")
         data_type = paddle::DataType::BFLOAT16;
+#endif
     else if (dtype ==  "float16")
         data_type = paddle::DataType::FLOAT16;
     else 
@@ -116,9 +118,11 @@ std::vector<paddle::Tensor> LaunchDequantInt8(const paddle::Tensor& input,
                 "Only bfloat16, float16 and float32 are supported. ");
 
     switch (data_type) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: 
             return DispatchLaunchDequantInt8<paddle::DataType::BFLOAT16>(input, scale);
             break;
+#endif
         case paddle::DataType::FLOAT16: 
             return DispatchLaunchDequantInt8<paddle::DataType::FLOAT16>(input, scale);
             break;
@@ -145,8 +149,10 @@ std::vector<paddle::DataType> DequantInt8Dtype(const paddle::DataType& input_dty
     paddle::DataType data_type;
     if (dtype == "float32")
         data_type = paddle::DataType::FLOAT32;
+#ifdef CUDA_ENABLE_BF16
     else if (dtype == "bfloat16")
         data_type = paddle::DataType::BFLOAT16;
+#endif
     else if (dtype ==  "float16")
         data_type = paddle::DataType::FLOAT16;
     else 

--- a/csrc/generation/encode_rotary_qk.cu
+++ b/csrc/generation/encode_rotary_qk.cu
@@ -193,11 +193,13 @@ void RotaryQK(const paddle::Tensor& q,
               const int32_t rotary_emb_dims, 
               bool use_neox) {
     switch (q.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return LaunchRotaryQK<paddle::DataType::BFLOAT16>(
                 q, kv, rotary_emb, seq_lens, rotary_emb_dims, use_neox
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return LaunchRotaryQK<paddle::DataType::FLOAT16>(
                 q, kv, rotary_emb, seq_lens, rotary_emb_dims, use_neox

--- a/csrc/generation/helper.h
+++ b/csrc/generation/helper.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "paddle/extension.h"
-#include <cub/cub.cuh>
 #include <curand_kernel.h>
 
 constexpr int kBlockSize = 256; 
@@ -71,12 +70,14 @@ public:
   typedef paddle::float16 data_t;
 };
 
+#ifdef CUDA_ENABLE_BF16
 template <>
 class PDTraits<paddle::DataType::BFLOAT16> {
 public:
   typedef __nv_bfloat16 DataType;
   typedef paddle::bfloat16 data_t;
 };
+#endif
 
 template <typename T, int Size>
 struct alignas(sizeof(T) * Size) AlignedVector {

--- a/csrc/generation/qkv_transpose_split.cu
+++ b/csrc/generation/qkv_transpose_split.cu
@@ -135,6 +135,7 @@ std::vector<paddle::Tensor> QKVTransposeSplit(const paddle::Tensor& qkv,
                                               int num_head,
                                               int head_size) {
     switch (qkv.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return qkv_transpose_split<paddle::DataType::BFLOAT16>(
                 qkv,
@@ -145,6 +146,7 @@ std::vector<paddle::Tensor> QKVTransposeSplit(const paddle::Tensor& qkv,
                 head_size
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return qkv_transpose_split<paddle::DataType::FLOAT16>(
                 qkv,

--- a/csrc/generation/quant_int8.cu
+++ b/csrc/generation/quant_int8.cu
@@ -23,8 +23,9 @@
 #include<stdio.h>
 #include<algorithm>
 #include<cuda_fp16.h>
+#ifdef CUDA_ENABLE_BF16
 #include<cuda_bf16.h>
-
+#endif
 
 constexpr int DequantKernelVecSize = 4;
 
@@ -52,10 +53,12 @@ __forceinline__ __device__ half add_mul<half>(half a, half b, half c) {
     return __hmul(__hadd(a, b), c);
 }
 
+#ifdef CUDA_ENABLE_BF16
 template<>
 __forceinline__ __device__ __nv_bfloat16 add_mul<__nv_bfloat16>(__nv_bfloat16 a, __nv_bfloat16 b, __nv_bfloat16 c) {
     return __hmul(__hadd(a, b), c);
 }
+#endif
 
 
 
@@ -210,11 +213,13 @@ std::vector<paddle::Tensor> QuantInt8(const paddle::Tensor& input,
                                       float min_bound) {
     // printf("#### quant int8 scale:%f \n",scale);
     switch (input.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return LaunchQuantInt8<paddle::DataType::BFLOAT16>(
                 input, shift, smooth, scale, round_type, max_bound, min_bound
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return LaunchQuantInt8<paddle::DataType::FLOAT16>(
                 input, shift, smooth, scale, round_type, max_bound, min_bound

--- a/csrc/generation/rebuild_padding.cu
+++ b/csrc/generation/rebuild_padding.cu
@@ -109,6 +109,7 @@ std::vector<paddle::Tensor> RebuildPadding(const paddle::Tensor& tmp_out,
                                            const paddle::Tensor& seq_lens,
                                            const paddle::Tensor& input_ids) {
     switch (tmp_out.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return rebuild_padding<paddle::DataType::BFLOAT16>(
                 tmp_out,
@@ -117,6 +118,7 @@ std::vector<paddle::Tensor> RebuildPadding(const paddle::Tensor& tmp_out,
                 input_ids
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return rebuild_padding<paddle::DataType::FLOAT16>(
                 tmp_out,

--- a/csrc/generation/token_penalty_multi_scores.cu
+++ b/csrc/generation/token_penalty_multi_scores.cu
@@ -156,6 +156,7 @@ std::vector<paddle::Tensor> TokenPenaltyMultiScores(const paddle::Tensor& pre_id
                                                     const paddle::Tensor& eos_token_id) {
 
     switch (logits.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return token_penalty_multi_scores_kernel<paddle::DataType::BFLOAT16>(
                 pre_ids,
@@ -168,6 +169,7 @@ std::vector<paddle::Tensor> TokenPenaltyMultiScores(const paddle::Tensor& pre_id
                 eos_token_id
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return token_penalty_multi_scores_kernel<paddle::DataType::FLOAT16>(
                 pre_ids,

--- a/csrc/generation/transpose_removing_padding.cu
+++ b/csrc/generation/transpose_removing_padding.cu
@@ -125,6 +125,7 @@ std::vector<paddle::Tensor> ApplyTransposeRemovingPadding(const paddle::Tensor& 
                                                           const paddle::Tensor& seq_lens, 
                                                           const paddle::Tensor& padding_offset) {
     switch (input.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return apply_transpose_remove_padding<paddle::DataType::BFLOAT16>(
                 input,
@@ -132,6 +133,7 @@ std::vector<paddle::Tensor> ApplyTransposeRemovingPadding(const paddle::Tensor& 
                 padding_offset
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return apply_transpose_remove_padding<paddle::DataType::FLOAT16>(
                 input,

--- a/csrc/generation/write_cache_kv.cu
+++ b/csrc/generation/write_cache_kv.cu
@@ -154,11 +154,13 @@ void WriteCacheKV(const paddle::Tensor& input_k,
                   const paddle::Tensor& cache_kv,
                   const paddle::Tensor& sequence_lengths_shape) {
     switch (cache_kv.type()) {
+#ifdef CUDA_ENABLE_BF16
         case paddle::DataType::BFLOAT16: {
             return LaunchWriteCacheKV<paddle::DataType::BFLOAT16>(
                 input_k, input_v, cache_kv, sequence_lengths_shape
             );
         }
+#endif
         case paddle::DataType::FLOAT16: {
             return LaunchWriteCacheKV<paddle::DataType::FLOAT16>(
                 input_k, input_v, cache_kv, sequence_lengths_shape

--- a/csrc/setup_cuda.py
+++ b/csrc/setup_cuda.py
@@ -47,8 +47,18 @@ def get_gencode_flags():
             "arch=compute_70,code=sm_70",
         ]
 
+def set_custom_flags():
+    custom_flags = []
+    # set CUDA_ENABLE_BF16
+    prop = paddle.device.cuda.get_device_properties()
+    cc = prop.major * 10 + prop.minor
+    if cc >= 80:
+        custom_flags.append("-DCUDA_ENABLE_BF16")
+    
+    return custom_flags
 
 gencode_flags = get_gencode_flags()
+custom_flags = set_custom_flags()
 
 setup(
     name="paddlenlp_ops",
@@ -69,7 +79,7 @@ setup(
             "./generation/dequant_int8.cu",
         ],
         extra_compile_args={
-            "cxx": ["-O3"],
+            "cxx": ["-O3"] + custom_flags,
             "nvcc": [
                 "-O3",
                 "-U__CUDA_NO_HALF_OPERATORS__",
@@ -79,7 +89,8 @@ setup(
                 "-U__CUDA_NO_BFLOAT162_OPERATORS__",
                 "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
             ]
-            + gencode_flags,
+            + gencode_flags
+            + custom_flags,
         },
     ),
 )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
csrc building enable bfloat16 default, which is not supported when cuda arch < sm80. This PR add `CUDA_ENBALE_BF16` macro definition in building stage, which can avoid this problem.