### PR TITLE
[neural search] fix the bug of reading files when calculating the recall scores

### DIFF
--- a/applications/neural_search/recall/in_batch_negative/evaluate.py
+++ b/applications/neural_search/recall/in_batch_negative/evaluate.py
@@ -73,17 +73,15 @@ if __name__ == "__main__":
     with open(args.recall_result_file, "r", encoding="utf-8") as f:
         relevance_labels = []
         for index, line in enumerate(f):
-            if index % args.recall_num == 0 and index != 0:
-                rs.append(relevance_labels)
-                relevance_labels = []
-
             text, recalled_text, cosine_sim = line.rstrip().split("\t")
             if text2similar[text] == recalled_text:
                 relevance_labels.append(1)
             else:
                 relevance_labels.append(0)
 
-        rs.append(relevance_labels)
+            if (index + 1) % args.recall_num == 0:
+                rs.append(relevance_labels)
+                relevance_labels = []
 
     recall_N = []
     recall_num = [1, 5, 10, 20, 50]

--- a/applications/neural_search/recall/simcse/evaluate.py
+++ b/applications/neural_search/recall/simcse/evaluate.py
@@ -57,16 +57,15 @@ if __name__ == "__main__":
     with open(args.recall_result_file, "r", encoding="utf-8") as f:
         relevance_labels = []
         for index, line in enumerate(f):
-
-            if index % args.recall_num == 0 and index != 0:
-                rs.append(relevance_labels)
-                relevance_labels = []
-
             text, recalled_text, cosine_sim = line.rstrip().split("\t")
             if text2similar[text] == recalled_text:
                 relevance_labels.append(1)
             else:
                 relevance_labels.append(0)
+
+            if (index + 1) % args.recall_num == 0:
+                rs.append(relevance_labels)
+                relevance_labels = []
 
     recall_N = []
     recall_num = [1, 5, 10, 20, 50]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
[ Bug fixes ]

### PR changes
[ Scripts ]

### Description
For this file 'applications/neural_search/recall/in_batch_negative/evaluate.py'.
If (the number of rows in 'similar_text_pair') mod ('recall_num') doesn't equal 0, the current code will still store the remaining rows in the 'rs' list, resulting in inconsistent list dimensions stored in the 'rs' list. Although it won't raise errors, logically there are some problems.

In this file 'applications/neural_search/recall/simcse/evaluate.py'.
The current loop will not save the last 'relevance_labels' list into the 'rs' list.

Therefore, the corrected code can be applied to the above two files. Besides, I think the issue should be similar for the following files:

examples/semantic_indexing/evaluate.py
applications/question_answering/supervised_qa/faq_system/evaluate.py
applications/question_answering/supervised_qa/faq_finance/evaluate.py
applications/text_classification/multi_class/retrieval_based/evaluate.py
applications/text_classification/hierarchical/retrieval_based/evaluate.py

I hadn't modified these files because I didn't check the usage in their modules. Please check those files. Thanks.