### PR TITLE
support multicard export for qwen

### DIFF
--- a/llm/export_model.py
+++ b/llm/export_model.py
@@ -42,8 +42,7 @@ def load_inference_model(model_path, model_name, param_name, exe):
 
 def validate_pdmodel(model_path, model_prefix):
     paddle.enable_static()
-    place = paddle.CUDAPlace(0)
-    exe = paddle.static.Executor(place)
+    exe = paddle.static.Executor()
     scope = paddle.static.Scope()
 
     with paddle.static.scope_guard(scope):

--- a/llm/predictor.py
+++ b/llm/predictor.py
@@ -49,8 +49,8 @@ from paddlenlp.transformers import (
     AutoConfig,
     AutoModelForCausalLM,
     AutoTokenizer,
-    ChatGLMv2Tokenizer,
     ChatGLMTokenizer,
+    ChatGLMv2Tokenizer,
     LlamaTokenizer,
     PretrainedModel,
     PretrainedTokenizer,
@@ -242,7 +242,8 @@ class BasePredictor:
             padding=True,
             # when use chat_template, it should not add special tokens
             # chatglm2 prefix-tokens can not be tokenized into ids
-            add_special_tokens=self.tokenizer.chat_template is None or isinstance(self.tokenizer, (ChatGLMv2Tokenizer, ChatGLMTokenizer)),
+            add_special_tokens=self.tokenizer.chat_template is None
+            or isinstance(self.tokenizer, (ChatGLMv2Tokenizer, ChatGLMTokenizer)),
         )
         return tokenized_source
 
