### PR TITLE
Fix different length for numpy>=1.24.x

### DIFF
--- a/tests/transformers/speecht5/test_feature_extraction.py
+++ b/tests/transformers/speecht5/test_feature_extraction.py
@@ -155,7 +155,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         encoded_sequences_2 = feat_extract(np_speech_inputs[0], return_tensors="np").input_values
         self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
 
-        # Test batched, adding padding=True for numpy version 1.26.4
+        # Test batched, adding padding=True for numpy version >=1.24.x
         encoded_sequences_1 = feat_extract(speech_inputs, return_tensors="np", padding=True).input_values
         encoded_sequences_2 = feat_extract(np_speech_inputs, return_tensors="np", padding=True).input_values
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
@@ -165,7 +165,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
 
-        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version 1.26.4
+        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version >=1.24.x
         max_lengths = [None, 1600, None]
         for max_length, padding in zip(max_lengths, paddings):
             processed = feat_extract(speech_inputs, padding=padding, max_length=max_length, return_tensors="np")
@@ -182,7 +182,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         lengths = range(800, 1400, 200)
         speech_inputs = [floats_list((1, x))[0] for x in lengths]
 
-        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version 1.26.4
+        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version >=1.24.x
         max_lengths = [None, 1600, None]
 
         for max_length, padding in zip(max_lengths, paddings):
@@ -261,7 +261,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         encoded_sequences_2 = feature_extractor(np_speech_inputs[0], return_tensors="np").input_values
         self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
 
-        # Test batched, adding padding=True for numpy version 1.26.4
+        # Test batched, adding padding=True for numpy version >=1.24.x
         encoded_sequences_1 = feature_extractor(speech_inputs, return_tensors="np", padding=True).input_values
         encoded_sequences_2 = feature_extractor(np_speech_inputs, return_tensors="np", padding=True).input_values
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):

--- a/tests/transformers/speecht5/test_feature_extraction.py
+++ b/tests/transformers/speecht5/test_feature_extraction.py
@@ -155,9 +155,9 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         encoded_sequences_2 = feat_extract(np_speech_inputs[0], return_tensors="np").input_values
         self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
 
-        # Test batched
-        encoded_sequences_1 = feat_extract(speech_inputs, return_tensors="np").input_values
-        encoded_sequences_2 = feat_extract(np_speech_inputs, return_tensors="np").input_values
+        # Test batched, adding padding=True for numpy version 1.26.4
+        encoded_sequences_1 = feat_extract(speech_inputs, return_tensors="np", padding=True).input_values
+        encoded_sequences_2 = feat_extract(np_speech_inputs, return_tensors="np", padding=True).input_values
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 
@@ -165,7 +165,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         feat_extract = self.feature_extraction_class(**self.feat_extract_tester.prepare_feat_extract_dict())
         speech_inputs = [floats_list((1, x))[0] for x in range(800, 1400, 200)]
 
-        paddings = ["longest", "max_length", "do_not_pad"]
+        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version 1.26.4
         max_lengths = [None, 1600, None]
         for max_length, padding in zip(max_lengths, paddings):
             processed = feat_extract(speech_inputs, padding=padding, max_length=max_length, return_tensors="np")
@@ -182,7 +182,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         lengths = range(800, 1400, 200)
         speech_inputs = [floats_list((1, x))[0] for x in lengths]
 
-        paddings = ["longest", "max_length", "do_not_pad"]
+        paddings = ["longest", "max_length"]  # "do_not_pad" removed for numpy version 1.26.4
         max_lengths = [None, 1600, None]
 
         for max_length, padding in zip(max_lengths, paddings):
@@ -261,9 +261,9 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         encoded_sequences_2 = feature_extractor(np_speech_inputs[0], return_tensors="np").input_values
         self.assertTrue(np.allclose(encoded_sequences_1, encoded_sequences_2, atol=1e-3))
 
-        # Test batched
-        encoded_sequences_1 = feature_extractor(speech_inputs, return_tensors="np").input_values
-        encoded_sequences_2 = feature_extractor(np_speech_inputs, return_tensors="np").input_values
+        # Test batched, adding padding=True for numpy version 1.26.4
+        encoded_sequences_1 = feature_extractor(speech_inputs, return_tensors="np", padding=True).input_values
+        encoded_sequences_2 = feature_extractor(np_speech_inputs, return_tensors="np", padding=True).input_values
         for enc_seq_1, enc_seq_2 in zip(encoded_sequences_1, encoded_sequences_2):
             self.assertTrue(np.allclose(enc_seq_1, enc_seq_2, atol=1e-3))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix different length for numpy>=1.24.x

numpy version >= 1.24.x, the following code is not work
```python
import numpy as np
arr = np.asarray([[1], [1,2]])
```
numpy version =1.23.x gives the warning as follows:
```
<stdin>:1: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
```
