### PR TITLE
【inference】support load or save Llama2-7b in three patterns

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -366,7 +366,7 @@ class StaticGraphPredictor(BasePredictor):
         # inference_config.disable_glog_info()
         inference_config.enable_new_executor()
 
-        if paddle.framework.use_pir_api() or in_pir_executor_mode():
+        if in_pir_executor_mode():
             inference_config.enable_new_ir()
             if in_cinn_mode():
                 inference_config.enable_cinn()

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -361,15 +361,13 @@ class StaticGraphPredictor(BasePredictor):
             # set CPU configs accordingly,
             # such as enable_mkldnn, set_cpu_math_library_num_threads
             inference_config.disable_gpu()
-        # inference_config.disable_glog_info()
+        inference_config.disable_glog_info()
         inference_config.enable_new_executor()
 
         if in_pir_executor_mode():
             inference_config.enable_new_ir()
             if in_cinn_mode():
                 inference_config.enable_cinn()
-        # if use optimized_model to inference
-        # inference_config.use_optimized_model(True)
 
         with static_mode_guard():
             self.predictor = paddle.inference.create_predictor(inference_config)

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -347,9 +347,7 @@ class StaticGraphPredictor(BasePredictor):
         super().__init__(config, tokenizer)
 
         params_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".pdiparams")
-        # set FLAGS_enable_pir_api True json+pir
-        # set FLAGS_enable_pir_api False pdmodel+old ir
-        # set FLAGS_enable_pir_api False  FLAGS_enable_pir_in_executor True pdmodel+ pir ir
+
         if paddle.framework.use_pir_api():
             model_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".json")
         else:

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -347,7 +347,6 @@ class StaticGraphPredictor(BasePredictor):
         super().__init__(config, tokenizer)
 
         params_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".pdiparams")
-
         if paddle.framework.use_pir_api():
             model_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".json")
         else:
@@ -363,7 +362,6 @@ class StaticGraphPredictor(BasePredictor):
             inference_config.disable_gpu()
         inference_config.disable_glog_info()
         inference_config.enable_new_executor()
-
         if in_pir_executor_mode():
             inference_config.enable_new_ir()
             if in_cinn_mode():
@@ -377,6 +375,7 @@ class StaticGraphPredictor(BasePredictor):
     def _preprocess(self, input_text: str | list[str]):
         inputs = super()._preprocess(input_text)
         inputs["max_new_tokens"] = np.array(self.config.max_length, dtype="int64")
+
         inputs["top_p"] = np.array(self.config.top_p, dtype="float32")
         inputs["temperature"] = np.array(self.config.temperature, dtype="float32")
         inputs["top_k"] = np.array(self.config.top_k, dtype="int64")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

补充:

- 导出pdmodel:

`python ./predict/export_model.py --model_name_or_path meta-llama/Llama-2-7b-chat --output_path ./inference --dtype float16`

- 导出json:

`FLAGS_enable_pir_api=1  python ./predict/export_model.py --model_name_or_path meta-llama/Llama-2-7b-chat --output_path ./inference --dtype float16`

支持三种模式跑

- 跑Llama2-7b.pdmodel +旧ir 

`python ./predict/predictor.py --model_name_or_path ./llama2-7b --dtype float16 --mode static`

- 跑Llama2-7b.pdmodel +pir

`FLAGS_enable_pir_in_executor=1 python ./predict/predictor.py --model_name_or_path ./llama2-7b --dtype float16 --mode static`

- 跑Llama2-7b.json +pir

`FLAGS_enable_pir_api=1 python ./predict/predictor.py --model_name_or_path ./inference --dtype float16 --mode static`
如需测试保存优化后的模型再推理，设置inference_config.use_optimized_model(True)，第一次执行会先保存优化后的模型，第二次执行，会直接加载优化后的模型进行推理