### PR TITLE
[AMP] add auto cast in init parameters

### DIFF
--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -490,7 +490,7 @@ def main():
     if model_args.continue_training:
         # NOTE(gongenlei): new add
         if training_args.autotuner_benchmark:
-            model = model_class.from_config(config, dtype=dtype)
+            model = model_class.from_config(config, dtype=dtype, fp16_level=training_args.fp16_opt_level)
         else:
             model = model_class.from_pretrained(
                 model_args.model_name_or_path,
@@ -498,7 +498,7 @@ def main():
                 dtype=dtype,
             )
     else:
-        model = model_class.from_config(config, dtype=dtype)
+        model = model_class.from_config(config, dtype=dtype, fp16_level=training_args.fp16_opt_level)
 
     if model_args.sequence_parallel:
         register_sequence_parallel_allreduce_hooks(

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -989,6 +989,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 Override the default `paddle.dtype` and load the model under this dtype.
         """
         dtype = kwargs.pop("dtype", None)
+        fp16_level = kwargs.pop("fp16_level", None)
 
         if dtype is None:
             if config.dtype is not None:
@@ -996,8 +997,12 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             else:
                 dtype = paddle.get_default_dtype()
 
-        with dtype_guard(dtype):
-            model = cls(config, **kwargs)
+        if fp16_level is None or fp16_level == "O1":
+            with dtype_guard(dtype):
+                model = cls(config, **kwargs)
+        else:
+            with paddle.amp.auto_cast(True, level=fp16_level, dtype=dtype):
+                model = cls(config, **kwargs)
 
         return model
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
In amp O2 level, some op may not have fp16 kernel (etc. gaussian). It will cause weight set_value failure due to dtype not match. It can solve by adding amp auto cast in init parameters.

![image](https://github.com/PaddlePaddle/PaddleNLP/assets/31957460/e91beaa0-39b2-4b3c-975d-b9dfcfacf451)
