### PR TITLE
[LLM] fix Qwen-7b-Chat precision issue

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -744,6 +744,7 @@ def create_predictor(
 
     tensor_parallel_rank, tensor_parallel_degree = init_dist_env()
     if not predictor_args.inference_model:
+        tokenizer.padding_side = "left"
         if predictor_args.mode == "dynamic":
             if model_args.model_type == "gpt-3":
                 sys.path.append("./gpt-3")


### PR DESCRIPTION
set default tokenizer padding style as "left" in one of existing code branch

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
llm/predictor.py > create_predictor()

### Description
<!-- Describe what this PR does -->
Fix Qwen-7B-Chat model precision issue, in which batch inference return false results.
The issue is caused by error setting of tokenizer `padding_side`, which should be "left" instead of default "right".
This PR modifies default `padding_side` as "left" in one of tokenizer creation code branch to fix the issue.