### PR TITLE
【pir save 】Modiy export llama model file in pir mode

### DIFF
--- a/llm/predict/export_model.py
+++ b/llm/predict/export_model.py
@@ -55,12 +55,15 @@ def validate_pdmodel(model_path, model_prefix, device):
         net_program, feed_target_names, fetch_targets = paddle.static.io.load_inference_model(
             os.path.join(model_path, model_prefix), exe
         )
+
         if not paddle.framework.use_pir_api():
             for block in net_program.blocks:
                 ops: list[paddle.framework.Operator] = block.ops
                 for op in tqdm(ops, desc="checking the validation of ops"):
                     if op.type.lower() == "print":
-                        logger.warning(f"UNEXPECTED OP<{op.type}> which will reduce the performace of the static model")
+                        logger.warning(
+                            f"UNEXPECTED OP<{op.type}> which will reduce the performace of the static model"
+                        )
 
 
 def main():

--- a/llm/predict/export_model.py
+++ b/llm/predict/export_model.py
@@ -55,12 +55,12 @@ def validate_pdmodel(model_path, model_prefix, device):
         net_program, feed_target_names, fetch_targets = paddle.static.io.load_inference_model(
             os.path.join(model_path, model_prefix), exe
         )
-
-        for block in net_program.blocks:
-            ops: list[paddle.framework.Operator] = block.ops
-            for op in tqdm(ops, desc="checking the validation of ops"):
-                if op.type.lower() == "print":
-                    logger.warning(f"UNEXPECTED OP<{op.type}> which will reduce the performace of the static model")
+        if not paddle.framework.use_pir_api():
+            for block in net_program.blocks:
+                ops: list[paddle.framework.Operator] = block.ops
+                for op in tqdm(ops, desc="checking the validation of ops"):
+                    if op.type.lower() == "print":
+                        logger.warning(f"UNEXPECTED OP<{op.type}> which will reduce the performace of the static model")
 
 
 def main():

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1091,8 +1091,13 @@ class GenerationMixin(object):
             next_tokens = paddle.argmax(probs, axis=-1).unsqueeze(-1)
             next_scores = paddle.index_sample(probs, next_tokens)
 
-            if pad_token_id is not None:
-                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
+            if eos_token_id is not None:
+                if pad_token_id is None:
+                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
+                else:
+                    next_tokens = paddle.where(
+                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
+                    )
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
             cur_len += 1
@@ -1234,8 +1239,13 @@ class GenerationMixin(object):
 
             next_scores = paddle.index_sample(origin_probs, next_tokens)
 
-            if pad_token_id is not None:
-                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
+            if eos_token_id is not None:
+                if pad_token_id is None:
+                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
+                else:
+                    next_tokens = paddle.where(
+                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
+                    )
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
@@ -1406,8 +1416,13 @@ class GenerationMixin(object):
             next_scores = paddle.index_sample(origin_probs, next_tokens)
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
-            if pad_token_id is not None:
-                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
+            if eos_token_id is not None:
+                if pad_token_id is None:
+                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
+                else:
+                    next_tokens = paddle.where(
+                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
+                    )
 
             input_ids = paddle.concat([input_ids, next_tokens], axis=1)
 

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1091,7 +1091,7 @@ class GenerationMixin(object):
             next_tokens = paddle.argmax(probs, axis=-1).unsqueeze(-1)
             next_scores = paddle.index_sample(probs, next_tokens)
 
-            if eos_token_id is not None:
+            if eos_token_id is not None and pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
@@ -1234,7 +1234,7 @@ class GenerationMixin(object):
 
             next_scores = paddle.index_sample(origin_probs, next_tokens)
 
-            if eos_token_id is not None:
+            if eos_token_id is not None and pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1091,7 +1091,7 @@ class GenerationMixin(object):
             next_tokens = paddle.argmax(probs, axis=-1).unsqueeze(-1)
             next_scores = paddle.index_sample(probs, next_tokens)
 
