### PR TITLE
【AutoParallel】Change benchmark config for llama2-7b

### DIFF
--- a/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
+++ b/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
@@ -25,7 +25,7 @@
   "learning_rate": 3e-05,
   "min_learning_rate": 3e-06,
   "warmup_steps": 30,
-  "logging_steps": 1,
+  "logging_steps": 10,
   "max_steps": 50,
   "save_steps": 5000,
   "eval_steps": 1000,

--- a/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
+++ b/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
@@ -9,6 +9,7 @@
   "tensor_parallel_degree": 1,
   "pipeline_parallel_degree": 1,
   "sharding": "stage2",
+  "data_parallel_config": "enable_allreduce_avg_in_gradinent_scale gradient_sync_after_accumulate",
   "sharding_parallel_config": "enable_stage2_overlap",
   "tensor_parallel_config": "enable_mp_async_allreduce",
   "pipeline_parallel_config": "",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Enable to use `reduce_agv` to replace `reduce_sum + scale`. 