### PR TITLE
update version

### DIFF
--- a/paddlenlp/__init__.py
+++ b/paddlenlp/__init__.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+from datetime import datetime
 
 PADDLENLP_STABLE_VERSION = "PADDLENLP_STABLE_VERSION"
 
@@ -21,6 +22,9 @@ PADDLENLP_STABLE_VERSION = "PADDLENLP_STABLE_VERSION"
 __version__ = "3.0.0b0.post"
 if os.getenv(PADDLENLP_STABLE_VERSION):
     __version__ = __version__.replace(".post", "")
+else:
+    formatted_date = datetime.now().date().strftime("%Y%m%d")
+    __version__ = __version__.replace(".post", ".post{}".format(formatted_date))
 
 if "datasets" in sys.modules.keys():
     from paddlenlp.utils.log import logger

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if os.getenv(PADDLENLP_STABLE_VERSION):
     __version__ = __version__.replace(".post", "")
 else:
     formatted_date = datetime.now().date().strftime("%Y%m%d")
-    __version__ = __version__.replace(".post", ".dev{}".format(formatted_date))
+    __version__ = __version__.replace(".post", ".post{}".format(formatted_date))
 
 
 extras = {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
#8754 and #8791 make the style of the version  `3.0.0b0.dev20240723` (version+datetime). However, that does not allow us to get the latest version from https://www.paddlepaddle.org.cn/whl/paddlenlp.html based on the latest date. Thus, we have modified the version style to `3.0.0b0.post202407223` (version+post+datetime).