### PR TITLE
Support 5.2 bloom

### DIFF
--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -811,6 +811,36 @@ class BlockInferencePredictorMixin:
         self.inputs["eos_token_id"] = paddle.to_tensor(
             np.array(eos_token_id * config.batch_size).reshape(-1, 1).astype("int64")
         )
+        # bloom model needs src_mask and tgt_mask!
+        if "bloom" in self.architectures:
+            lower_one_tril = paddle.tril(
+                paddle.ones(shape=(self.total_max_length, self.total_max_length), dtype=self.dtype)
+            )
+            lower_one_tril = lower_one_tril[None, None, :, :]
+            self.inputs["src_mask"] = lower_one_tril.tile([self.batch_size, 1, 1, 1])
+            self.inputs["tgt_mask"] = paddle.full(
+                shape=[config.batch_size, 1, 1, self.total_max_length], fill_value=1, dtype=self.dtype
+            )
+            arange_tensor_encoder = paddle.arange(self.total_max_length).astype(self.dtype)
+            alibi_slopes = get_alibi_slopes(self.num_attention_heads)
+            alibi = alibi_slopes[None, :, None, None] * arange_tensor_encoder
+            alibi_encoder = alibi.tile([self.batch_size, 1, self.total_max_length, 1])
+            alibi_decoder = alibi.tile(
+                [
+                    self.batch_size,
+                    1,
+                    1,
+                    1,
+                ]
+            )
+            # self.inputs["src_mask/tgt_mask"] is read only, will not be updated!
+            self.inputs["src_mask"] = (
+                alibi_encoder + (1 - self.inputs["src_mask"]) * paddle.finfo(self.dtype).min
+            ).cast(self.dtype)
+            self.inputs["tgt_mask"] = (
+                alibi_decoder + (1 - self.inputs["tgt_mask"]) * paddle.finfo(self.dtype).min
+            ).cast(self.dtype)
+
         # need update
         self.inputs["block_tables"] = paddle.full(
             shape=[config.batch_size, self.pre_max_block_num], fill_value=-1, dtype="int32"
@@ -1315,16 +1345,23 @@ def create_predictor(
                 )
                 model.eval()
             elif "bloom" in config.architectures[0].lower():
-                from paddlenlp.experimental.transformers import (
-                    BloomForCausalLMInferenceModel,
-                )
+                if predictor_args.block_attn:
+                    from paddlenlp.experimental.transformers import (
+                        BlommForCausalBlockLMInferenceModel as Model,
+                    )
 
-                model = BloomForCausalLMInferenceModel.from_pretrained(
+                    config.block_size = predictor_args.block_size
+                    config.max_seq_len = predictor_args.total_max_length
+                else:
+                    from paddlenlp.experimental.transformers import (
+                        BloomForCausalLMInferenceModel as Model,
+                    )
+                model = Model.from_pretrained(
                     predictor_args.model_name_or_path,
                     config=config,
                     dtype=predictor_args.dtype,
                 )
-                cache_kvs_shape = BloomForCausalLMInferenceModel.get_cache_kvs_shape(
+                cache_kvs_shape = Model.get_cache_kvs_shape(
                     config, predictor_args.batch_size, predictor_args.total_max_length
                 )
                 model.eval()
@@ -1400,11 +1437,18 @@ def create_predictor(
                     config, predictor_args.batch_size, predictor_args.total_max_length
                 )
             elif "bloom" in config.architectures[0].lower():
-                from paddlenlp.experimental.transformers import (
-                    BloomForCausalLMInferenceModel,
-                )
+                if predictor_args.block_attn:
+                    from paddlenlp.experimental.transformers import (
+                        BlommForCausalBlockLMInferenceModel as Model,
+                    )
 
-                cache_kvs_shape = BloomForCausalLMInferenceModel.get_cache_kvs_shape(
+                    config.block_size = predictor_args.block_size
+                    config.max_seq_len = predictor_args.total_max_length
+                else:
+                    from paddlenlp.experimental.transformers import (
+                        BloomForCausalLMInferenceModel as Model,
+                    )
+                cache_kvs_shape = Model.get_cache_kvs_shape(
                     config, predictor_args.batch_size, predictor_args.total_max_length
                 )
             elif "gpt" in config.architectures[0].lower():

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -1347,21 +1347,21 @@ def create_predictor(
             elif "bloom" in config.architectures[0].lower():
                 if predictor_args.block_attn:
                     from paddlenlp.experimental.transformers import (
-                        BlommForCausalBlockLMInferenceModel as Model,
+                        BlommForCausalBlockLMInferenceModel as BloomInferenceModel,
                     )
 
                     config.block_size = predictor_args.block_size
                     config.max_seq_len = predictor_args.total_max_length
                 else:
                     from paddlenlp.experimental.transformers import (
-                        BloomForCausalLMInferenceModel as Model,
+                        BloomForCausalLMInferenceModel as BloomInferenceModel,
                     )
-                model = Model.from_pretrained(
+                model = BloomInferenceModel.from_pretrained(
                     predictor_args.model_name_or_path,
                     config=config,
                     dtype=predictor_args.dtype,
                 )
-                cache_kvs_shape = Model.get_cache_kvs_shape(
+                cache_kvs_shape = BloomInferenceModel.get_cache_kvs_shape(
                     config, predictor_args.batch_size, predictor_args.total_max_length
                 )
                 model.eval()
@@ -1439,16 +1439,16 @@ def create_predictor(
             elif "bloom" in config.architectures[0].lower():
                 if predictor_args.block_attn:
                     from paddlenlp.experimental.transformers import (
-                        BlommForCausalBlockLMInferenceModel as Model,
+                        BlommForCausalBlockLMInferenceModel as BloomInferenceModel,
                     )
 
                     config.block_size = predictor_args.block_size
                     config.max_seq_len = predictor_args.total_max_length
                 else:
                     from paddlenlp.experimental.transformers import (
-                        BloomForCausalLMInferenceModel as Model,
+                        BloomForCausalLMInferenceModel as BloomInferenceModel,
                     )
-                cache_kvs_shape = Model.get_cache_kvs_shape(
+                cache_kvs_shape = BloomInferenceModel.get_cache_kvs_shape(
                     config, predictor_args.batch_size, predictor_args.total_max_length
                 )
             elif "gpt" in config.architectures[0].lower():

--- a/paddlenlp/experimental/transformers/bloom/modeling.py
+++ b/paddlenlp/experimental/transformers/bloom/modeling.py
@@ -636,15 +636,6 @@ class BloomBlockInferenceModel(BloomModelInferenceModel):
                 **kwargs,
             )
 
-        # if inputs_embeds.shape[0] == 100:
-        #     print("哈哈哈")
-        #     import numpy as np
-        #     static_dict = {
-        #         "hidden_states": hidden_states.numpy(),
-        #     }
-        #     np.savez('/zhoukangkang/my.npz', **static_dict)
-        #     exit(0)
-
         hidden_states = self.ln_f(hidden_states)
 
         return BaseModelOutputWithPastAndCrossAttentions(

--- a/paddlenlp/experimental/transformers/bloom/modeling.py
+++ b/paddlenlp/experimental/transformers/bloom/modeling.py
@@ -754,8 +754,6 @@ class BlommForCausalBlockLMInferenceModel(GenerationBlockInferenceModel, BloomPr
         hidden_states = outputs[0]
 
         output = self.lm_head(hidden_states)
-        
-        #print(output[0,:20])
 
         return output
 

--- a/paddlenlp/experimental/transformers/bloom/modeling.py
+++ b/paddlenlp/experimental/transformers/bloom/modeling.py
@@ -19,15 +19,18 @@ import paddle
 from paddle import Tensor, nn
 from paddle.distributed import fleet
 from paddle.nn.quant import weight_quantize
-from paddlenlp_ops import get_padding_offset
+from paddlenlp_ops import get_padding_offset, get_padding_offset_v2
 
 from paddlenlp.experimental.transformers.fused_transformer_layers import (
     FusedMultiTransformerBase,
     FusedMultiTransformerConfig,
     FusedMultiTransformerWeightOnly,
+    FusedBlockMultiTransformer,
+    FusedBlockMultiTransformerWeightOnly,
 )
 from paddlenlp.experimental.transformers.generation_utils import (
     GenerationInferenceModel,
+    GenerationBlockInferenceModel,
 )
 from paddlenlp.transformers.bloom.modeling import BloomPreTrainedModel
 from paddlenlp.transformers.model_outputs import (
@@ -42,6 +45,8 @@ from paddlenlp.transformers.model_utils import (
 __all__ = [
     "BloomModelInferenceModel",
     "BloomForCausalLMInferenceModel",
+    "BloomBlockInferenceModel",
+    "BlommForCausalBlockLMInferenceModel",
 ]
 
 
@@ -189,11 +194,8 @@ class BloomModelInferenceModel(BloomPreTrainedModel):
             ffn2_weight_scale_attrs=ffn2_weight_scale_attrs,
             ffn2_bias_attrs=ffn2_bias_attrs,
         )
-
-        if self.use_weight_only:
-            self.transformer_block = FusedMultiTransformerWeightOnly(transformer_config)
-        else:
-            self.transformer_block = FusedMultiTransformerBase(transformer_config)
+        
+        self.set_transformer_block(transformer_config)
 
         self.cache_kvs = []
 
@@ -201,6 +203,13 @@ class BloomModelInferenceModel(BloomPreTrainedModel):
         self.ln_f = nn.LayerNorm(self.embed_dim, epsilon=config.layer_norm_epsilon)
 
         self.gradient_checkpointing = False
+
+
+    def set_transformer_block(self, transformer_config):
+        if self.use_weight_only:
+            self.transformer_block = FusedMultiTransformerWeightOnly(transformer_config)
+        else:
+            self.transformer_block = FusedMultiTransformerBase(transformer_config)
 
     def get_input_embeddings(self):
         return self.word_embeddings
@@ -273,6 +282,15 @@ class BloomModelInferenceModel(BloomPreTrainedModel):
                 seq_lens=seq_len,
                 time_step=paddle.increment(paddle.shape(attention_mask)[-1], -1) if is_decoder else None,
             )
+
+        #if inputs_embeds.shape[0] == 100:
+            # print("哈哈哈")
+            # import numpy as np
+            # static_dict = {
+            #     "hidden_states": hidden_states.numpy(),
+            # }
+            # np.savez('/zhoukangkang/your.npz', **static_dict)
+            # exit(0)
 
         # Add last hidden state
         hidden_states = self.ln_f(hidden_states)
@@ -566,3 +584,198 @@ class BloomForCausalLMInferenceModel(GenerationInferenceModel, BloomPreTrainedMo
         beam_idx at every generation step.
         """
         return tuple(tuple(past_state.index_select(0, beam_idx) for past_state in layer_past) for layer_past in past)
+
+
+
+@register_base_model
+class BloomBlockInferenceModel(BloomModelInferenceModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.max_seq_len = config.max_seq_len
+        self.block_size = config.block_size
+
+    def set_transformer_block(self, transformer_config):
+        if self.use_weight_only:
+            self.transformer_block = FusedBlockMultiTransformerWeightOnly(transformer_config)
+        else:
+            self.transformer_block = FusedBlockMultiTransformer(transformer_config)
+
+    def remove_padding(self, input_ids, seq_lens_this_time):
+        cum_offsets_now = paddle.cumsum(self.max_seq_len - seq_lens_this_time)
+        token_num = paddle.sum(seq_lens_this_time)
+        ids_remove_padding, cum_offsets, padding_offset, cu_seqlens_q, cu_seqlens_k = get_padding_offset_v2(
+            input_ids, cum_offsets_now, token_num, seq_lens_this_time
+        )
+        return ids_remove_padding, padding_offset, cum_offsets, cu_seqlens_q, cu_seqlens_k
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        caches=None,
+        pre_caches=None,
+        output_attentions=False,
+        output_hidden_states=None,
+        return_dict=False,
+        **kwargs,
+    ):  
+
+        seq_lens_this_time = kwargs.get("seq_lens_this_time", None)
+        ids_remove_padding, padding_offset, cum_offsets, cu_seqlens_q, cu_seqlens_k = self.remove_padding(
+                input_ids, seq_lens_this_time
+            )
+        kwargs["cu_seqlens_q"] = cu_seqlens_q
+        kwargs["cu_seqlens_k"] = cu_seqlens_k
+        kwargs["padding_offsets"] = padding_offset
+        kwargs["max_input_length"] = self.max_seq_len
+
+        if inputs_embeds is None:
+            inputs_embeds = self.word_embeddings(ids_remove_padding)
+        
+        hidden_states = self.word_embeddings_layernorm(inputs_embeds)
+
+        with dy2st_nocheck_guard_context():
+            hidden_states, _ = self.transformer_block(
+                input_ids=input_ids,
+                src=hidden_states,
+                cum_offsets=cum_offsets,
+                attn_mask=attention_mask,
+                caches=caches,
+                pre_caches=pre_caches,
+                rotary_embs=None,
+                **kwargs,
+            )
+        
+        # if inputs_embeds.shape[0] == 100:
+        #     print("哈哈哈")
+        #     import numpy as np
+        #     static_dict = {
+        #         "hidden_states": hidden_states.numpy(),
+        #     }
+        #     np.savez('/zhoukangkang/my.npz', **static_dict)
+        #     exit(0)
+
+        hidden_states = self.ln_f(hidden_states)
+
+        return BaseModelOutputWithPastAndCrossAttentions(
+            last_hidden_state=hidden_states,
+            past_key_values=None,
+            hidden_states=None,
+            attentions=None,
+        )
+
+
+
+class BlommForCausalBlockLMInferenceModel(GenerationBlockInferenceModel, BloomPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.bloom = BloomBlockInferenceModel(config)
+        self.lm_head = BloomLMHead(config, self.bloom.word_embeddings.weight)
+
+    @classmethod
+    def get_cache_kvs_shape(cls, config, max_batch_size: int = None, max_length: int = None):
+
+        max_block_per_seq = (config.max_seq_len + config.block_size - 1) // config.block_size
+        if max_batch_size == -1:
+            max_block_nums = None
+        else:
+            max_block_nums = max_batch_size * max_block_per_seq
+
+        cache_kvs = []
+        for _ in range(config.n_layer):
+            cache_kv_shape = [
+                max_block_nums,
+                config.n_head // max(config.tensor_parallel_degree, 1),
+                config.block_size,
+                config.hidden_size // config.n_head,
+            ]
+            cache_kvs.append(cache_kv_shape)
+            cache_kvs.append(cache_kv_shape)
+        return cache_kvs
+
+    def prepare_inputs_for_generation(self, **kwargs):
+        # only last token for inputs_ids if cache is defined in kwargs
+        input_ids = kwargs["input_ids"]
+        src_mask = kwargs.get("src_mask", None)
+
+        tgt_mask = kwargs.get("tgt_mask", None)
+
+        block_tables = kwargs.get("block_tables", None)
+
+        pre_caches = kwargs.get("pre_caches", None)
+        caches = kwargs.get("caches", None)
+
+        seq_lens_this_time = kwargs["seq_lens_this_time"]
+
+        seq_lens_encoder = kwargs["seq_lens_encoder"]
+        seq_lens_decoder = kwargs["seq_lens_decoder"]
+        k_quant_scales = kwargs.get("k_quant_scales", None)
+        v_quant_scales = kwargs.get("v_quant_scales", None)
+        k_dequant_scales = kwargs.get("k_dequant_scales", None)
+        v_dequant_scales = kwargs.get("v_dequant_scales", None)
+
+        # only slice a part of src_mask, because of phi::FlashAttnUnpaddedKernel.
+        valid_max_encoder_len = paddle.max(seq_lens_encoder)
+        src_mask = src_mask[:,:,:valid_max_encoder_len,:valid_max_encoder_len]
+
+        model_inputs = {
+            "input_ids": input_ids,
+            "src_mask": src_mask,
+            "tgt_mask": tgt_mask,
+            "rope_emb": None,
+            "pre_caches": pre_caches,
+            "caches": caches,
+            "seq_lens_this_time": seq_lens_this_time,
+            "seq_lens_encoder": seq_lens_encoder,
+            "seq_lens_decoder": seq_lens_decoder,
+            "block_tables": block_tables,
+            "k_quant_scales": k_quant_scales,
+            "v_quant_scales": v_quant_scales,
+            "k_dequant_scales": k_dequant_scales,
+            "v_dequant_scales": v_dequant_scales,
+        }
+        return model_inputs
+
+    def forward(
+        self,
+        input_ids,
+        src_mask=None,
+        tgt_mask=None,
+        pre_caches=None,
+        caches=None,
+        seq_lens_this_time=None,
+        seq_lens_encoder=None,
+        seq_lens_decoder=None,
+        rope_emb=None,
+        block_tables=None,
+        k_quant_scales=None,
+        v_quant_scales=None,
+        k_dequant_scales=None,
+        v_dequant_scales=None,
+    ):
+        outputs = self.bloom(
+            input_ids,
+            attention_mask = src_mask,
+            tgt_mask = tgt_mask,
+            caches=caches,
+            rope_emb=rope_emb,
+            block_tables=block_tables,
+            pre_caches=pre_caches,
+            seq_lens_this_time=seq_lens_this_time,
+            seq_lens_encoder=seq_lens_encoder,
+            seq_lens_decoder=seq_lens_decoder,
+            k_quant_scales=k_quant_scales,
+            v_quant_scales=v_quant_scales,
+            k_dequant_scales=k_dequant_scales,
+            v_dequant_scales=v_dequant_scales,
+        )
+
+        hidden_states = outputs[0]
+
+        output = self.lm_head(hidden_states)
+        return output
+
+    @paddle.no_grad()
+    def set_state_dict(self, state_dict):
+        self.bloom.set_state_dict(state_dict)

--- a/paddlenlp/experimental/transformers/bloom/modeling.py
+++ b/paddlenlp/experimental/transformers/bloom/modeling.py
@@ -738,7 +738,8 @@ class BlommForCausalBlockLMInferenceModel(GenerationBlockInferenceModel, BloomPr
             attention_mask=src_mask,
             tgt_mask=tgt_mask,
             caches=caches,
-            rope_emb=rope_emb,
+            # bloom does not have rope_emb!
+            rope_emb=None,
             block_tables=block_tables,
             pre_caches=pre_caches,
             seq_lens_this_time=seq_lens_this_time,
@@ -753,6 +754,9 @@ class BlommForCausalBlockLMInferenceModel(GenerationBlockInferenceModel, BloomPr
         hidden_states = outputs[0]
 
         output = self.lm_head(hidden_states)
+        
+        #print(output[0,:20])
+
         return output
 
     @paddle.no_grad()

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -1362,16 +1362,6 @@ class FusedBlockMultiTransformer(FusedMultiTransformerBase):
             v_quant_scales = self.cache_v_scales
             k_dequant_scales = self.cache_k_out_scales
             v_dequant_scales = self.cache_v_out_scales
-        
-        # print(" ", kwargs.get("seq_lens_encoder"))
-        # print(" ", kwargs.get("seq_lens_decoder"))
-        # print(" ", kwargs.get("seq_lens_this_time"))
-        # print("cu_seqlens_q", kwargs.get("cu_seqlens_q", None))
-        # print("cu_seqlens_k", kwargs.get("cu_seqlens_k", None))
-        # print("cum_offsets", kwargs.get("cum_offsets", None))
-        # print("block_tables", kwargs.get("block_tables", None))
-        # print("padding_offsets", kwargs.get("padding_offsets", None))
-        # print("max_input_length", kwargs.get("max_input_length", -1))
 
         fmha_out = paddle.incubate.nn.functional.block_multihead_attention(
             qkv_out,
@@ -1406,19 +1396,6 @@ class FusedBlockMultiTransformer(FusedMultiTransformerBase):
             quant_max_bound=self.config.quant_max_bound,
             quant_min_bound=self.config.quant_min_bound,
         )[0]
-
-        if fmha_out.shape[0] == 8 and i >= 0:
-            pass
-            # print("fhma_out", qkv_out)
-            # print("fhma_out", caches[2 * i + 1].shape)
-            # import numpy as np
-            # static_dict = {
-            #     "hidden_states": qkv_out.numpy(),
-            #     "fmha_out" : fmha_out.numpy(),
-            #     "attn_mask" : attn_mask.numpy(),
-            # }
-            # np.savez('/zhoukangkang/my.npz', **static_dict)
-            # exit(0)
 
         out_linear_out = self.compute_out_linear(fmha_out, i)
 

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -1362,6 +1362,16 @@ class FusedBlockMultiTransformer(FusedMultiTransformerBase):
             v_quant_scales = self.cache_v_scales
             k_dequant_scales = self.cache_k_out_scales
             v_dequant_scales = self.cache_v_out_scales
+        
+        # print(" ", kwargs.get("seq_lens_encoder"))
+        # print(" ", kwargs.get("seq_lens_decoder"))
+        # print(" ", kwargs.get("seq_lens_this_time"))
+        # print("cu_seqlens_q", kwargs.get("cu_seqlens_q", None))
+        # print("cu_seqlens_k", kwargs.get("cu_seqlens_k", None))
+        # print("cum_offsets", kwargs.get("cum_offsets", None))
+        # print("block_tables", kwargs.get("block_tables", None))
+        # print("padding_offsets", kwargs.get("padding_offsets", None))
+        # print("max_input_length", kwargs.get("max_input_length", -1))
 
         fmha_out = paddle.incubate.nn.functional.block_multihead_attention(
             qkv_out,
@@ -1396,6 +1406,19 @@ class FusedBlockMultiTransformer(FusedMultiTransformerBase):
             quant_max_bound=self.config.quant_max_bound,
             quant_min_bound=self.config.quant_min_bound,
         )[0]
+
+        if fmha_out.shape[0] == 8 and i >= 0:
+            pass
+            # print("fhma_out", qkv_out)
+            # print("fhma_out", caches[2 * i + 1].shape)
+            # import numpy as np
+            # static_dict = {
+            #     "hidden_states": qkv_out.numpy(),
+            #     "fmha_out" : fmha_out.numpy(),
+            #     "attn_mask" : attn_mask.numpy(),
+            # }
+            # np.savez('/zhoukangkang/my.npz', **static_dict)
+            # exit(0)
 
         out_linear_out = self.compute_out_linear(fmha_out, i)
 

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -477,12 +477,13 @@ class GenerationBlockInferenceModel(GenerationMixin):
             src_mask_spec = paddle.static.InputSpec(shape=[None, 1, None, None], dtype=dtype, name="src_mask")
         else:
             src_mask_spec = None
-        
 
         # bloom model needs src_mask and tgt_mask!
         if "bloom" in self.config.architectures[0].lower():
             src_mask_spec = paddle.static.InputSpec(shape=[None, None, None, None], dtype=dtype, name="src_mask")
             tgt_mask_spec = paddle.static.InputSpec(shape=[None, None, 1, None], dtype=dtype, name="tgt_mask")
+        else:
+            tgt_mask_spec = None
 
         input_spec = [
             paddle.static.InputSpec(shape=[None, None], dtype="int64", name="input_ids"),  # input_ids
@@ -566,7 +567,7 @@ class GenerationBlockInferenceModel(GenerationMixin):
         v_quant_scales=None,
         k_dequant_scales=None,
         v_dequant_scales=None,
-        tgt_mask = None,
+        tgt_mask=None,
         **model_kwargs,
     ):
 
@@ -704,7 +705,5 @@ class GenerationBlockInferenceModel(GenerationMixin):
             temperature,
             model_kwargs,
         )
-
-        #print("next_tokens", next_tokens)
 
         return next_tokens

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -354,7 +354,7 @@ class GenerationInferenceModel(GenerationMixin):
                 "real_time_save.temp_ids",
                 self.config.tensor_parallel_rank,
             )
-            print("next_tokens", next_tokens)
+
             return next_tokens, model_kwargs
 
         # encoder

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -211,6 +211,7 @@ class PredictorBaseTest(LLMTest, unittest.TestCase):
     ["model_name_or_path", "model_class"],
     [
         ["__internal_testing__/tiny-fused-llama-inference5.2", LlamaForCausalLM],
+        ["__internal_testing__/tiny-fused-bloom", BloomForCausalLM],
     ],
 )
 class BlockAttnPredictorTest(LLMTest, unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features：支持bloom类模型的5.2 推理

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->


- 动态图运行代码

python3.8  predictor.py     --model_name_or_path /root/.paddlenlp/models/bigscience/bloom-7b1/     --dtype float16     --src_length 102     --max_length 1024    --block_attn    --batch_size 2    --inference_model > dynamic_2.txt

- 动态图运行weight only int8代码

python3.8  predictor.py     --model_name_or_path /root/.paddlenlp/models/bigscience/bloom-7b1/     --dtype float16     --src_length 102     --max_length 1024 --block_attn  --batch_size 2    --inference_model --quant_type weight_only_int8   

- 动转静命令和静态图推理命令

python3.8 export_model.py --model_name_or_path /root/.paddlenlp/models/bigscience/bloom-7b1/ --inference_model --output_path ./inference --dtype float16 --block_attn --quant_type weight_only_int8   

python3.8  predictor.py --model_name_or_path ./inference --inference_model --dtype "float16" --mode "static" --batch_size 2 --block_attn


- wint8 动转静和静态图推理命令

python3.8 export_model.py --model_name_or_path /root/.paddlenlp/models/bigscience/bloom-7b1/ --inference_model --output_path ./inference_wint8 --dtype float16 --block_attn --quant_type weight_only_int8 

python3.8  predictor.py --model_name_or_path ./inference_wint8 --inference_model --dtype "float16" --batch_size 2  --mode "static" --quant_type weight_only_int8   --block_attn



