### PR TITLE
[bug fix] fix sharding stage1 allgather overlap bug, which needs to forbiden pin memory

### DIFF
--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -403,10 +403,6 @@ def main():
     else:
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
-    print("--888--" * 100)
-    print("training_args:", training_args)
-    print("--888--" * 100)
-
     if training_args.enable_linear_fused_grad_add:
         from fused_layers import mock_layers
 

--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 import paddle
-from paddle.io.reader import use_pinned_memory
 
 from paddlenlp.data.causal_dataset import (
     build_train_valid_test_datasets,
@@ -505,6 +504,8 @@ def main():
             "enable_stage1_allgather_overlap" in training_args.sharding_parallel_config
             or "enable_stage1_broadcast_overlap" in training_args.sharding_parallel_config
         ):
+            from paddle.io.reader import use_pinned_memory
+
             use_pinned_memory(False)
 
     if get_env_device() == "xpu" and training_args.gradient_accumulation_steps > 1:

--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -47,6 +47,7 @@ from paddlenlp.transformers import (
 from paddlenlp.utils.batch_sampler import DistributedBatchSampler
 from paddlenlp.utils.log import logger
 from paddlenlp.utils.tools import get_env_device
+from paddle.io.reader import use_pinned_memory
 
 # Pretaining Environment Variables to support sharding stage1 overlap optimization.
 os.environ["USE_CASUAL_MASK"] = "True"
@@ -634,4 +635,5 @@ def main():
 
 
 if __name__ == "__main__":
+    use_pinned_memory(False)
     main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1、sharding stage overlap不能正确生效，原因是没有禁用pin memory
2、必须使用paddle.io.reader 里的 use_pinned_memory， paddle.io.base里面的use_pinned_memory(False)无法生效，原因未知