### PR TITLE
[BugFix] fix test_sample_generate bug.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ unit-test:
 
 .PHONY: install
 install:
-
-        pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
+	pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
 	pip install -r requirements-dev.txt
 	pip install -r requirements.txt
 	pip install -r paddlenlp/experimental/autonlp/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ unit-test:
 
 .PHONY: install
 install:
+        pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
 	pip install -r requirements-dev.txt
 	pip install -r requirements.txt
 	pip install -r paddlenlp/experimental/autonlp/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ unit-test:
 
 .PHONY: install
 install:
+
         pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
 	pip install -r requirements-dev.txt
 	pip install -r requirements.txt

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1209,18 +1209,6 @@ class GenerationMixin(object):
 
             # multinomial already support fp16 and bf16 currently, fix issue: https://github.com/PaddlePaddle/Paddle/issues/51852
             next_tokens = paddle.multinomial(probs)
-            # # multinomial not support fp16 and bf16 currently, issue: https://github.com/PaddlePaddle/Paddle/issues/51852
-            # if probs.dtype == paddle.bfloat16 and top_k == 1:
-            #     probs = probs.astype("float32")
-            #     next_tokens = paddle.unsqueeze(paddle.argmax(probs, axis=-1), -1)
-            # else:
-            #     # next_tokens = paddle.multinomial(probs)
-            #     probs = probs.cpu()
-            #     from paddlenlp.transformers.utils import device_guard
-
-            #     with device_guard("cpu"):
-            #         next_tokens = paddle.multinomial(probs)
-            #     next_tokens = next_tokens.cuda()
 
             if self.config.tensor_parallel_degree > 1:
                 # Maybe no need to broadcast if seed is set correclty.

--- a/paddlenlp/transformers/blenderbot/modeling.py
+++ b/paddlenlp/transformers/blenderbot/modeling.py
@@ -193,6 +193,8 @@ class BlenderbotDecoderLayer(nn.TransformerDecoderLayer):
         normalize_before=True,
         weight_attr=None,
         bias_attr=None,
+        *args,
+        **kwargs,
     ):
         super(BlenderbotDecoderLayer, self).__init__(
             d_model=d_model,
@@ -205,6 +207,8 @@ class BlenderbotDecoderLayer(nn.TransformerDecoderLayer):
             normalize_before=normalize_before,
             weight_attr=weight_attr,
             bias_attr=bias_attr,
+            *args,
+            **kwargs,
         )
 
     def forward(self, tgt, memory=None, tgt_mask=None, memory_mask=None, cache=None):

--- a/paddlenlp/transformers/blenderbot_small/modeling.py
+++ b/paddlenlp/transformers/blenderbot_small/modeling.py
@@ -126,6 +126,8 @@ class BlenderbotSmallDecoderLayer(nn.TransformerDecoderLayer):
         normalize_before=True,
         weight_attr=None,
         bias_attr=None,
+        *args,
+        **kwargs,
     ):
         super(BlenderbotSmallDecoderLayer, self).__init__(
             d_model=d_model,
@@ -138,6 +140,8 @@ class BlenderbotSmallDecoderLayer(nn.TransformerDecoderLayer):
             normalize_before=normalize_before,
             weight_attr=weight_attr,
             bias_attr=bias_attr,
+            *args,
+            **kwargs,
         )
 
     def forward(self, tgt, memory=None, tgt_mask=None, memory_mask=None, cache=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-paddlepaddle
 paddleocr<2.7
 pre-commit
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-paddlepaddle==2.5.1
+paddlepaddle
 paddleocr<2.7
 pre-commit
 pytest


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

        # For test_sample_generate such as: NVIDIA_TF32_OVERRIDE=0 FLAGS_cudnn_deterministic=1 python3.10 -m pytest -svv tests/transformers/bloom/test_modeling.py::BloomModelTest_0::test_sample_generate
        # There are serious memory bug for this tensor slice. which use the original tensor mem ptr for cold start
        # Here we just clone the tensor to avoid this problem.
        input_ids = input_ids.clone()