### PR TITLE
Do not save moe_group

### DIFF
--- a/paddlenlp/transformers/configuration_utils.py
+++ b/paddlenlp/transformers/configuration_utils.py
@@ -903,6 +903,8 @@ class PretrainedConfig:
             output["model_type"] = self.__class__.model_type
         if "_auto_class" in output:
             del output["_auto_class"]
+        if "moe_group" in output:
+            del output["moe_group"]
 
         output["quantization_config"] = self.quantization_config.to_dict()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Don't save moe_group in config.
