### PR TITLE
[NPU] Fix sequence parallel lib import

### DIFF
--- a/paddlenlp/peft/lora/lora_layers.py
+++ b/paddlenlp/peft/lora/lora_layers.py
@@ -26,20 +26,19 @@ from paddle.distributed.fleet.meta_parallel import (
 
 from ...transformers import linear_utils
 
+ColumnSequenceParallelLinear = linear_utils.ColumnSequenceParallelLinear
+RowSequenceParallelLinear = linear_utils.RowSequenceParallelLinear
+
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         AllGatherOp,
-        ColumnSequenceParallelLinear,
         ReduceScatterOp,
-        RowSequenceParallelLinear,
         mark_as_sequence_parallel_parameter,
     )
 except:
     AllGatherOp = None
     ReduceScatterOp = None
     mark_as_sequence_parallel_parameter = None
-    ColumnSequenceParallelLinear = linear_utils.ColumnSequenceParallelLinear
-    RowSequenceParallelLinear = linear_utils.RowSequenceParallelLinear
 
 
 from ...transformers.mc2_parallel_linear import (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix sequence parallel lib import.

1. When replacing LoRA module for `npu` device, `ColumnSequenceParallelLoRALinear` and `RowSequenceParallelLoRALinear` should inherit from `MC2ColumnSeqParallelLinear` and `MC2RowSeqParallelLinear`, respectively.
2. `export FLAGS_NPU_MC2=1` can open `MC2ColumnSeqParallelLinear` and `MC2RowSeqParallelLinear`.

