### PR TITLE
enable use_fast_layer_norm for llama2 benchmark

### DIFF
--- a/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_13b/pretrain-llama2_13b-auto_tuner.json
+++ b/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_13b/pretrain-llama2_13b-auto_tuner.json
@@ -16,6 +16,7 @@
     "sequence_parallel": 0,   
     "use_flash_attention": true,
     "use_fused_rms_norm": true,
+    "use_fast_layer_norm": true,
     "fuse_attention_ffn": true,
     "fuse_attention_qkv": true,
     "use_fused_rope": true,

--- a/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_70b/pretrain-llama2_70b-auto_tuner.json
+++ b/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_70b/pretrain-llama2_70b-auto_tuner.json
@@ -16,6 +16,7 @@
     "sequence_parallel": 1,   
     "use_flash_attention": true,
     "use_fused_rms_norm": true,
+    "use_fast_layer_norm": true,
     "fuse_attention_ffn": true,
     "fuse_attention_qkv": true,
     "use_fused_rope": true,

--- a/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_7b/pretrain-llama2_7b-auto_tuner.json
+++ b/tests/test_tipc/dygraph/hybrid_parallelism/llama2/auto_config_llama2_7b/pretrain-llama2_7b-auto_tuner.json
@@ -16,6 +16,7 @@
     "sequence_parallel": 0,   
     "use_flash_attention": true,
     "use_fused_rms_norm": true,
+    "use_fast_layer_norm": true,
     "fuse_attention_ffn": true,
     "fuse_attention_qkv": true,
     "use_fused_rope": true,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
开启use_fast_layer_norm，从而在llama2的benchmark中取得更好的性能收益指标