### PR TITLE
[Bug Fix] fix slice bug in LlamaRotaryEmbedding

### DIFF
--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -417,8 +417,8 @@ class LlamaRotaryEmbedding(nn.Layer):
 
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
-        cos = self.cos_cached[:, :, :seq_len, ...]
-        sin = self.sin_cached[:, :, :seq_len, ...]
+        cos = self.cos_cached[:, :seq_len, :, :]
+        sin = self.sin_cached[:, :seq_len, :, :]
         return (
             cos.cast(x.dtype) if cos.dtype != x.dtype else cos,
             sin.cast(x.dtype) if sin.dtype != x.dtype else sin,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
In `LlamaRotaryEmbedding`, `self.cos_cached` and `self.sin_cached` are both the shape of `[1, max_seq_len_cached, 1, self.dim]`, but `forward` function wrongly does slice operation on dimension 2 which is the dimension with the constant value `1`. We update dimensions which should be slice actually.


<img width="748" alt="Snipaste_2024-01-23_16-30-55" src="https://github.com/PaddlePaddle/PaddleNLP/assets/61354321/4d9df48b-60d5-43d1-9531-69975ec66bec">
