### PR TITLE
【AutoParallel】Change the `dtype` of initializing the model

### DIFF
--- a/llm/llama/auto_parallel/run_pretrain_auto_static.py
+++ b/llm/llama/auto_parallel/run_pretrain_auto_static.py
@@ -552,7 +552,8 @@ def main():
     #     if training_args.bf16:
     #         dtype = "bfloat16"
 
-    model = model_class._from_config(config)
+    # The `amp` of static graph model can't accept a model initialized with `dtype float16 or bfloat16`
+    model = model_class._from_config(config, dtype="float32")
 
     if training_args.recompute:
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
The `amp` of static graph model can't accept a model initialized with `dtype float16 or bfloat16`, so use the `dtype float32` to initialize the model in static graph model.