### PR TITLE
adapter new type promotion rule for Paddle 2.6

### DIFF
--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -933,7 +933,7 @@ class GPTForGenerationAuto(nn.Layer):
     def update_scores_for_generation(self, scores, next_scores, length, unfinished_flag):
         # update scores
 
-        unfinished_scores = (scores * length + next_scores) / (length + 1)
+        unfinished_scores = (scores * length.astype(scores.dtype) + next_scores) / (length.astype(scores.dtype) + 1)
         scores = paddle.where(unfinished_flag, unfinished_scores, scores)
         return scores
 

--- a/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -809,7 +809,7 @@ class GPTForGeneration(nn.Layer):
     def update_scores_for_generation(self, scores, next_scores, length, unfinished_flag):
         # update scores
 
-        unfinished_scores = (scores * length + next_scores) / (length + 1)
+        unfinished_scores = (scores * length.astype(scores.dtype) + next_scores) / (length.astype(scores.dtype) + 1)
         scores = paddle.where(unfinished_flag, unfinished_scores, scores)
         return scores
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
fix DLTP-83706
adapter new type promotion rule for Paddle 2.6
