### PR TITLE
[LLM] add Qwen-7B-Chat to PaddleNLP unit test

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -1187,6 +1187,7 @@ def create_predictor(
 
     tensor_parallel_rank, tensor_parallel_degree = init_dist_env()
     if not predictor_args.inference_model:
+        tokenizer.padding_side = "left"
         if predictor_args.mode == "dynamic":
             if model_args.model_type == "gpt-3":
                 sys.path.append("./gpt-3")

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1059,10 +1059,8 @@ class GenerationMixin(object):
 
             # pre-process distribution
             next_token_logits = self.adjust_logits_during_generation(next_token_logits)
-            next_tokens_scores = logits_processors(input_ids, next_token_logits)
+            probs = logits_processors(input_ids, next_token_logits)
             # greedy
-            probs = F.softmax(next_tokens_scores)
-            probs = paddle.log(probs)
             next_tokens = paddle.argmax(probs, axis=-1).unsqueeze(-1)
             next_scores = paddle.index_sample(probs, next_tokens)
 

--- a/paddlenlp/transformers/qwen/tokenizer.py
+++ b/paddlenlp/transformers/qwen/tokenizer.py
@@ -70,6 +70,7 @@ class QWenTokenizer(PretrainedTokenizer):
         self,
         vocab_file,
         errors="replace",
+        padding_side="left",
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -26,6 +26,7 @@ from paddlenlp.transformers import (  # ChatGLMForCausalLM,
     ChatGLMForCausalLM,
     ChatGLMv2ForCausalLM,
     LlamaForCausalLM,
+    QWenForCausalLM,
 )
 from paddlenlp.utils.downloader import (
     COMMUNITY_MODEL_PREFIX,
@@ -43,6 +44,7 @@ from .testing_utils import LLMTest, argv_context_guard, load_test_config
         ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm", ChatGLMForCausalLM],
         ["__internal_testing__/tiny-fused-chatglm2", ChatGLMv2ForCausalLM],
+        ["__internal_testing__/tiny-fused-qwen-inference5.2", QWenForCausalLM],
     ],
 )
 class PredictorTest(LLMTest, unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
add Qwen-7B-Chat in PaddleNLP unit-test (test_predictor)

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
bug fix: 
  1. fix default `padding_side` from right to left in batch inference of Qwen
  2. remove logits post-process in GenerationMixin > greedy_search
unit test: add Qwen into unit test