### PR TITLE
Fix tokens count for benchmark

### DIFF
--- a/llm/run_finetune.py
+++ b/llm/run_finetune.py
@@ -564,7 +564,7 @@ def main():
             neft_post_hook_handle.remove()
         if training_args.benchmark:
             total_effective_tokens = (
-                sum([len(i["input_ids"]) for i in trainer.train_dataset]) * training_args.num_train_epochs
+                sum([len(i["input_ids"]) for i in trainer.train_dataset]) * train_result.metrics["progress_or_epoch"]
             )
             effective_tokens_per_second = total_effective_tokens / train_result.metrics["train_runtime"]
             logger.info(f"Effective_Tokens_per_second: {effective_tokens_per_second} ")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Set `total_effective_tokens=all_tokens * progress_or_epoch`. 
When training or fine-tuning with a `max_step` and using Data Parallelism (DP) or Sharding with a factor greater than 1, the calculation of `total_effective_tokens` may be incorrect.