### PR TITLE
【AutoParallel】Change `max_steps` in Llama2-7b config for auto-parallel.

### DIFF
--- a/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
+++ b/tests/test_tipc/static/auto_parallel/llama2/pretrain_config_llama2_7b/pretrain-llama2_7b.json
@@ -26,7 +26,7 @@
   "min_learning_rate": 3e-06,
   "warmup_steps": 30,
   "logging_steps": 10,
-  "max_steps": 50,
+  "max_steps": 500,
   "save_steps": 5000,
   "eval_steps": 1000,
   "weight_decay": 0.01,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Change `max_steps` in Llama2-7b config for auto-parallel.