### PR TITLE
Adjust the interface AutoTrainer._wrap_for_dist_loader

### DIFF
--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -101,11 +101,12 @@ class AutoTrainer(Trainer):
             meshes.append(_get_mesh(self.args.pipeline_parallel_degree - 1))
         return meshes
 
-    def _wrap_for_dist_loader(self, train_dataloader):
+    def _wrap_for_dist_loader(self, train_dataloader, is_dataset_splitted=False):
         dist_loader = dist.shard_dataloader(
             dataloader=train_dataloader,
             meshes=self._get_meshes_for_loader(),
             shard_dims="dp",
+            is_dataset_splitted=is_dataset_splitted,
         )
         return dist_loader
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
auto_trainer中shard_dataloader默认切dp，不支持用户通过collate_fn自定义组batch，修改_wrap_for_dist_loader接口以支持对shard_dataloader行为的控制