### PR TITLE
[LLM] fix bug when loss is None in llama modeling.py

### DIFF
--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -1654,8 +1654,11 @@ class LlamaPretrainingCriterion(paddle.nn.Layer):
             binary_sequence = paddle.where(
                 masked_lm_loss > 0, paddle.ones_like(masked_lm_loss), paddle.zeros_like(masked_lm_loss)
             )
-            sum_ = paddle.sum(binary_sequence)
-            loss = 0 if sum_ == 0 else paddle.sum(masked_lm_loss * binary_sequence) / sum_
+            count = paddle.sum(binary_sequence)
+            if count == 0:
+                loss = paddle.sum(masked_lm_loss * binary_sequence)
+            else:
+                loss = paddle.sum(masked_lm_loss * binary_sequence) / count
 
         return loss
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug Fixs

### PR changes
Models

### Description
修复llama模型在训练过程中由异常数据导致的loss为None时引发的异常， #8342 中考虑到了这一问题，但loss设置为了float而非tensor形式。
另可参考： #8348 #8299 