### PR TITLE
[Bug Fix] fix paddle multipy_fwd_func warning message

### DIFF
--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -366,10 +366,12 @@ class LlamaRMSNorm(nn.Layer):
 
         if paddle.in_dynamic_mode():
             with paddle.amp.auto_cast(False):
-                variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
+                hidden_states = hidden_states.astype("float32")
+                variance = hidden_states.pow(2).mean(-1, keepdim=True)
                 hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
         else:
-            variance = hidden_states.astype("float32").pow(2).mean(-1, keepdim=True)
+            hidden_states = hidden_states.astype("float32")
+            variance = hidden_states.pow(2).mean(-1, keepdim=True)
             hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states
 
         if self.weight.dtype in [paddle.float16, paddle.bfloat16]:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
由于主框架在 https://github.com/PaddlePaddle/Paddle/issues/59518 中对于multiply输入类型不一致会输出warning日志。
在amp level=O2情况下：
`hidden_states = paddle.rsqrt(variance + self.variance_epsilon) * hidden_states`中`paddle.rsqrt(variance + self.variance_epsilon)`结果为float32，`hidden_states `为fp16/bf16。


报错日志
![image](https://github.com/PaddlePaddle/PaddleNLP/assets/31957460/25a2f68f-2f68-4f5b-a58f-f639cd99b92d)


复现脚本：
```bash
SCRIPT_HOME=$(cd $(dirname $0); pwd)

CARDS="0,1"

task_name="llama_pp2dp4"
rm -rf "$SCRIPT_HOME/output/$task_name/"
rm -rf "$SCRIPT_HOME/output/${task_name}_log"

TP=2
PP=1
SHARDING_STAGE="stage1"


python -u  -m paddle.distributed.launch \
    --devices=$CARDS \
    --log_dir "output/$task_name""_log" \
    run_pretrain.py \
    --model_name_or_path "__internal_testing__/tiny-random-llama" \
    --tokenizer_name_or_path "__internal_testing__/tiny-random-llama" \
    --input_dir "/workspace/dataset/llama_openwebtext2" \
    --output_dir "output/$task_name" \
    --split 949,50,1 \
    --max_seq_length 1024 \
    --per_device_train_batch_size 1 \
    --per_device_eval_batch_size 1 \
    --fuse_attention_qkv 1 \
    --fuse_attention_ffn 1 \
    --use_flash_attention 1 \
    --use_fused_rms_norm 0 \
    --fp16 \
    --fp16_opt_level "O2" \
    --scale_loss 1024 \
    --amp_master_grad 1 \
    --max_grad_norm 1.0 \
    --tensor_parallel_degree $TP \
    --pipeline_parallel_degree $PP \
    --sharding $SHARDING_STAGE \
    --learning_rate 5.0e-5 \
    --min_learning_rate 1.0e-9 \
    --lr_scheduler_type "cosine" \
    --max_steps 6000 \
    --save_steps 6000 \
    --weight_decay 0.01 \
    --adam_beta1 0.9 \
    --adam_beta2 0.95 \
    --warmup_ratio 0.1 \
    --logging_steps 1 \
    --dataloader_num_workers 0 \
    --gradient_accumulation_steps 1 \
    --eval_steps 1000 \
    --report_to "visualdl" \
    --disable_tqdm true \
    --continue_training 0 \
    --recompute 0 \
    --do_train \
    --device "gpu" \
    --overwrite_output_dir True
```
