### PR TITLE
Fix  save_total_limit 1 does not work

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -2231,7 +2231,9 @@ class Trainer:
             need_to_rotate_checkpoints = self.args.should_save_model_state
 
         # Delete only by one process
-        need_to_rotate_checkpoints = need_to_rotate_checkpoints and (self.args.local_rank == 0 or self.args.local_rank == -1)
+        need_to_rotate_checkpoints = need_to_rotate_checkpoints and (
+            self.args.local_rank == 0 or self.args.local_rank == -1
+        )
         if need_to_rotate_checkpoints:
             self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)
 

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -2231,7 +2231,7 @@ class Trainer:
             need_to_rotate_checkpoints = self.args.should_save_model_state
 
         # Delete only by one process
-        need_to_rotate_checkpoints = need_to_rotate_checkpoints and self.args.local_rank == 0
+        need_to_rotate_checkpoints = need_to_rotate_checkpoints and (self.args.local_rank == 0 or self.args.local_rank == -1)
         if need_to_rotate_checkpoints:
             self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
 Others
### Description
<!-- Describe what this PR does -->

When training on a single machine, **save_total_limit** does not work because the default value of **local_rank** is -1.

