### PR TITLE
[bug fix] fix create_optimizer_and_scheduler for auto_parallel

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -764,7 +764,8 @@ class Trainer:
                 self._load_optimizer_and_scheduler(resume_from_checkpoint)
         else:
             model = self.model_wrapped
-            self.create_optimizer_and_scheduler(num_training_steps=max_steps)
+            if delay_optimizer_creation:
+                self.create_optimizer_and_scheduler(num_training_steps=max_steps)
 
         logger.info(f"{self.runtime_timer.log()}")
         logger.info("***** Running training *****")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
自动并行下，create_optimizer_and_scheduler 会调用两次，导致optimizer中的lr_schedule和trainer.lr_schedule不一致，导致lr_schedule.step()时对optimizer未产生影响，导致学习率一直为0