### PR TITLE
modify Paddlemix qwen dytostatic 

### DIFF
--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import paddle
 import paddle.distributed as dist
-from paddle.framework import LayerHelper, core, in_dynamic_mode
+from paddle.framework import LayerHelper, core, in_dynamic_or_pir_mode
 from paddle.incubate.nn.functional import (
     fused_layer_norm,
     fused_rms_norm,
@@ -88,7 +88,7 @@ def fused_act_bias_wrapper(
     quant_max_bound=0,
     quant_min_bound=0,
 ):
-    if in_dynamic_mode():
+    if in_dynamic_or_pir_mode():
         return paddle._C_ops.fused_bias_act(
             x,
             bias,

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import paddle
 import paddle.distributed as dist
-from paddle.framework import LayerHelper, core, in_dynamic_or_pir_mode
+from paddle.framework import LayerHelper, core, in_dynamic_mode, in_dynamic_or_pir_mode
 from paddle.incubate.nn.functional import (
     fused_layer_norm,
     fused_rms_norm,
@@ -89,6 +89,7 @@ def fused_act_bias_wrapper(
     quant_min_bound=0,
 ):
     if in_dynamic_or_pir_mode():
+
         return paddle._C_ops.fused_bias_act(
             x,
             bias,

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -172,6 +172,7 @@ class GenerationInferenceModel(GenerationMixin):
         model_kwargs["frequency_score"] = frequency_score
         model_kwargs["presence_score"] = presence_score
         model_kwargs["logits_processors"] = logits_processors or LogitsProcessorList()
+        model_kwargs["pre_caches"] = pre_caches
 
         ret = self.sample(
             input_ids,
@@ -182,7 +183,7 @@ class GenerationInferenceModel(GenerationMixin):
             inputs_embeds=inputs_embeds,
             **model_kwargs,
         )
-        model_kwargs["pre_caches"] = pre_caches
+
         return ret
 
     def update_model_kwargs_for_generation(self, cache, just_decoder, next_tokens, eos_token_id, model_kwargs):

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -172,7 +172,6 @@ class GenerationInferenceModel(GenerationMixin):
         model_kwargs["frequency_score"] = frequency_score
         model_kwargs["presence_score"] = presence_score
         model_kwargs["logits_processors"] = logits_processors or LogitsProcessorList()
-        model_kwargs["pre_caches"] = pre_caches
 
         ret = self.sample(
             input_ids,
@@ -183,6 +182,7 @@ class GenerationInferenceModel(GenerationMixin):
             inputs_embeds=inputs_embeds,
             **model_kwargs,
         )
+        model_kwargs["pre_caches"] = pre_caches
         return ret
 
     def update_model_kwargs_for_generation(self, cache, just_decoder, next_tokens, eos_token_id, model_kwargs):

--- a/paddlenlp/generation/logits_process.py
+++ b/paddlenlp/generation/logits_process.py
@@ -291,7 +291,10 @@ class ForcedEOSTokenLogitsProcessor(LogitsProcessor):
 
 
 def TopKProcess(probs: paddle.Tensor, top_k: int, min_tokens_to_keep: int):
-    top_k = min(max(top_k, min_tokens_to_keep), probs.shape[-1])
+    top_k = paddle.minimum(
+        paddle.maximum(paddle.to_tensor(top_k), paddle.to_tensor(min_tokens_to_keep)),
+        paddle.to_tensor(probs.shape[-1]),
+    )
     # Remove all tokens with a probability less than the last token of the top-k
     # cast to float16 to support generation & d2s
     if probs.dtype == paddle.bfloat16:

--- a/tests/transformers/test_modeling_common.py
+++ b/tests/transformers/test_modeling_common.py
@@ -967,8 +967,10 @@ class GenerationD2STestMixin:
                         use_top_p=False,
                     ),
                 )
-
-                model_path = os.path.join(tempdir, "model.pdmodel")
+                if paddle.framework.use_pir_api():
+                    model_path = os.path.join(tempdir, "model.json")
+                else:
+                    model_path = os.path.join(tempdir, "model.pdmodel")
                 params_path = os.path.join(tempdir, "model.pdiparams")
                 config = paddle.inference.Config(model_path, params_path)
 
@@ -1036,7 +1038,10 @@ class GenerationD2STestMixin:
                     ),
                 )
 
-                model_path = os.path.join(tempdir, "model.pdmodel")
+                if paddle.framework.use_pir_api():
+                    model_path = os.path.join(tempdir, "model.json")
+                else:
+                    model_path = os.path.join(tempdir, "model.pdmodel")
                 params_path = os.path.join(tempdir, "model.pdiparams")
                 config = paddle.inference.Config(model_path, params_path)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
thers
### Description
<!-- Describe what this PR does -->
适配api 的pir 分支 支持qwen 模型pir模式动转静

使用非paddle api min， max 在动转静之后会恒定的返回第一个值，虽然可以导出，但可能会改变行为影响精度，因此使用paddle api 实现。