### PR TITLE
[LLM] add Qwen-7B-Chat in unit-test

### DIFF
--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -43,6 +43,7 @@ from .testing_utils import LLMTest, argv_context_guard, load_test_config
         ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm2", ChatGLMv2ForCausalLM],
+        ["__internal_testing__/tiny-fused-qwen", QwenForCausalLM],
     ],
 )
 class PredictorTest(LLMTest, unittest.TestCase):


### PR DESCRIPTION
add Qwen-7B-Chat in PaddleNLP unit-test (test_predictor)

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
unit test: tests/llm/test_predictor.py > parameterized_class
### Description
<!-- Describe what this PR does -->
add Qwen-7B-Chat in PaddleNLP unit-test