### PR TITLE
[neural search][fix bug of evaluate.py]

### DIFF
--- a/applications/neural_search/recall/in_batch_negative/evaluate.py
+++ b/applications/neural_search/recall/in_batch_negative/evaluate.py
@@ -13,18 +13,29 @@
 # limitations under the License.
 
 import argparse
+import time
 
 import numpy as np
 
-import time
-
 parser = argparse.ArgumentParser()
-parser.add_argument("--similar_text_pair", type=str,
-                    default='', help="The full path of similar pair file")
-parser.add_argument("--recall_result_file", type=str,
-                    default='', help="The full path of recall result file")
-parser.add_argument("--recall_num", type=int, default=10,
-                    help="Most similar number of doc recalled from corpus per query")
+parser.add_argument(
+    "--similar_text_pair",
+    type=str,
+    default="",
+    help="The full path of similar pair file",
+)
+parser.add_argument(
+    "--recall_result_file",
+    type=str,
+    default="",
+    help="The full path of recall result file",
+)
+parser.add_argument(
+    "--recall_num",
+    type=int,
+    default=10,
+    help="Most similar number of doc recalled from corpus per query",
+)
 
 
 args = parser.parse_args()
@@ -54,7 +65,7 @@ if __name__ == "__main__":
     text2similar = {}
     with open(args.similar_text_pair, "r", encoding="utf-8") as f:
         for line in f:
-            text, similar_text = line.rstrip().split("\t")
+            text, similar_text = line.rstrip().split("\t$$$")
             text2similar[text] = similar_text
 
     rs = []
@@ -62,23 +73,24 @@ if __name__ == "__main__":
     with open(args.recall_result_file, "r", encoding="utf-8") as f:
         relevance_labels = []
         for index, line in enumerate(f):
-
             if index % args.recall_num == 0 and index != 0:
                 rs.append(relevance_labels)
                 relevance_labels = []
 
-            text, recalled_text, cosine_sim = line.rstrip().split("\t")
+            text, recalled_text, cosine_sim = line.rstrip().split("\t$$$")
             if text2similar[text] == recalled_text:
                 relevance_labels.append(1)
             else:
                 relevance_labels.append(0)
 
+        rs.append(relevance_labels)
+
     recall_N = []
-    recall_num = [1, 5, 10, 20, 50]
+    recall_num = [1, 3, 5, 10, 50]
     for topN in recall_num:
         R = round(100 * recall(rs, N=topN), 3)
         recall_N.append(str(R))
-    result = open("result.tsv", "a")
+    result = open("./result.tsv", "a")
     res = []
     timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime())
     res.append(timestamp)

--- a/applications/neural_search/recall/in_batch_negative/evaluate.py
+++ b/applications/neural_search/recall/in_batch_negative/evaluate.py
@@ -86,11 +86,11 @@ if __name__ == "__main__":
         rs.append(relevance_labels)
 
     recall_N = []
-    recall_num = [1, 3, 5, 10, 50]
+    recall_num = [1, 5, 10, 20, 50]
     for topN in recall_num:
         R = round(100 * recall(rs, N=topN), 3)
         recall_N.append(str(R))
-    result = open("./result.tsv", "a")
+    result = open("result.tsv", "a")
     res = []
     timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime())
     res.append(timestamp)

--- a/applications/neural_search/recall/in_batch_negative/evaluate.py
+++ b/applications/neural_search/recall/in_batch_negative/evaluate.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     text2similar = {}
     with open(args.similar_text_pair, "r", encoding="utf-8") as f:
         for line in f:
-            text, similar_text = line.rstrip().split("\t$$$")
+            text, similar_text = line.rstrip().split("\t")
             text2similar[text] = similar_text
 
     rs = []
@@ -77,7 +77,7 @@ if __name__ == "__main__":
                 rs.append(relevance_labels)
                 relevance_labels = []
 
-            text, recalled_text, cosine_sim = line.rstrip().split("\t$$$")
+            text, recalled_text, cosine_sim = line.rstrip().split("\t")
             if text2similar[text] == recalled_text:
                 relevance_labels.append(1)
             else:


### PR DESCRIPTION
hi there:
```
with open(args.recall_result_file, "r", encoding="utf-8") as f:
        relevance_labels = []
        for index, line in enumerate(f):

            if index % args.recall_num == 0 and index != 0:
                rs.append(relevance_labels)
                relevance_labels = []

            text, recalled_text, cosine_sim = line.rstrip().split("\t")
            if text2similar[text] == recalled_text:
                relevance_labels.append(1)
            else:
                relevance_labels.append(0)
```
this chunk of code read a txt file line by line. And spliting the recall cases by the recall num. However, this chunk of code does not consider the last recall results. So, to fix it, have to add one more append function once the file is reading complete.

您好，
这段代码存在一个bug，这段代码按照recall num来进行按行读取数据，但是最后的一块召回结果并未被记录。举个例子，一个8行的txt和recall_num 2，这段代码只能够读取2，4，6行数据的召回结果，7和8的结果被丢掉了。为了修复这个bug, 可以在循环外再apped一次
