### PR TITLE
Support llama3.1 in non block_attn mode

### DIFF
--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -693,13 +693,31 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                 high_freq_factor = self.rope_scaling.get("high_freq_factor", 4.0)
                 original_max_position_embeddings = self.rope_scaling.get("original_max_position_embeddings", 8192)
                 new_rope = fused_get_rotary_embedding(
-                    input_ids, position_ids, self.head_dim_shape_tensor, position_offset, self.rope_theta, self.use_neox, True,
-                    factor, low_freq_factor, high_freq_factor, original_max_position_embeddings
+                    input_ids,
+                    position_ids,
+                    self.head_dim_shape_tensor,
+                    position_offset,
+                    self.rope_theta,
+                    self.use_neox,
+                    True,
+                    factor,
+                    low_freq_factor,
+                    high_freq_factor,
+                    original_max_position_embeddings,
                 )
         else:
             new_rope = fused_get_rotary_embedding(
-                input_ids, position_ids, self.head_dim_shape_tensor, position_offset, self.rope_theta, self.use_neox, False,
-                0.0, 0.0, 0.0, 0
+                input_ids,
+                position_ids,
+                self.head_dim_shape_tensor,
+                position_offset,
+                self.rope_theta,
+                self.use_neox,
+                False,
+                0.0,
+                0.0,
+                0.0,
+                0,
             )
 
         with dy2st_nocheck_guard_context():


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
 Models

### Description
fused_get_rope kernel算子支持rope_scaling，支持llama3.1在非block_atten模式，修复精度问题。

命令：python predict/predictor.py --model_name_or_path meta-llama/Meta-Llama-3.1-8B-Instruct --dtype bfloat16 --decode_strategy greedy_search --mode dynamic --inference_model 1 --block_attn 0 --batch_size 2 --data_file data/test.json
