### PR TITLE
修复fast_ln算子动半开启后报错

### DIFF
--- a/legacy/model_zoo/gpt-3/external_ops/fast_ln/ln_api.cpp
+++ b/legacy/model_zoo/gpt-3/external_ops/fast_ln/ln_api.cpp
@@ -529,6 +529,14 @@ std::vector<std::vector<int64_t>> RMSLnBwdInferShape(
   return {x_shape, scale_shape};
 }
 
+std::vector<paddle::DataType> LnBwdInferDtype(paddle::DataType x_dtype,
+                                              paddle::DataType scale_dtype,
+                                              paddle::DataType mean_dtype,
+                                              paddle::DataType invvar_dtype,
+                                              paddle::DataType dy_dtype) {
+  return {x_dtype, scale_dtype, scale_dtype};
+}
+
 PD_BUILD_OP(fast_ln)
     .Inputs({"x", "scale", "bias"})
     .Outputs({"y", "mean", "invvar"})
@@ -542,7 +550,8 @@ PD_BUILD_GRAD_OP(fast_ln)
     .Outputs({paddle::Grad("x"), paddle::Grad("scale"), paddle::Grad("bias")})
     .Attrs({"epsilon: float"})
     .SetKernelFn(PD_KERNEL(LnBwd))
-    .SetInferShapeFn(PD_INFER_SHAPE(LnBwdInferShape));
+    .SetInferShapeFn(PD_INFER_SHAPE(LnBwdInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(LnBwdInferDtype));
 
 PD_BUILD_OP(fast_rms_norm)
     .Inputs({"x", "scale"})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Others

### PR changes
Others

### Description
动半中fast_ln算子在开启后，反向算子输出bias@GRAD但是找不到对应的输入，inferdtype会出错，这里给fast_ln定义自己的InferDtypeFn
