### PR TITLE
[DCU] fix llama inference bug on DCU

### DIFF
--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -550,11 +550,7 @@ class FusedMultiTransformerBase(Layer):
             if config.trans_qkvw
             else [self.embed_dim, (self.num_heads + 2 * self.kv_num_heads) * self.head_dim]
         )
-        self.linear_weight_shape = (
-            [self.num_heads * self.head_dim, self.embed_dim]
-            if config.trans_qkvw
-            else [self.embed_dim, self.num_heads * self.head_dim]
-        )
+        self.linear_weight_shape = [self.num_heads * self.head_dim, self.embed_dim]
         self.ffn1_weight_shape = (
             [self.embed_dim, self.dim_feedforward * 2]
             if self.activation.endswith("glu")

--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -565,7 +565,7 @@ class LlamaInferenceModel(LlamaPretrainedModel):
             use_neox_rotary_style=True,
             use_dynamic_cachekv_quant=config.use_cachekv_int8 == "dynamic",
             rank_id=config.tensor_parallel_rank,
-            trans_qkvw=(True if not paddle.is_compiled_with_rocm() else False),
+            trans_qkvw=(False if paddle.is_compiled_with_rocm() and self.quant_type == "a8w8" else True),
         )
 
         self.set_transformer_block(transformer_config)
@@ -752,7 +752,7 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                 unfused_state_dict["self_attn.v_proj.weight"] = state_dict[
                     "llama.layers.{}.self_attn.v_proj.weight".format(idx)
                 ]
-                if paddle.is_compiled_with_rocm():
+                if paddle.is_compiled_with_rocm() and self.quant_type == "a8w8":
                     concated_qkv_weight = np.concatenate(
                         [
                             unfused_state_dict["self_attn.q_proj.weight"],


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Models

### Description
<!-- Describe what this PR does -->
Some changes in [PR 8800](https://github.com/PaddlePaddle/PaddleNLP/pull/8800) affect the function of DCU in other inference scenarios, so restrictions are added to reduce the scope of impact.

The following scenarios have been tested on the DCU

- dynamic
  - [x] fp16
  - [x] a8w8
  - [x] a8w8c8
- static
  - [x] fp16
  - [x] a8w8
  - [x] a8w8c8