### PR TITLE
[fix][fix a bug of evaluate.py]

### DIFF
--- a/applications/neural_search/recall/in_batch_negative/evaluate.py
+++ b/applications/neural_search/recall/in_batch_negative/evaluate.py
@@ -72,6 +72,7 @@ if __name__ == "__main__":
                 relevance_labels.append(1)
             else:
                 relevance_labels.append(0)
+        rs.append(relevance_labels)
 
     recall_N = []
     recall_num = [1, 5, 10, 20, 50]


### PR DESCRIPTION
hi there:

with open(args.recall_result_file, "r", encoding="utf-8") as f:
        relevance_labels = []
        for index, line in enumerate(f):

            if index % args.recall_num == 0 and index != 0:
                rs.append(relevance_labels)
                relevance_labels = []

            text, recalled_text, cosine_sim = line.rstrip().split("\t")
            if text2similar[text] == recalled_text:
                relevance_labels.append(1)
            else:
                relevance_labels.append(0)

this chunk of code read a txt file line by line. And spliting the recall cases by the recall num. However, this chunk of code does not consider the last recall results. So, to fix it, have to add one more append function once the file is reading complete.

您好，
这段代码存在一个bug，这段代码按照recall num来进行按行读取数据，但是最后的一块召回结果并未被记录。举个例子，一个8行的txt和recall_num 2，这段代码只能够读取2，4，6行数据的召回结果，7和8的结果被丢掉了。为了修复这个bug, 可以在循环外再apped一次
