### PR TITLE
refine benchmard bert ips stat

### DIFF
--- a/model_zoo/bert/run_pretrain.py
+++ b/model_zoo/bert/run_pretrain.py
@@ -425,8 +425,9 @@ def do_train(args):
                 lr_scheduler.step()
                 optimizer.clear_grad()
 
-                if global_step % args.logging_steps == 0:
-                    loss_numpy = loss.numpy()
+                # NOTE: For accurate data statistics， please open the comments below：
+                # if global_step % args.logging_steps == 0:
+                #     loss = loss.numpy()
                 total_samples += args.batch_size
                 train_run_cost = time.time() - batch_start
                 train_cost_avg.record(train_run_cost)
@@ -453,7 +454,7 @@ def do_train(args):
                             global_step,
                             epoch,
                             step,
-                            loss_numpy,
+                            loss,
                             reader_cost_avg.get_average(),
                             train_cost_avg.get_average(),
                             total_samples / args.logging_steps,

--- a/model_zoo/bert/run_pretrain.py
+++ b/model_zoo/bert/run_pretrain.py
@@ -424,6 +424,9 @@ def do_train(args):
                     optimizer.step()
                 lr_scheduler.step()
                 optimizer.clear_grad()
+
+                if global_step % args.logging_steps == 0:
+                    loss_numpy = loss.numpy()
                 total_samples += args.batch_size
                 train_run_cost = time.time() - batch_start
                 train_cost_avg.record(train_run_cost)
@@ -450,7 +453,7 @@ def do_train(args):
                             global_step,
                             epoch,
                             step,
-                            loss,
+                            loss_numpy,
                             reader_cost_avg.get_average(),
                             train_cost_avg.get_average(),
                             total_samples / args.logging_steps,

--- a/model_zoo/bert/run_pretrain.py
+++ b/model_zoo/bert/run_pretrain.py
@@ -425,7 +425,7 @@ def do_train(args):
                 lr_scheduler.step()
                 optimizer.clear_grad()
 
-                # NOTE: For accurate data statistics， please open the comments below：
+                # NOTE: For accurate data statistics, please open the comments below，especially when args.logging_steps==1.
                 # if global_step % args.logging_steps == 0:
                 #     loss = loss.numpy()
                 total_samples += args.batch_size


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
Benchmark统计平均每个step的IPS存在错误：
由于Bert模型在loss.numpy()时才会阻塞CPU，等待GPU完成全部运算。原有时间统计逻辑会遗漏从`train_run_cost = time.time() - batch_start`到`logger.info`（print loss）之间的GPU用时。
因此，相应的step只统计了前向的batch_cost，没有统计反向和Optimizer。

这种情况，如果log_step==1，那么没个step统计都是错误的。如果log_step==10，则每10个step中第1个step是错误的，后9个是正确的。这导致我们的IPS统计偏高。

但Torch的统计存在的问题，考虑到IPS更多用于与竞品性能对比使用。因此对该问题不做修改。但添加Note标注。