-            if eos_token_id is not None and pad_token_id is not None:
+            if pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
@@ -1234,7 +1234,7 @@ class GenerationMixin(object):
 
             next_scores = paddle.index_sample(origin_probs, next_tokens)
 
-            if eos_token_id is not None and pad_token_id is not None:
+            if pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
@@ -1406,7 +1406,7 @@ class GenerationMixin(object):
             next_scores = paddle.index_sample(origin_probs, next_tokens)
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
-            if eos_token_id is not None and pad_token_id is not None:
+            if pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             input_ids = paddle.concat([input_ids, next_tokens], axis=1)

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1406,7 +1406,7 @@ class GenerationMixin(object):
             next_scores = paddle.index_sample(origin_probs, next_tokens)
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
-            if eos_token_id is not None:
+            if eos_token_id is not None and pad_token_id is not None:
                 next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             input_ids = paddle.concat([input_ids, next_tokens], axis=1)

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -594,6 +594,12 @@ class GenerationMixin(object):
             kwargs["use_fp16_decoding"] = True
         self.prepare_fast_entry(kwargs)
 
+    def set_pad_token_id(self, pad_token_id, eos_token_id):
+        if pad_token_id is None and eos_token_id is not None:
+            print("Setting `pad_token_id` to `eos_token_id`:{} for " "open-end generation.".format(eos_token_id))
+            pad_token_id = eos_token_id
+        return pad_token_id
+
     @paddle.no_grad()
     def generate(
         self,
@@ -869,9 +875,7 @@ class GenerationMixin(object):
                     "`streamer` cannot be used with beam search (yet!). Make sure that `num_beams` is set to 1."
                 )
 
-        if pad_token_id is None and eos_token_id is not None:
-            print("Setting `pad_token_id` to `eos_token_id`:{} for " "open-end generation.".format(eos_token_id))
-            pad_token_id = eos_token_id
+        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
 
         if generation_config.max_length != 0 and generation_config.max_new_tokens == DEFAULT_MAX_NEW_TOKENS:
             logger.warning("`max_length` will be deprecated in future releases, use `max_new_tokens` instead.")
@@ -1038,6 +1042,7 @@ class GenerationMixin(object):
         synced_gpus=False,
         **model_kwargs
     ):
+        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
         model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
@@ -1092,12 +1097,7 @@ class GenerationMixin(object):
             next_scores = paddle.index_sample(probs, next_tokens)
 
             if eos_token_id is not None:
-                if pad_token_id is None:
-                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
-                else:
-                    next_tokens = paddle.where(
-                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
-                    )
+                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
             cur_len += 1
@@ -1148,6 +1148,7 @@ class GenerationMixin(object):
         synced_gpus=False,
         **model_kwargs
     ):
+        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
         model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
 
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
@@ -1238,14 +1239,8 @@ class GenerationMixin(object):
                 )
 
             next_scores = paddle.index_sample(origin_probs, next_tokens)
-
             if eos_token_id is not None:
-                if pad_token_id is None:
-                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
-                else:
-                    next_tokens = paddle.where(
-                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
-                    )
+                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
 
@@ -1343,6 +1338,7 @@ class GenerationMixin(object):
         min_tokens_to_keep=1,
     ):
 
+        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
         if paddle.is_tensor(top_k) and not paddle.is_tensor(top_p):
@@ -1382,7 +1378,9 @@ class GenerationMixin(object):
             del model_inputs["use_cache"]
             return self(**model_inputs, **immutable)
 
-        def _post_process_(outputs, input_ids, cur_len, origin_len, scores, unfinished_flag, model_kwargs):
+        def _post_process_(
+            outputs, input_ids, cur_len, origin_len, scores, unfinished_flag, model_kwargs, pad_token_id
+        ):
             if isinstance(outputs, tuple):
                 logits = outputs[0]
             elif isinstance(outputs, ModelOutput):
