### PR TITLE
Add p2p_comm_overlap for Llama-2-70b benchmark.

### DIFF
--- a/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_70b/pretrain-llama2_70b-auto_tuner.json
+++ b/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_70b/pretrain-llama2_70b-auto_tuner.json
@@ -11,7 +11,7 @@
     "sharding": "stage1",
     "sharding_parallel_config": "split_param enable_stage1_overlap",
     "tensor_parallel_config": "enable_delay_scale_loss enable_mp_async_allreduce enable_mp_skip_c_identity enable_mp_fused_linear_param_grad_add",
-    "pipeline_parallel_config": "enable_delay_scale_loss enable_release_grads disable_partial_send_recv",
+    "pipeline_parallel_config": "enable_delay_scale_loss enable_release_grads disable_partial_send_recv enable_overlap_p2p_comm",
     "virtual_pp_degree": 5,
     "sequence_parallel": 1,   
     "use_flash_attention": true,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Llama-2-70b模型benchmark开启`p2p_comm_overlap`优化。性能提升数据如下：
![image](https://github.com/PaddlePaddle/PaddleNLP/assets/12538138/e92f3595-ad96-49ff-9818-72d48bef38a9)
