### PR TITLE
Fix FusedLinearWithGradAdd bug

### DIFF
--- a/llm/llama/fused_layers.py
+++ b/llm/llama/fused_layers.py
@@ -58,16 +58,18 @@ class FusedLinearWithGradAdd(paddle.autograd.PyLayer):
 
         if hasattr(weight, "main_grad") and hasattr(bias, "main_grad"):
             weight.main_grad, bias.main_grad = _C_ops.fused_linear_param_grad_add(
-                x, y_grad, weight.main_grad, bias.main_grad, True
+                x, y_grad, weight.main_grad, bias.main_grad, True, True
             )
             return x_grad, None, None
         else:
             if weight.grad is not None:
                 assert bias.grad is not None
-                weight.grad, bias.grad = _C_ops.fused_linear_param_grad_add(x, y_grad, weight.grad, bias.grad, False)
+                weight.grad, bias.grad = _C_ops.fused_linear_param_grad_add(
+                    x, y_grad, weight.grad, bias.grad, False, True
+                )
                 return x_grad, None, None
             else:
-                weight_grad, bias_grad = _C_ops.fused_linear_param_grad_add(x, y_grad, None, None, False)
+                weight_grad, bias_grad = _C_ops.fused_linear_param_grad_add(x, y_grad, None, None, False, True)
                 return x_grad, weight_grad, bias_grad
 
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
llm/gpt3 模型在开启 `enable_linear_fused_grad_add` 策略后会报错：
<img width="1085" alt="image" src="https://github.com/PaddlePaddle/PaddleNLP/assets/61354321/e0f4d295-d34d-4218-872c-8c19038317a4">

具体定位到问题出现在 `FusedLinearWithGradAdd` 的 backward 方法中。`FusedLinearWithGradAdd.backward` 会调用 `fused_linear_param_grad_add` 算子进行计算，而 `_C_ops.fused_linear_param_grad_add` api 接收六个参数输入：

```python
(Tensor x, Tensor dout, Tensor dweight, Tensor dbias, bool multi_precision = true, bool has_bias = true)
```

当前 `FusedLinearWithGradAdd` 在调用 `_C_ops.fused_linear_param_grad_add` 时缺少第六个参数（`has_bias`）参数的输入，导致 C++ api 没法正确解析出 `has_bias` 参数，进而报错

补充说明：
https://github.com/PaddlePaddle/PaddleNLP/pull/6602 也修复了类似的问题