### PR TITLE
【AutoParallel】disable send_recv_overlap in benchmark

### DIFF
--- a/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_13b/pretrain-llama2_13b.json
+++ b/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_13b/pretrain-llama2_13b.json
@@ -12,7 +12,7 @@
   "data_parallel_config": "enable_allreduce_avg_in_gradinent_scale gradient_sync_after_accumulate",
   "sharding_parallel_config": "enable_stage2_overlap",
   "tensor_parallel_config": "enable_mp_async_allreduce",
-  "pipeline_parallel_config": "enable_send_recv_overlap enable_split_backward",
+  "pipeline_parallel_config": "enable_split_backward",
   "pipeline_schedule_mode": "VPP", 
   "virtual_pp_degree": 5,
   "sequence_parallel": 0,   


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Disable send_recv_overlap in llama2-13B benchmark of StaticGraph-AutoParallel.