### PR TITLE
modify dict include none to aviod pir dytostatic bug in while op

### DIFF
--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -172,7 +172,8 @@ class GenerationInferenceModel(GenerationMixin):
         model_kwargs["frequency_score"] = frequency_score
         model_kwargs["presence_score"] = presence_score
         model_kwargs["logits_processors"] = logits_processors or LogitsProcessorList()
-        model_kwargs["pre_caches"] = pre_caches
+        if pre_caches is not None:
+            model_kwargs["pre_caches"] = pre_caches
 
         ret = self.sample(
             input_ids,
@@ -282,8 +283,10 @@ class GenerationInferenceModel(GenerationMixin):
 
         # let inputs_embeds enter into model_kwargs.
         # because the code below directly use the model_kwargs as a parameter without using inputs_embeds.
-        model_kwargs["inputs_embeds"] = inputs_embeds
-        model_kwargs["all_input_ids"] = input_ids
+        if inputs_embeds is not None:
+            model_kwargs["inputs_embeds"] = inputs_embeds
+        if input_ids is not None:
+            model_kwargs["all_input_ids"] = input_ids
         logits_processors = model_kwargs.pop("logits_processors")
 
         def _forward_(**args):

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -285,8 +285,7 @@ class GenerationInferenceModel(GenerationMixin):
         # because the code below directly use the model_kwargs as a parameter without using inputs_embeds.
         if inputs_embeds is not None:
             model_kwargs["inputs_embeds"] = inputs_embeds
-        if input_ids is not None:
-            model_kwargs["all_input_ids"] = input_ids
+        model_kwargs["all_input_ids"] = input_ids
         logits_processors = model_kwargs.pop("logits_processors")
 
         def _forward_(**args):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
pcard-67164
pir 下while op 要求输入和输出都是类型相同的value,  此处model_kwargs 作为while 的输入是一个dict ，dict 中包含了为none 的数据，while 无法支持，因此需要根据其是否为none 判断是否要加入dict中。 当这些参数为none时，sample 函数中不会使用到，因此不会对程序正确性产生影响
<img width="1001" alt="截屏2024-08-08 15 28 34" src="https://github.com/user-attachments/assets/16422fb7-cbfd-41fa-abc5-5031c43964f3">

