### PR TITLE
[Safetensors] Fix mmap for Windows system

### DIFF
--- a/paddlenlp/trainer/plugins/unified_checkpoint.py
+++ b/paddlenlp/trainer/plugins/unified_checkpoint.py
@@ -17,6 +17,7 @@ import gc
 import json
 import multiprocessing
 import os
+import sys
 
 import numpy as np
 import paddle
@@ -67,10 +68,12 @@ from paddlenlp.utils.nested import nested_copy, nested_copy_place
 from paddlenlp.utils.tools import get_env_device
 
 if is_safetensors_available():
-    # from safetensors import safe_open
     from safetensors.numpy import save_file as safe_save_file
 
-    from paddlenlp.utils.safetensors import fast_safe_open as safe_open
+    if sys.platform.startswith("win"):
+        from safetensors import safe_open
+    else:
+        from paddlenlp.utils.safetensors import fast_safe_open as safe_open
 
 FP32_MASTER = "fp32_master_0"
 optimizer_scalar_name = [

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -20,6 +20,7 @@ import inspect
 import json
 import os
 import re
+import sys
 import tempfile
 import warnings
 from contextlib import contextmanager
@@ -108,12 +109,13 @@ def unwrap_optimizer(optimizer, optimizer_instances=()):
 
 
 if is_safetensors_available():
-
-    # from safetensors import safe_open
     from safetensors.numpy import load_file as safe_load_file
     from safetensors.numpy import save_file as safe_save_file
 
-    from paddlenlp.utils.safetensors import fast_safe_open as safe_open
+    if sys.platform.startswith("win"):
+        from safetensors import safe_open
+    else:
+        from paddlenlp.utils.safetensors import fast_safe_open as safe_open
 
 
 def prune_linear_layer(layer: nn.Linear, index: paddle.Tensor, dim: int = 0) -> nn.Linear:

--- a/paddlenlp/utils/safetensors.py
+++ b/paddlenlp/utils/safetensors.py
@@ -15,7 +15,6 @@
 import copy
 import json
 import mmap
-import sys
 from collections import OrderedDict
 
 import numpy as np
@@ -278,10 +277,7 @@ class fast_safe_open:
         self.filename = filename
         self.framework = framework
         self.file = open(self.filename, "rb")
-        if sys.platform.startswith("win"):
-            self.file_mmap = mmap.mmap(self.file.fileno(), 0)
-        else:
-            self.file_mmap = mmap.mmap(self.file.fileno(), 0, flags=mmap.MAP_PRIVATE)
+        self.file_mmap = mmap.mmap(self.file.fileno(), 0, flags=mmap.MAP_PRIVATE)
         self.base, self.tensors_decs, self.__metadata__ = read_metadata(self.file)
         self.tensors = OrderedDict()
         for key, info in self.tensors_decs.items():

--- a/paddlenlp/utils/safetensors.py
+++ b/paddlenlp/utils/safetensors.py
@@ -15,6 +15,7 @@
 import copy
 import json
 import mmap
+import sys
 from collections import OrderedDict
 
 import numpy as np
@@ -277,7 +278,10 @@ class fast_safe_open:
         self.filename = filename
         self.framework = framework
         self.file = open(self.filename, "rb")
-        self.file_mmap = mmap.mmap(self.file.fileno(), 0, flags=mmap.MAP_PRIVATE)
+        if sys.platform.startswith("win"):
+            self.file_mmap = mmap.mmap(self.file.fileno(), 0)
+        else:
+            self.file_mmap = mmap.mmap(self.file.fileno(), 0, flags=mmap.MAP_PRIVATE)
         self.base, self.tensors_decs, self.__metadata__ = read_metadata(self.file)
         self.tensors = OrderedDict()
         for key, info in self.tensors_decs.items():

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -296,6 +296,22 @@ def require_package(*package_names):
     return decorator
 
 
+def skip_platform(*platform):
+    """decorator which can detect that it will skip the specific platform
+
+    Args:
+        platform (str): the name of platform, including win32, cygwin, linux, and darwin
+    """
+
+    def decorator(func):
+        for plat in platform:
+            if sys.platform.startswith(plat):
+                return unittest.skip(f"platform<{plat}> matched, so to skip this test")(func)
+        return func
+
+    return decorator
+
+
 def is_slow_test() -> bool:
     """check whether is the slow test
 

--- a/tests/transformers/test_safetensors.py
+++ b/tests/transformers/test_safetensors.py
@@ -17,11 +17,11 @@ import tempfile
 import unittest
 
 import numpy as np
-
-# from safetensors import safe_open
 from safetensors.numpy import load_file, save_file
 
 from paddlenlp.utils.safetensors import fast_load_file, fast_safe_open
+
+from ..testing_utils import skip_platform
 
 
 class FastSafetensors(unittest.TestCase):
@@ -42,6 +42,7 @@ class FastSafetensors(unittest.TestCase):
             count += 1
         print(self.weigth_map)
 
+    @skip_platform("win32", "cygwin")
     def test_load_file(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "test.safetensors")
@@ -52,6 +53,7 @@ class FastSafetensors(unittest.TestCase):
                 np.testing.assert_equal(v, sf_load[k])
                 np.testing.assert_equal(v, fs_sf_load[k])
 
+    @skip_platform("win32", "cygwin")
     def test_safe_open(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "test.safetensors")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
To address the disparities in mmap APIs across Windows and Unix, this PR includes checks for operating system differences.

The mmap comment is copied as follows:
```text
Windows: mmap(fileno, length[, tagname[, access[, offset]]])

Maps length bytes from the file specified by the file handle fileno, and returns a mmap object. If length is larger than the current size of the file, the file is extended to contain length bytes. If length is 0, the maximum length of the map is the current size of the file, except that if the file is empty Windows raises an exception (you cannot create an empty mapping on Windows).

Unix: mmap(fileno, length[, flags[, prot[, access[, offset]]]])

Maps length bytes from the file specified by the file descriptor fileno, and returns a mmap object. If length is 0, the maximum length of the map will be the current size of the file when mmap is called. flags specifies the nature of the mapping. MAP_PRIVATE creates a private copy-on-write mapping, so changes to the contents of the mmap object will be private to this process, and MAP_SHARED creates a mapping that's shared with all other processes mapping the same areas of the file. The default value is MAP_SHARED.

To map anonymous memory, pass -1 as the fileno (both versions).
```
