### PR TITLE
fix version show

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import errno
 import io
 import os
 import subprocess
+from datetime import datetime
 
 import setuptools
 
@@ -113,7 +114,8 @@ __version__ = "3.0.0b0.post"
 if os.getenv(PADDLENLP_STABLE_VERSION):
     __version__ = __version__.replace(".post", "")
 else:
-    __version__ = __version__.replace(".post", "+{}".format(commit[:7]))
+    formatted_date = datetime.now().date().strftime("%Y%m%d")
+    __version__ = __version__.replace(".post", ".dev{}".format(formatted_date))
 
 
 extras = {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
#8754 makes the style of the version `3.0.0b0+a3223317` (`version+commit id`). However, that does not allow us to get the latest version from `https://www.paddlepaddle.org.cn/whl/paddlenlp.html` based on the latest date. Thus, we have modified the version style to `3.0.0b0.dev20240722` (`version+datetime`).