### PR TITLE
[FIX Download] update converted logic & fix hf hub download subfolder bug

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -52,7 +52,7 @@ from paddle.nn import Embedding, Layer
 from paddle.utils.download import is_url as is_remote_url
 from tqdm.auto import tqdm
 
-from paddlenlp.utils.downloader import get_path_from_url_with_filelock, hf_file_exists
+from paddlenlp.utils.downloader import get_path_from_url_with_filelock
 from paddlenlp.utils.env import (
     CONFIG_NAME,
     LEGACY_CONFIG_NAME,
@@ -367,28 +367,7 @@ def resolve_weight_file_from_hf_hub(repo_id: str, cache_dir: str, support_conver
         support_conversion (bool): whether support converting pytorch weight file to paddle weight file
         subfolder (str, optional) An optional value corresponding to a folder inside the repo.
     """
-    is_local = os.path.isdir(repo_id)
-    if not is_local:
-        if hf_file_exists(repo_id, PADDLE_WEIGHTS_NAME, subfolder=subfolder):
-            file_name = PADDLE_WEIGHTS_NAME
-            assert (
-                support_conversion is False
-            ), "Please call set convert_from_torch for paddle weights on huggingface hub, eg. Model.from_pretrained(model_name, from_hf_hub=True, convert_from_torch=False)"
-        elif hf_file_exists(repo_id, PYTORCH_WEIGHTS_NAME, subfolder=subfolder):
-            if not support_conversion:
-                raise EntryNotFoundError(
-                    f"can not download `{PADDLE_WEIGHTS_NAME} from https://huggingface.co/{repo_id}` "
-                    "and current model doesn't support conversion from pytorch weight file to paddle weight file"
-                )
-            file_name = PYTORCH_WEIGHTS_NAME
-        else:
-            raise EntryNotFoundError(
-                message=f"can not find the paddle/pytorch weight file from: https://huggingface.co/{repo_id}",
-                response=None,
-            )
-    else:
-        # for local file, we use support_conversion to select paddle or torch weight.
-        file_name = PYTORCH_WEIGHTS_NAME if support_conversion else PADDLE_WEIGHTS_NAME
+    file_name = PYTORCH_WEIGHTS_NAME if support_conversion else PADDLE_WEIGHTS_NAME
 
     file_name_list = [SAFE_WEIGHTS_NAME] + [file_name] + [PYTORCH_WEIGHTS_INDEX_NAME] + [SAFE_WEIGHTS_INDEX_NAME]
     resolved_file = None

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -564,8 +564,8 @@ def cached_file_for_hf_hub(
         subfolder = ""
 
     path_or_repo_id = str(path_or_repo_id)
-    full_filename = os.path.join(subfolder, filename)
     if os.path.isdir(path_or_repo_id):
+        full_filename = os.path.join(subfolder, filename)
         resolved_file = os.path.join(os.path.join(path_or_repo_id, subfolder), filename)
         if not os.path.isfile(resolved_file):
             if _raise_exceptions_for_missing_entries:
@@ -584,10 +584,10 @@ def cached_file_for_hf_hub(
 
     try:
         # Load from URL or cache if already cached
-        download_check(path_or_repo_id, full_filename, addition="from_hf_hub")
+        download_check(path_or_repo_id, filename, addition="from_hf_hub")
         resolved_file = hf_hub_download(
             repo_id=path_or_repo_id,
-            filename=full_filename,
+            filename=filename,
             cache_dir=cache_dir,
             subfolder=subfolder,
             library_name="PaddleNLP",

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -564,8 +564,8 @@ def cached_file_for_hf_hub(
         subfolder = ""
 
     path_or_repo_id = str(path_or_repo_id)
+    full_filename = os.path.join(subfolder, filename)
     if os.path.isdir(path_or_repo_id):
-        full_filename = os.path.join(subfolder, filename)
         resolved_file = os.path.join(os.path.join(path_or_repo_id, subfolder), filename)
         if not os.path.isfile(resolved_file):
             if _raise_exceptions_for_missing_entries:
@@ -584,7 +584,7 @@ def cached_file_for_hf_hub(
 
     try:
         # Load from URL or cache if already cached
-        download_check(path_or_repo_id, filename, addition="from_hf_hub")
+        download_check(path_or_repo_id, full_filename, addition="from_hf_hub")
         resolved_file = hf_hub_download(
             repo_id=path_or_repo_id,
             filename=filename,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
1. hf hub 下载的时候不需要 给filename拼subfolder，否则会出现 subfolder/subfolder/filename
2. 权重转换的时候自动检测同级目录是否存在 model_state.pdparams文件，如果存在就直接使用并load_file成为state_dict
3. 加载转换后的paddle权重文件的逻辑进行修改，先是通过检测与torch同级目录的paddle文件是否存在 https://github.com/PaddlePaddle/PaddleNLP/blob/bb6c7351c1045d4bad73051440a56f6f941192b6/paddlenlp/transformers/model_utils.py#L2141 ，如果存在就直接加载（原先的时候第二次加载是不会走这里的逻辑，现在统一一下，走这里）