### PR TITLE
support multicard export for QWen

### DIFF
--- a/llm/export_model.py
+++ b/llm/export_model.py
@@ -42,8 +42,7 @@ def load_inference_model(model_path, model_name, param_name, exe):
 
 def validate_pdmodel(model_path, model_prefix):
     paddle.enable_static()
-    place = paddle.CUDAPlace(0)
-    exe = paddle.static.Executor(place)
+    exe = paddle.static.Executor()
     scope = paddle.static.Scope()
 
     with paddle.static.scope_guard(scope):

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -1414,6 +1414,8 @@ def create_predictor(
                     predictor_args.model_name_or_path,
                     config=config,
                     dtype=predictor_args.dtype,
+                    tensor_parallel_degree=tensor_parallel_degree,
+                    tensor_parallel_rank=tensor_parallel_rank,
                 )
                 model.eval()
             else:

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -257,6 +257,7 @@ class FusedMultiTransformerConfig:
         self.ring_id = ring_id
         self.tensor_parallel_degree = tensor_parallel_degree
 
+
 class FusedMultiTransformerBase(Layer):
     def __init__(self, config: FusedMultiTransformerConfig):
         super().__init__()
@@ -369,8 +370,7 @@ class FusedMultiTransformerBase(Layer):
             qkv_bias = None
             if qkv_bias_attr:
                 qkv_bias = self.create_parameter(
-                    shape=[(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
-                                config.tensor_parallel_degree],
+                    shape=[(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // config.tensor_parallel_degree],
                     attr=qkv_bias_attr,
                     dtype=self._dtype,
                     is_bias=True,
@@ -548,16 +548,14 @@ class FusedMultiTransformerBase(Layer):
 
     def init_weight_shape(self, config):
         self.qkv_weight_shape = (
-            [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
-                    config.tensor_parallel_degree, 
-                self.embed_dim]
+            [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // config.tensor_parallel_degree, self.embed_dim]
             if config.trans_qkvw
-            else [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
-                    config.tensor_parallel_degree,
-                 self.embed_dim]
+            else [
+                (self.num_heads + 2 * self.kv_num_heads) * self.head_dim // config.tensor_parallel_degree,
+                self.embed_dim,
+            ]
         )
-        self.linear_weight_shape = [self.num_heads * self.head_dim // config.tensor_parallel_degree, 
-                                    self.embed_dim]
+        self.linear_weight_shape = [self.num_heads * self.head_dim // config.tensor_parallel_degree, self.embed_dim]
         self.ffn1_weight_shape = (
             [self.embed_dim, self.dim_feedforward * 2 // config.tensor_parallel_degree]
             if self.activation.endswith("glu")

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -196,6 +196,7 @@ class FusedMultiTransformerConfig:
         kv_num_heads=-1,
         use_dynamic_cachekv_quant=True,
         rank_id=-1,
+        tensor_parallel_degree=1,
     ):
         self.embed_dim = embed_dim
         self.num_heads = num_heads
@@ -254,7 +255,7 @@ class FusedMultiTransformerConfig:
         self.rank_id = rank_id
         self.trans_qkvw = trans_qkvw
         self.ring_id = ring_id
-
+        self.tensor_parallel_degree = tensor_parallel_degree
 
 class FusedMultiTransformerBase(Layer):
     def __init__(self, config: FusedMultiTransformerConfig):
@@ -368,7 +369,8 @@ class FusedMultiTransformerBase(Layer):
             qkv_bias = None
             if qkv_bias_attr:
                 qkv_bias = self.create_parameter(
-                    shape=[(self.num_heads + 2 * self.kv_num_heads) * self.head_dim],
+                    shape=[(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
+                                config.tensor_parallel_degree],
                     attr=qkv_bias_attr,
                     dtype=self._dtype,
                     is_bias=True,
@@ -546,17 +548,22 @@ class FusedMultiTransformerBase(Layer):
 
     def init_weight_shape(self, config):
         self.qkv_weight_shape = (
-            [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim, self.embed_dim]
+            [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
+                    config.tensor_parallel_degree, 
+                self.embed_dim]
             if config.trans_qkvw
-            else [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim, self.embed_dim]
+            else [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim // 
+                    config.tensor_parallel_degree,
+                 self.embed_dim]
         )
-        self.linear_weight_shape = [self.num_heads * self.head_dim, self.embed_dim]
+        self.linear_weight_shape = [self.num_heads * self.head_dim // config.tensor_parallel_degree, 
+                                    self.embed_dim]
         self.ffn1_weight_shape = (
-            [self.embed_dim, self.dim_feedforward * 2]
+            [self.embed_dim, self.dim_feedforward * 2 // config.tensor_parallel_degree]
             if self.activation.endswith("glu")
-            else [self.embed_dim, self.dim_feedforward]
+            else [self.embed_dim, self.dim_feedforward // config.tensor_parallel_degree]
         )
-        self.ffn2_weight_shape = [self.dim_feedforward, self.embed_dim]
+        self.ffn2_weight_shape = [self.dim_feedforward // config.tensor_parallel_degree, self.embed_dim]
 
     def get_weight_create_dype(self):
         return self._dtype

--- a/paddlenlp/experimental/transformers/qwen/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen/modeling.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import paddle
 from paddle import nn
+from paddle.distributed import fleet
 from paddle.nn.quant import weight_quantize
 from paddlenlp_ops import fused_get_rotary_embedding, get_padding_offset
 
@@ -85,7 +86,26 @@ class QWenInferenceModel(QWenPretrainedModel):
                 self.quant_type
             )
 
-        self.wte = nn.Embedding(self.vocab_size, self.hidden_size)
+        if config.tensor_parallel_degree > 1:
+            self.wte = fleet.meta_parallel.VocabParallelEmbedding(
+                self.vocab_size,
+                self.hidden_size,
+                weight_attr=paddle.ParamAttr(initializer=nn.initializer.XavierNormal()),
+            )
+        else:
+            self.wte = nn.Embedding(
+                self.vocab_size,
+                self.hidden_size,
+            )
+
+        # get ring_id
+        ring_id = -1
+        try:
+            hcg = fleet.get_hybrid_communicate_group()
+            model_parallel_group = hcg.get_model_parallel_group()
+            ring_id = model_parallel_group.id
+        except:
+            pass
 
         ln_scale_attrs = [paddle.ParamAttr(name="fuseqwen.{}.ln_scale".format(i)) for i in range(self.num_layers)]
         qkv_weight_attrs = [
@@ -144,7 +164,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             activation="swiglu",
             num_layers=config.num_hidden_layers,
             nranks=1,
-            ring_id=-1,
+            ring_id=ring_id,
             ln_scale_attrs=ln_scale_attrs,
             qkv_weight_attrs=qkv_weight_attrs,
             qkv_weight_scale_attrs=qkv_weight_scale_attrs,
@@ -159,6 +179,8 @@ class QWenInferenceModel(QWenPretrainedModel):
             epsilon=self.layer_norm_epsilon,
             norm_type="rmsnorm",
             use_neox_rotary_style=True,
+            rank_id=config.tensor_parallel_rank,
+            tensor_parallel_degree=config.tensor_parallel_degree
         )
 
         if self.use_weight_only:
@@ -184,7 +206,8 @@ class QWenInferenceModel(QWenPretrainedModel):
         ln_f_weight = paddle.to_tensor(state_dict["qwen.ln_f.weight"], dtype=self.ln_f.weight.dtype)
         self.wte.weight.set_value(wte_weight)
         self.ln_f.weight.set_value(ln_f_weight)
-
+        head_size = self.hidden_size // self.num_attention_heads
+        
         for idx in range(self.num_layers):
             ln_scale = paddle.to_tensor(
                 state_dict["qwen.h.{}.ln_1.weight".format(idx)], dtype=self.transformer_block.ln_scales[idx].dtype

--- a/paddlenlp/experimental/transformers/qwen/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen/modeling.py
@@ -180,7 +180,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             norm_type="rmsnorm",
             use_neox_rotary_style=True,
             rank_id=config.tensor_parallel_rank,
-            tensor_parallel_degree=config.tensor_parallel_degree
+            tensor_parallel_degree=config.tensor_parallel_degree,
         )
 
         if self.use_weight_only:
@@ -206,8 +206,7 @@ class QWenInferenceModel(QWenPretrainedModel):
         ln_f_weight = paddle.to_tensor(state_dict["qwen.ln_f.weight"], dtype=self.ln_f.weight.dtype)
         self.wte.weight.set_value(wte_weight)
         self.ln_f.weight.set_value(ln_f_weight)
-        head_size = self.hidden_size // self.num_attention_heads
-        
+
         for idx in range(self.num_layers):
             ln_scale = paddle.to_tensor(
                 state_dict["qwen.h.{}.ln_1.weight".format(idx)], dtype=self.transformer_block.ln_scales[idx].dtype

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -35,10 +35,9 @@ from paddlenlp.utils.downloader import (
     get_path_from_url_with_filelock,
     url_file_exists,
 )
+from tests.llm.testing_utils import LLMTest, argv_context_guard, load_test_config
 from tests.parallel_launch import TestMultipleGpus
 from tests.testing_utils import GPUsTesting, require_gpu
-
-from .testing_utils import LLMTest, argv_context_guard, load_test_config
 
 
 @parameterized_class(
@@ -330,8 +329,7 @@ class GPUsPredictorTest(LLMTest, GPUsTesting, unittest.TestCase):
         self.assertGreaterEqual(count / len(result_0), 0.4)
 
 
-# TestMultipleGpus already inherits from unittest.
-class QWenVLTest(LLMTest, TestMultipleGpus):
+class QWenVLTest(LLMTest, unittest.TestCase):
     config_path: str = "./tests/fixtures/llm/predictor.yaml"
     model_name_or_path: str = "__internal_testing__/tiny-fused-qwen"
     model_class = QWenForCausalLM
@@ -435,14 +433,17 @@ class QWenVLTest(LLMTest, TestMultipleGpus):
 
             main()
 
+
+class QWenVLMulticardExportTest(LLMTest, TestMultipleGpus):
+    model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
+    model_class = QWenForCausalLM
+
     def test_export_twocards(self):
-        export_file = "llm/export_model.py"
+        export_file = "../../llm/export_model.py"
         multicard_export_args = {}
         multicard_export_args["model_name_or_path"] = self.model_name_or_path
         multicard_export_args["output_path"] = self.output_dir
         multicard_export_args["dtype"] = "float16"
         multicard_export_args["inference_model"] = True
-        multicard_export_args["model_prefix"] = "qwen"
-        multicard_export_args["model_type"] = "qwen-img2txt"
 
         self.run_n1c2(export_file, **multicard_export_args)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -330,7 +330,8 @@ class GPUsPredictorTest(LLMTest, GPUsTesting, unittest.TestCase):
         self.assertGreaterEqual(count / len(result_0), 0.4)
 
 
-class QWenVLTest(LLMTest, unittest.TestCase, TestMultipleGpus):
+# TestMultipleGpus already inherits from unittest.
+class QWenVLTest(LLMTest, TestMultipleGpus):
     config_path: str = "./tests/fixtures/llm/predictor.yaml"
     model_name_or_path: str = "__internal_testing__/tiny-fused-qwen"
     model_class = QWenForCausalLM

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -434,7 +434,7 @@ class QWenVLTest(LLMTest, unittest.TestCase):
             main()
 
 
-class QWenVLMulticardExportTest(LLMTest, TestMultipleGpus):
+class QWenMulticardExportTest(LLMTest, TestMultipleGpus):
     model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
     model_class = QWenForCausalLM
 

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -436,13 +436,13 @@ class QWenVLTest(LLMTest, TestMultipleGpus):
             main()
 
     def test_export_twocards(self):
-        self.export_file = "llm/export_model.py"
-        self.multicard_export_args = {}
-        self.multicard_export_args["model_name_or_path"] = self.model_name_or_path
-        self.multicard_export_args["output_path"] = self.output_dir
-        self.multicard_export_args["dtype"] = "float16"
-        self.multicard_export_args["inference_model"] = True
-        self.multicard_export_args["model_prefix"] = "qwen"
-        self.multicard_export_args["model_type"] = "qwen-img2txt"
+        export_file = "llm/export_model.py"
+        multicard_export_args = {}
+        multicard_export_args["model_name_or_path"] = self.model_name_or_path
+        multicard_export_args["output_path"] = self.output_dir
+        multicard_export_args["dtype"] = "float16"
+        multicard_export_args["inference_model"] = True
+        multicard_export_args["model_prefix"] = "qwen"
+        multicard_export_args["model_type"] = "qwen-img2txt"
 
-        self.run_n1c2(self.export_file, **self.multicard_export_args)
+        self.run_n1c2(export_file, **multicard_export_args)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -35,6 +35,7 @@ from paddlenlp.utils.downloader import (
     get_path_from_url_with_filelock,
     url_file_exists,
 )
+from tests.parallel_launch import TestMultipleGpus
 from tests.testing_utils import GPUsTesting, require_gpu
 
 from .testing_utils import LLMTest, argv_context_guard, load_test_config
@@ -329,7 +330,7 @@ class GPUsPredictorTest(LLMTest, GPUsTesting, unittest.TestCase):
         self.assertGreaterEqual(count / len(result_0), 0.4)
 
 
-class QWenVLTest(LLMTest, unittest.TestCase):
+class QWenVLTest(LLMTest, unittest.TestCase, TestMultipleGpus):
     config_path: str = "./tests/fixtures/llm/predictor.yaml"
     model_name_or_path: str = "__internal_testing__/tiny-fused-qwen"
     model_class = QWenForCausalLM
@@ -432,3 +433,15 @@ class QWenVLTest(LLMTest, unittest.TestCase):
             from export_model import main
 
             main()
+
+    def test_export_twocards(self):
+        self.export_file = "llm/export_model.py"
+        self.multicard_export_args = {}
+        self.multicard_export_args["model_name_or_path"] = self.model_name_or_path
+        self.multicard_export_args["output_path"] = self.output_dir
+        self.multicard_export_args["dtype"] = "float16"
+        self.multicard_export_args["inference_model"] = True
+        self.multicard_export_args["model_prefix"] = "qwen"
+        self.multicard_export_args["model_type"] = "qwen-img2txt"
+
+        self.run_n1c2(self.export_file, **self.multicard_export_args)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -438,7 +438,7 @@ class QWenVLMulticardExportTest(LLMTest, TestMultipleGpus):
     model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
     model_class = QWenForCausalLM
 
-    def test_export_twocards(self):
+    def test_export_two_cards(self):
         export_file = "../../llm/export_model.py"
         multicard_export_args = {}
         multicard_export_args["model_name_or_path"] = self.model_name_or_path


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
support multicard export for QWen
验证方法：
运行下面的命令进行两卡导出:
```
python -m paddle.distributed.launch --gpus 1,2 export_model.py --model_name_or_path qwen-vl/qwen-vl-7b-static --output_path ./QWen_check_points --dtype float16 --inference_model
```

closed，参见新 PR：https://github.com/PaddlePaddle/PaddleNLP/pull/8158