### PR TITLE
解决HuggingFace 预训练模型压缩部署示例中自动压缩x2paddle_sst2问题

### DIFF
--- a/paddlenlp/metrics/glue.py
+++ b/paddlenlp/metrics/glue.py
@@ -342,10 +342,12 @@ class PearsonAndSpearman(Metric):
             preds = preds.numpy()
         if isinstance(labels, paddle.Tensor):
             labels = labels.numpy()
-        preds = np.squeeze(preds.reshape(-1, 1)).tolist()
-        labels = np.squeeze(labels.reshape(-1, 1)).tolist()
-        self.preds.append(preds)
-        self.labels.append(labels)
+        # 确保 preds 和 labels 是一维数组
+        preds = np.squeeze(preds).reshape(-1).tolist()
+        labels = np.squeeze(labels).reshape(-1).tolist()
+        # 现在 preds 和 labels 应该是一维列表，我们将它们包装成列表的列表
+        self.preds.append([preds])
+        self.labels.append([labels])
 
     def accumulate(self):
         """
@@ -368,8 +370,8 @@ class PearsonAndSpearman(Metric):
                 coefficient.
 
         """
-        preds = [item for sublist in self.preds for item in sublist]
-        labels = [item for sublist in self.labels for item in sublist]
+        preds = [item for sublist in self.preds for item in sublist[0]]
+        labels = [item for sublist in self.labels for item in sublist[0]]
         pearson = self.pearson(preds, labels)
         spearman = self.spearman(preds, labels)
         return (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Pcard-71501
解决[HuggingFace 预训练模型压缩部署示例](https://github.com/PaddlePaddle/PaddleSlim/tree/develop/example/auto_compression/pytorch_huggingface)中自动压缩x2paddle_sst2时的bug