### PR TITLE
[Encode Fix]fix ernie-m encode

### DIFF
--- a/paddlenlp/transformers/ernie_m/tokenizer.py
+++ b/paddlenlp/transformers/ernie_m/tokenizer.py
@@ -173,8 +173,10 @@ class ErnieMTokenizer(PretrainedTokenizer):
         else:
             pieces = self.sp_model.SampleEncodeAsPieces(text, 64, 0.1)
         new_pieces = []
-        for piece in pieces:
+        for i, piece in enumerate(pieces):
             if piece == SPIECE_UNDERLINE:
+                if i > 0:
+                    new_pieces.append(SPIECE_UNDERLINE)
                 continue
             lst_i = 0
             for i, c in enumerate(piece):
@@ -199,8 +201,22 @@ class ErnieMTokenizer(PretrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens):
         """Converts a sequence of tokens (strings for sub-words) in a single string."""
-        out_string = "".join(tokens).replace(SPIECE_UNDERLINE, " ").strip()
-        return out_string
+        current_sub_tokens = []
+        out_string = ""
+        prev_is_special = False
+        for token in tokens:
+            # make sure that special tokens are not decoded using sentencepiece model
+            if token in self.all_special_tokens:
+                if not prev_is_special:
+                    out_string += " "
+                out_string += self.sp_model.decode(current_sub_tokens) + token
+                prev_is_special = True
+                current_sub_tokens = []
+            else:
+                current_sub_tokens.append(token)
+                prev_is_special = False
+        out_string += self.sp_model.decode(current_sub_tokens)
+        return out_string.strip()
 
     def convert_ids_to_string(self, ids):
         """


### PR DESCRIPTION
修正ernie-m系列编码解码结果不一致的问题（异常合并不该合并的token），在原有逻辑中，修改部分为
1. 保留原有方案中跳过SPIECE_UNDERLINE的操作，实际上应该保留
2. 如果句首为SPIECE_UNDERLINE，则不应该被加入
3. 更新相关SPIECE_UNDERLINE的处理逻辑