### PR TITLE
[LLM] fix bug when masked_lm_loss is None in llama modeling.py

### DIFF
--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -1722,7 +1722,7 @@ class LlamaPretrainingCriterion(paddle.nn.Layer):
                 _hcg = fleet.get_hybrid_communicate_group()
                 masked_lm_loss = ConcatSePMaskedLoss.apply(masked_lm_loss, axis=1, group=_hcg.get_sep_parallel_group())
             # skip ignore_index which loss == 0
-            masked_lm_loss = masked_lm_loss[masked_lm_loss > 0]
+            masked_lm_loss = masked_lm_loss[masked_lm_labels != self.ignore_index]
             loss = paddle.mean(masked_lm_loss)
 
         return loss


### PR DESCRIPTION
Change-Id: I7b6ba9248e61bee24eb463698af26727394f023a

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
llama modeling

### Description
如issue #8299 所示，llama模型LlamaPretrainingCriterion类中的masked_lm_loss为空时，无法计算loss = paddle.mean，mean不支持输入shape==[0]，本次修复恢复为之前版本的实现