### PR TITLE
lora训练时需要固定原始模型权重

### DIFF
--- a/llm/finetune_generation.py
+++ b/llm/finetune_generation.py
@@ -433,6 +433,8 @@ def main():
         else:
             model = LoRAModel.from_pretrained(model=model, lora_path=model_args.lora_path)
 
+        # lora训练固定原始模型权重
+        model.mark_only_lora_as_trainable()
         model.print_trainable_parameters()
 
     def compute_metrics_do_generation(eval_preds):


### PR DESCRIPTION

### PR types
bug 

### PR changes
lora训练时固定了原始模型权重
model.mark_only_lora_as_trainable()

### Description
<!-- Describe what this PR does -->
lora训练时固定了原始模型权重
