### PR TITLE
[Trainer] Fix distributed dataloader

### DIFF
--- a/paddlenlp/data/dist_dataloader.py
+++ b/paddlenlp/data/dist_dataloader.py
@@ -33,6 +33,11 @@ class DummyDataset(paddle.io.Dataset):
         return 0
 
 
+class IterableDummyDataset(paddle.io.IterableDataset):
+    def __iter__(self):
+        return None
+
+
 class DistDataLoader(paddle.io.DataLoader):
     """
     DistDataLoader is a wrapper of paddle.io.DataLoader.
@@ -57,10 +62,11 @@ class DistDataLoader(paddle.io.DataLoader):
         worker_init_fn=None,
         persistent_workers=False,
         eval=False,
+        is_iterable_dataset=False,
     ):
 
         if dataset is None:
-            dataset = DummyDataset()
+            dataset = DummyDataset() if not is_iterable_dataset else IterableDummyDataset()
             logger.info("rank has no data, use Dummpy dataset")
 
         super().__init__(dataset=dataset, batch_sampler=batch_sampler, collate_fn=collate_fn, num_workers=num_workers)
@@ -200,7 +206,7 @@ class DistDataLoader(paddle.io.DataLoader):
             try:
                 data = next(self._dataloader_iter)
                 data = nested_copy_place(data, place=paddle.framework._current_expected_place())
-            except:
-                pass
+            except Exception as e:
+                logger.debug(e)
         data = self._broadcast_data(data)
         return data

--- a/paddlenlp/data/dist_dataloader.py
+++ b/paddlenlp/data/dist_dataloader.py
@@ -61,9 +61,11 @@ class DistDataLoader(paddle.io.DataLoader):
         timeout=0,
         worker_init_fn=None,
         persistent_workers=False,
-        eval=False,
-        is_iterable_dataset=False,
+        **kwargs,
     ):
+
+        eval = kwargs.pop("eval", False)
+        is_iterable_dataset = kwargs.pop("is_iterable_dataset", False)
 
         if dataset is None:
             dataset = DummyDataset() if not is_iterable_dataset else IterableDummyDataset()

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1399,7 +1399,7 @@ class Trainer:
 
         train_dataset = self.train_dataset
         if self.args.distributed_dataloader:
-            is_iterable_dataset = self._is_iterable_dataset_dd(train_dataset)
+            is_iterable_dataset = self._is_iterable_dataset_distributed(train_dataset)
         else:
             is_iterable_dataset = self._is_iterable_dataset(train_dataset)
         if is_datasets_available() and train_dataset is not None and isinstance(train_dataset, datasets.Dataset):
@@ -1489,7 +1489,7 @@ class Trainer:
 
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
         if self.args.distributed_dataloader:
-            is_iterable_dataset = self._is_iterable_dataset_dd(eval_dataset)
+            is_iterable_dataset = self._is_iterable_dataset_distributed(eval_dataset)
         else:
             is_iterable_dataset = self._is_iterable_dataset(eval_dataset)
         if is_datasets_available() and eval_dataset is not None and isinstance(eval_dataset, datasets.Dataset):
@@ -1557,7 +1557,7 @@ class Trainer:
             raise ValueError("We don't need test_dataset when should_load_dataset is False.")
 
         if self.args.distributed_dataloader:
-            is_iterable_dataset = self._is_iterable_dataset_dd(test_dataset)
+            is_iterable_dataset = self._is_iterable_dataset_distributed(test_dataset)
         else:
             is_iterable_dataset = self._is_iterable_dataset(test_dataset)
         if is_datasets_available() and test_dataset is not None and isinstance(test_dataset, datasets.Dataset):
@@ -3220,7 +3220,7 @@ class Trainer:
     def _is_iterable_dataset(self, dataset):
         return isinstance(dataset, paddle.io.IterableDataset)
 
-    def _is_iterable_dataset_dd(self, dataset):
+    def _is_iterable_dataset_distributed(self, dataset):
         # For distributed dataloaer.
         is_iterable_dataset_tensor = paddle.to_tensor(self._is_iterable_dataset(dataset)).reshape([1])
         if dist.get_world_size() > 1:

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1398,9 +1398,12 @@ class Trainer:
             raise ValueError("We don't need train_dataset when should_load_dataset is False.")
 
         train_dataset = self.train_dataset
+        if self.args.distributed_dataloader:
+            is_iterable_dataset = self._is_iterable_dataset_dd(train_dataset)
+        else:
+            is_iterable_dataset = self._is_iterable_dataset(train_dataset)
         if is_datasets_available() and train_dataset is not None and isinstance(train_dataset, datasets.Dataset):
             train_dataset = self._remove_unused_columns(train_dataset, description="training")
-        _DataLoader = DistDataLoader if self.args.distributed_dataloader else DataLoader
 
         if self._is_iterable_dataset(train_dataset):
             if self.args.dataset_world_size > 1:
@@ -1412,24 +1415,42 @@ class Trainer:
                     process_index=self.args.dataset_rank,
                 )
 
-            return _DataLoader(
-                train_dataset,
-                batch_size=self.args.per_device_train_batch_size,
-                collate_fn=self.data_collator,
-                num_workers=self.args.dataloader_num_workers,
-            )
+            if self.args.distributed_dataloader:
+                return DistDataLoader(
+                    train_dataset,
+                    batch_size=self.args.per_device_train_batch_size,
+                    collate_fn=self.data_collator,
+                    num_workers=self.args.dataloader_num_workers,
+                    is_iterable_dataset=True,
+                )
+            else:
+                return DataLoader(
+                    train_dataset,
+                    batch_size=self.args.per_device_train_batch_size,
+                    collate_fn=self.data_collator,
+                    num_workers=self.args.dataloader_num_workers,
+                )
 
         train_sampler = self._get_train_sampler()
 
         if self.args.distributed_dataloader:
             logger.info("Training using DistDataLoader.")
 
-        return _DataLoader(
-            train_dataset,
-            batch_sampler=train_sampler,
-            collate_fn=self.data_collator,
-            num_workers=self.args.dataloader_num_workers,
-        )
+        if self.args.distributed_dataloader:
+            return DistDataLoader(
+                train_dataset,
+                batch_sampler=train_sampler if not is_iterable_dataset else None,
+                collate_fn=self.data_collator,
+                num_workers=self.args.dataloader_num_workers,
+                is_iterable_dataset=is_iterable_dataset,
+            )
+        else:
+            return DataLoader(
+                train_dataset,
+                batch_sampler=train_sampler,
+                collate_fn=self.data_collator,
+                num_workers=self.args.dataloader_num_workers,
+            )
 
     def _get_eval_sampler(self, eval_dataset: Dataset):
         if eval_dataset is None or not has_length(eval_dataset):
@@ -1476,7 +1497,10 @@ class Trainer:
             raise ValueError("We don't need eval_dataset when should_load_dataset is False.")
 
         eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
-
+        if self.args.distributed_dataloader:
+            is_iterable_dataset = self._is_iterable_dataset_dd(eval_dataset)
+        else:
+            is_iterable_dataset = self._is_iterable_dataset(eval_dataset)
         if is_datasets_available() and eval_dataset is not None and isinstance(eval_dataset, datasets.Dataset):
             eval_dataset = self._remove_unused_columns(eval_dataset, description="evaluation")
 
@@ -1497,6 +1521,7 @@ class Trainer:
                     collate_fn=self.data_collator,
                     num_workers=0,
                     eval=True,
+                    is_iterable_dataset=True,
                 )
             else:
                 return DataLoader(
@@ -1513,10 +1538,11 @@ class Trainer:
 
             return DistDataLoader(
                 eval_dataset,
-                batch_sampler=eval_sampler,
+                batch_sampler=eval_sampler if not is_iterable_dataset else None,
                 collate_fn=self.data_collator,
                 num_workers=self.args.dataloader_num_workers,
                 eval=True,
+                is_iterable_dataset=is_iterable_dataset,
             )
         else:
             return DataLoader(
@@ -1542,6 +1568,10 @@ class Trainer:
         if not self.args.should_load_dataset and test_dataset is not None:
             raise ValueError("We don't need test_dataset when should_load_dataset is False.")
 
+        if self.args.distributed_dataloader:
+            is_iterable_dataset = self._is_iterable_dataset_dd(test_dataset)
+        else:
+            is_iterable_dataset = self._is_iterable_dataset(test_dataset)
         if is_datasets_available() and test_dataset is not None and isinstance(test_dataset, datasets.Dataset):
             test_dataset = self._remove_unused_columns(test_dataset, description="test")
 
@@ -1562,6 +1592,7 @@ class Trainer:
                     collate_fn=self.data_collator,  # _get_collator_with_removed_columns
                     num_workers=self.args.dataloader_num_workers,
                     eval=True,
+                    is_iterable_dataset=True,
                 )
             else:
                 return DataLoader(
@@ -1579,10 +1610,11 @@ class Trainer:
             # We use the same batch_size as for eval.
             return DistDataLoader(
                 test_dataset,
-                batch_sampler=test_sampler,
+                batch_sampler=test_sampler if not is_iterable_dataset else None,
                 collate_fn=self.data_collator,
                 drop_last=self.args.dataloader_drop_last,
                 eval=True,
+                is_iterable_dataset=is_iterable_dataset,
             )
         else:
             return DataLoader(
@@ -1694,6 +1726,8 @@ class Trainer:
 
         if self.args.use_hybrid_parallel:
             if "hybrid_parallel_rng_state_tracker" in checkpoint_rng_state:
+                if self.args.tensor_parallel_degree <= 1:
+                    checkpoint_rng_state["hybrid_parallel_rng_state_tracker"].pop("model_parallel_rng", None)
                 fleet.meta_parallel.get_rng_state_tracker().set_states_tracker(
                     checkpoint_rng_state["hybrid_parallel_rng_state_tracker"]
                 )
@@ -3200,6 +3234,15 @@ class Trainer:
 
     def _is_iterable_dataset(self, dataset):
         return isinstance(dataset, paddle.io.IterableDataset)
+
+    def _is_iterable_dataset_dd(self, dataset):
+        # For distributed dataloaer.
+        is_iterable_dataset_tensor = paddle.to_tensor(self._is_iterable_dataset(dataset)).reshape([1])
+        if dist.get_world_size() > 1:
+            dist.all_reduce(is_iterable_dataset_tensor, op=dist.ReduceOp.MAX)
+        if is_iterable_dataset_tensor.item() == 1:
+            return True
+        return False
 
     def print_config(self, args=None, key=""):
         """