@@ -1415,14 +1413,8 @@ class GenerationMixin(object):
 
             next_scores = paddle.index_sample(origin_probs, next_tokens)
             scores = self.update_scores_for_generation(scores, next_scores, cur_len - origin_len, unfinished_flag)
-
             if eos_token_id is not None:
-                if pad_token_id is None:
-                    next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, 0.0))
-                else:
-                    next_tokens = paddle.where(
-                        unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id)
-                    )
+                next_tokens = paddle.where(unfinished_flag, next_tokens, paddle.full_like(next_tokens, pad_token_id))
 
             input_ids = paddle.concat([input_ids, next_tokens], axis=1)
 
@@ -1437,7 +1429,7 @@ class GenerationMixin(object):
 
         outputs = _forward_(**model_kwargs)
         input_ids, scores, unfinished_flag, model_kwargs = _post_process_(
-            outputs, input_ids, cur_len_gpu, origin_len_gpu, scores, unfinished_flag, model_kwargs
+            outputs, input_ids, cur_len_gpu, origin_len_gpu, scores, unfinished_flag, model_kwargs, pad_token_id
         )
 
         if hasattr(paddle.framework, "_no_check_dy2st_diff"):
@@ -1471,6 +1463,7 @@ class GenerationMixin(object):
                         scores,
                         unfinished_flag,
                         model_kwargs,
+                        pad_token_id,
                     )
                     paddle.increment(cur_len)
                     paddle.increment(cur_len_gpu)
@@ -1484,6 +1477,7 @@ class GenerationMixin(object):
                     scores,
                     unfinished_flag,
                     model_kwargs,
+                    pad_token_id,
                 )
                 paddle.increment(cur_len)
                 paddle.increment(cur_len_gpu)

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1042,7 +1042,6 @@ class GenerationMixin(object):
         synced_gpus=False,
         **model_kwargs
     ):
-        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
         model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()
 
@@ -1148,7 +1147,6 @@ class GenerationMixin(object):
         synced_gpus=False,
         **model_kwargs
     ):
-        pad_token_id = self.set_pad_token_id(pad_token_id, eos_token_id)
         model_kwargs["use_cache"] = model_kwargs.get("use_cache", True)
 
         logits_processors = logits_processors if logits_processors is not None else LogitsProcessorList()

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -255,7 +255,7 @@ def scaled_dot_product_attention(
             alibi = alibi.reshape([bsz, num_heads, 1, -1])
             attn_weights = attn_weights + alibi
 
-        if attn_weights.shape != [bsz, num_heads, q_len, kv_seq_len]:
+        if paddle.in_dynamic_mode() and attn_weights.shape != [bsz, num_heads, q_len, kv_seq_len]:
             raise ValueError(
                 f"Attention weights should be of shape {(bsz, num_heads, q_len, kv_seq_len)}, but is"
                 f" {attn_weights.shape}"
@@ -271,7 +271,7 @@ def scaled_dot_product_attention(
         if attention_mask is None:
             attention_mask = get_triangle_upper_mask(attn_weights)
         attention_mask = attention_mask.reshape([bsz, 1, q_len, kv_seq_len])
-        if attention_mask.shape != [bsz, 1, q_len, kv_seq_len]:
+        if paddle.in_dynamic_mode() and attention_mask.shape != [bsz, 1, q_len, kv_seq_len]:
             raise ValueError(
                 f"Attention mask should be of shape {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.shape}"
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
pcard-67164
修改多处代码支持在pir模式下对llama-2-7b模型导出
1. 动转静下遇到动态shape 无法导出，需要将paddlenlp/transformers/llama/modeling.py 中关于attn_weights.shape 的判断代码在动转静下跳过。因为动态图运行此处可以拦截错误，动转静不会出现问题。
2. 当pad_token_id = None 时，PIR下不允许传递给full_like 的value 是none,此处逻辑不完备，generate 函数中会判断如果没有pad_token_id 时将pad_token_id 设置为eos_token_id
3. PIR下没有print op 且op相关的方法也不同。需要进行分支处理