### PR TITLE
Add the missing truncation=True in llm/predictor.py

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -974,6 +974,7 @@ class BlockInferencePredictorMixin:
                 text,
                 return_tensors="np",
                 padding=True,
+                truncation=True,
                 max_length=self.config.src_length,
                 # if use chat_template, it will not add special_tokens
                 add_special_tokens=self.tokenizer.chat_template is None
@@ -1224,7 +1225,7 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin, BasePredictor)
     def _preprocess(self, source):
         BlockInferencePredictorMixin._preprocess(self, source)
         for i, text in enumerate(source):
-            tokens = self.tokenizer(text, return_tensors="np", padding=False, max_length=(self.config.src_length))
+            tokens = self.tokenizer(text, return_tensors="np", padding=False, truncation=True, max_length=(self.config.src_length))
             input_ids = tokens["input_ids"][0]
             length = len(input_ids)
             need_block_nums = (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
In `llm/predictor.py`, two calls to `tokenizer` are missing the `truncation=True` parameter, causing the results not to be truncated to `max_length`. This leads to errors in subsequent processing when using `--benchmark` for testing. This PR fixes this issue.