--- a/tests/trainer/test_unified_checkpoint.py
+++ b/tests/trainer/test_unified_checkpoint.py
@@ -659,7 +659,7 @@ class TestPaddleCheckpointOnN1C2Reset(TestMultipleGpus):
         self.need_allclose = True
         self.rtol = 1e-7
 
-        self.run_pretrain_file = "llm/llama/run_pretrain.py"
+        self.run_pretrain_file = "llm/run_pretrain.py"
 
     def runfirst(self, train_args):
         train_args["unified_checkpoint"] = 0
@@ -701,7 +701,7 @@ class TestUnifiedCheckpointOnN1C2Reset(TestMultipleGpus):
         self.need_allclose = True
         self.rtol = 1e-7
 
-        self.run_pretrain_file = "llm/llama/run_pretrain.py"
+        self.run_pretrain_file = "llm/run_pretrain.py"
         self.filelists = [
             "config.json",
             "master_weights-00001-of-00002.safetensors",
@@ -1130,24 +1130,6 @@ class TestUnifiedCheckpointOnN2C4ToN1C8AsyncSaveToDisk(TestUnifiedCheckpointBase
             self.run_n1c8(self.run_pretrain_file, **config)
             res = check_acc()
             np.testing.assert_allclose(res[0], res[-1], rtol=self.rtol)
-
-
-@pytest.mark.skipif(True, reason="Skip for None CE")
-class TestUnifiedCheckpointOnN1C8EnableAll(TestUnifiedCheckpointBase):
-    def setUp(self):
-        super().setUp()
-        for config_key in self.configs:
-            self.configs[config_key]["unified_checkpoint"] = 1
-            self.configs[config_key]["unified_checkpoint_config"] = "enable_all_options"
-
-        self.need_allclose = True
-        self.rtol = 1e-7
-
-    def runfirst(self, train_args):
-        self.run_n1c8(self.run_pretrain_file, **train_args)
-
-    def rerun(self, train_args):
-        self.run_n1c8(self.run_pretrain_file, **train_args)
 
 
 @pytest.mark.skipif(True, reason="Skip for None CE")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
1. Fix distributed dataloader.
2. Fix rng state loading.
3. Fix uc unittest.

Distributed dataloader造成hang住的原因：主要针对iterable数据集的热启场景。原来的写法， 数据进程的输入是iterable数据集，从而对应的sampler类型是Infinite类型；而非数据进程的数据输入是None，为None的情况下Paddle的Dataloader会自动设置sampler类型为batch sampler。由于在热启后一般会走跳过数据的逻辑，而跳过数据逻辑主要如下：
![截屏2024-08-15 17 08 57](https://github.com/user-attachments/assets/ad24c03e-83db-4c4d-a017-fbd676e6f533)

因此数据进程会走入第二个分支，而非数据进程会走入第一个分支，从而走入分支逻辑不一致导致卡住，从卡住时的堆栈可以看出具体问题。
数据进程的卡住见下图：
![截屏2024-08-15 17 06 42](https://github.com/user-attachments/assets/b0980d00-75e6-49e0-add6-c94dfac05166)
非数据进程的卡住见下图：
![截屏2024-08-15 17 07 22](https://github.com/user-attachments/assets/1ed3b1b1-17e8-4d1a-b660-feed3c82a85f)
