### PR TITLE
fix incorrect token counting in `llm/predictor.py`

### DIFF
--- a/llm/utils/utils.py
+++ b/llm/utils/utils.py
@@ -797,7 +797,7 @@ def read_res(model_name_or_path: str, tensor_queue: mp.Queue, result_queue: mp.Q
             break
     output = np.concatenate(outputs, axis=1).tolist()
     seqs = tokenizer.batch_decode(output, skip_special_tokens=True, clean_up_tokenization_spaces=False)
-    for i, seq in enumerate(seqs):
-        result_queue.put([i, seq])
+    for i, (out, seq) in enumerate(zip(output, seqs)):
+        result_queue.put([i, out, seq])
 
     logger.info("Finish read result message")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what this PR does -->
The `benchmark()` function is currently counting the number of generated characters instead of the generated tokens, which is incorrect for speed test. This PR modified the `predict()` interface and let it can optionally return the generated tokens before postprocessing, so that it can count the number of generated tokens in the `benchmark()` function.