### PR TITLE
Fix fast_ln compilation in CUDA 12.3

### DIFF
--- a/legacy/model_zoo/gpt-3/external_ops/fast_ln/ln.h
+++ b/legacy/model_zoo/gpt-3/external_ops/fast_ln/ln.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <cstdio>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <unordered_map>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
Fix fast_ln compilation in CUDA 12.3.