@@ -1414,6 +1415,8 @@ def create_predictor(
                     predictor_args.model_name_or_path,
                     config=config,
                     dtype=predictor_args.dtype,
+                    tensor_parallel_degree=tensor_parallel_degree,
+                    tensor_parallel_rank=tensor_parallel_rank,
                 )
                 model.eval()
             else:

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -548,7 +548,10 @@ class FusedMultiTransformerBase(Layer):
         self.qkv_weight_shape = (
             [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim, self.embed_dim]
             if config.trans_qkvw
-            else [(self.num_heads + 2 * self.kv_num_heads) * self.head_dim, self.embed_dim]
+            else [
+                (self.num_heads + 2 * self.kv_num_heads) * self.head_dim,
+                self.embed_dim,
+            ]
         )
         self.linear_weight_shape = [self.num_heads * self.head_dim, self.embed_dim]
         self.ffn1_weight_shape = (

--- a/paddlenlp/experimental/transformers/qwen/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen/modeling.py
@@ -155,7 +155,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             ffn2_weight_scale_attrs = [
                 paddle.ParamAttr(name="fuseqwen.{}.ffn2_weight_scale".format(i)) for i in range(self.num_layers)
             ]
-
+        nranks = 1 if config.tensor_parallel_degree == -1 else config.tensor_parallel_degree
         transformer_config = FusedMultiTransformerConfig(
             self.hidden_size,
             self.num_attention_heads,
@@ -163,7 +163,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             weight_only_quant_bits=self.weight_only_quant_bits,
             activation="swiglu",
             num_layers=config.num_hidden_layers,
-            nranks=config.tensor_parallel_degree,
+            nranks=nranks,
             ring_id=ring_id,
             ln_scale_attrs=ln_scale_attrs,
             qkv_weight_attrs=qkv_weight_attrs,

--- a/paddlenlp/experimental/transformers/qwen/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen/modeling.py
@@ -157,7 +157,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             ]
         # If not at inference mode in the create_predictor, the value of tensor_parallel_degree is -1.
         if config.tensor_parallel_degree == -1:
-            config.tensor_parallel_degree == 1
+            config.tensor_parallel_degree = 1
 
         transformer_config = FusedMultiTransformerConfig(
             self.hidden_size,

--- a/paddlenlp/experimental/transformers/qwen/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen/modeling.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import paddle
 from paddle import nn
+from paddle.distributed import fleet
 from paddle.nn.quant import weight_quantize
 from paddlenlp_ops import fused_get_rotary_embedding, get_padding_offset
 
@@ -85,7 +86,26 @@ class QWenInferenceModel(QWenPretrainedModel):
                 self.quant_type
             )
 
-        self.wte = nn.Embedding(self.vocab_size, self.hidden_size)
+        if config.tensor_parallel_degree > 1:
+            self.wte = fleet.meta_parallel.VocabParallelEmbedding(
+                self.vocab_size,
+                self.hidden_size,
+                weight_attr=paddle.ParamAttr(initializer=nn.initializer.XavierNormal()),
+            )
+        else:
+            self.wte = nn.Embedding(
+                self.vocab_size,
+                self.hidden_size,
+            )
+
+        # get ring_id
+        ring_id = -1
+        try:
+            hcg = fleet.get_hybrid_communicate_group()
+            model_parallel_group = hcg.get_model_parallel_group()
+            ring_id = model_parallel_group.id
+        except:
+            pass
 
         ln_scale_attrs = [paddle.ParamAttr(name="fuseqwen.{}.ln_scale".format(i)) for i in range(self.num_layers)]
         qkv_weight_attrs = [
@@ -143,8 +163,8 @@ class QWenInferenceModel(QWenPretrainedModel):
             weight_only_quant_bits=self.weight_only_quant_bits,
             activation="swiglu",
             num_layers=config.num_hidden_layers,
-            nranks=1,
-            ring_id=-1,
+            nranks=config.tensor_parallel_degree,
+            ring_id=ring_id,
             ln_scale_attrs=ln_scale_attrs,
             qkv_weight_attrs=qkv_weight_attrs,
             qkv_weight_scale_attrs=qkv_weight_scale_attrs,
@@ -159,6 +179,7 @@ class QWenInferenceModel(QWenPretrainedModel):
             epsilon=self.layer_norm_epsilon,
             norm_type="rmsnorm",
             use_neox_rotary_style=True,
+            rank_id=config.tensor_parallel_rank,
         )
 
         if self.use_weight_only:
@@ -184,6 +205,7 @@ class QWenInferenceModel(QWenPretrainedModel):
         ln_f_weight = paddle.to_tensor(state_dict["qwen.ln_f.weight"], dtype=self.ln_f.weight.dtype)
         self.wte.weight.set_value(wte_weight)
         self.ln_f.weight.set_value(ln_f_weight)
+        head_size = self.hidden_size // self.num_attention_heads
 
         for idx in range(self.num_layers):
             ln_scale = paddle.to_tensor(
@@ -193,7 +215,13 @@ class QWenInferenceModel(QWenPretrainedModel):
 
             qkv_weight = paddle.to_tensor(
                 state_dict["qwen.h.{}.attn.c_attn.weight".format(idx)].transpose([1, 0]), dtype=dtype
+            ).reshape(
+                [
+                    3 * (self.num_attention_heads // self.config.tensor_parallel_degree) * (head_size),
+                    self.hidden_size,
+                ]
             )
+
             if self.use_weight_only:
                 qkv_weight = paddle.transpose(qkv_weight, perm=[1, 0])
                 qkv_quanted_weight, qkv_weight_scale = weight_quantize(qkv_weight, algo=self.quant_type)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -440,7 +440,7 @@ class QWenMulticardExportTest(LLMTest, TestMultipleGpus):
     model_class = QWenForCausalLM
 
     def test_export_two_cards(self):
-        export_file = "../../llm/export_model.py"
+        export_file = "llm/export_model.py"
         multicard_export_args = {}
         multicard_export_args["model_name_or_path"] = self.model_name_or_path
         multicard_export_args["output_path"] = self.output_dir

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -35,6 +35,7 @@ from paddlenlp.utils.downloader import (
     get_path_from_url_with_filelock,
     url_file_exists,
 )
+from tests.parallel_launch import TestMultipleGpus
 from tests.testing_utils import GPUsTesting, require_gpu
 
 from .testing_utils import LLMTest, argv_context_guard, load_test_config
@@ -432,3 +433,18 @@ class QWenVLTest(LLMTest, unittest.TestCase):
             from export_model import main
 
             main()
+
+
+class QWenMulticardExportTest(LLMTest, TestMultipleGpus):
+    model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
+    model_class = QWenForCausalLM
+
+    def test_export_two_cards(self):
+        export_file = "../../llm/export_model.py"
+        multicard_export_args = {}
+        multicard_export_args["model_name_or_path"] = self.model_name_or_path
+        multicard_export_args["output_path"] = self.output_dir
+        multicard_export_args["dtype"] = "float16"
+        multicard_export_args["inference_model"] = True
+
+        self.run_n1c2(export_file, **multicard_export_args)

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -35,6 +35,7 @@ from paddlenlp.utils.downloader import (
     get_path_from_url_with_filelock,
     url_file_exists,
 )
+from tests.parallel_launch import TestMultipleGpus
 from tests.testing_utils import GPUsTesting, require_gpu
 
 from .testing_utils import LLMTest, argv_context_guard, load_test_config
@@ -432,3 +433,22 @@ class QWenVLTest(LLMTest, unittest.TestCase):
             from export_model import main
 
             main()
+
+
+class QWenMulticardExportTest(LLMTest, TestMultipleGpus):
+    model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
+    model_class = QWenForCausalLM
+
+    def test_export_two_cards(self):
+        export_file = "llm/export_model.py"
+        multicard_export_args = {}
+        multicard_export_args["model_name_or_path"] = self.model_name_or_path
+        multicard_export_args["output_path"] = self.output_dir
+        multicard_export_args["dtype"] = "float16"
+        multicard_export_args["inference_model"] = True
+
+        self.run_n1c2(export_file, **multicard_export_args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -35,7 +35,6 @@ from paddlenlp.utils.downloader import (
     get_path_from_url_with_filelock,
     url_file_exists,
 )
-from tests.parallel_launch import TestMultipleGpus
 from tests.testing_utils import GPUsTesting, require_gpu
 
 from .testing_utils import LLMTest, argv_context_guard, load_test_config
@@ -433,18 +432,3 @@ class QWenVLTest(LLMTest, unittest.TestCase):
             from export_model import main
 
             main()
-
-
-class QWenMulticardExportTest(LLMTest, TestMultipleGpus):
-    model_name_or_path: str = "__internal_testing__/tiny-fused-qwen-head2"
-    model_class = QWenForCausalLM
-
-    def test_export_two_cards(self):
-        export_file = "llm/export_model.py"
-        multicard_export_args = {}
-        multicard_export_args["model_name_or_path"] = self.model_name_or_path
-        multicard_export_args["output_path"] = self.output_dir
-        multicard_export_args["dtype"] = "float16"
-        multicard_export_args["inference_model"] = True
-
-        self.run_n1c2(export_file, **multicard_export_args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
support multicard export for qwen

验证方法：
运行下面的命令进行两卡导出:
```
python -m paddle.distributed.launch --gpus 1,2 export_model.py --model_name_or_path qwen-vl/qwen-vl-7b-static --output_path ./QWen_check_points --dtype float16 --inference_model
```