### PR TITLE
【inference】support load or save Llama2-7b in three patterns

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -346,9 +346,7 @@ class StaticGraphPredictor(BasePredictor):
     def __init__(self, config: PredictorArgument, tokenizer: PretrainedTokenizer = None):
         super().__init__(config, tokenizer)
 
-        params_path = self.config.model_prefix
-        model_path = self.config.model_name_or_path
-        inference_config = paddle.inference.Config(model_path, params_path)
+        inference_config = paddle.inference.Config(self.config.model_name_or_path, self.config.model_prefix)
 
         if self.config.device == "gpu":
             # set GPU configs accordingly

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -346,11 +346,8 @@ class StaticGraphPredictor(BasePredictor):
     def __init__(self, config: PredictorArgument, tokenizer: PretrainedTokenizer = None):
         super().__init__(config, tokenizer)
 
-        params_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".pdiparams")
-        if paddle.framework.use_pir_api():
-            model_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".json")
-        else:
-            model_path = os.path.join(self.config.model_name_or_path, self.config.model_prefix + ".pdmodel")
+        params_path = self.config.model_prefix
+        model_path = self.config.model_name_or_path
         inference_config = paddle.inference.Config(model_path, params_path)
 
         if self.config.device == "gpu":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
补充:

- 导出pdmodel:

`python ./predict/export_model.py --model_name_or_path meta-llama/Llama-2-7b-chat --output_path ./llama_pdmodel --dtype float16`

- 导出json:

`FLAGS_enable_pir_api=1  python ./predict/export_model.py --model_name_or_path meta-llama/Llama-2-7b-chat --output_path ./llama-json --dtype float16`

支持三种模式跑

- 跑Llama2-7b.pdmodel +旧ir 

`python ./predict/predictor.py --model_name_or_path ./llama_pdmodel  --dtype float16 --mode static`

- 跑Llama2-7b.pdmodel +pir

`FLAGS_enable_pir_in_executor=1 python ./predict/predictor.py --model_name_or_path ./llama_pdmodel  --dtype float16 --mode static`

- 跑Llama2-7b.json +pir

`FLAGS_enable_pir_api=1 python ./predict/predictor.py --model_name_or_path ./llama-json  --dtype float16 --mode static`
如需测试保存优化后的模型再推理，设置inference_config.use_optimized_model(True)，第一次执行会先保存优化后的模型，第二次执行，会直接加载优化后的模型进行推理