### PR TITLE
[Bug fixes] fix TP_of_chatglm

### DIFF
--- a/paddlenlp/transformers/chatglm/modeling.py
+++ b/paddlenlp/transformers/chatglm/modeling.py
@@ -19,6 +19,7 @@ import re
 from functools import partial
 from typing import Any, Dict, Optional
 
+import numpy as np
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
@@ -681,13 +682,39 @@ class ChatGLMPretrainedModel(PretrainedModel):
 
         from paddlenlp.transformers.conversion_utils import split_or_merge_func
 
+        def split_or_merge_mlp_weights(tensor_parallel_degree, tensor_parallel_rank, is_split, tensor):
+            if is_split:
+                return split_mlp_weights(tensor_parallel_degree, tensor_parallel_rank, tensor)
+            else:
+                assert (
+                    len(tensor) == tensor_parallel_degree
+                ), "The length of tensor_list must match tensor_parallel_degree"
+                return merge_mlp_weights(tensor_parallel_degree, tensor)
+
         def split_mlp_weights(tensor_parallel_degree, tensor_parallel_rank, tensor):
             split_size = tensor.shape[-1] // tensor_parallel_degree // 2
-            gate = tensor[..., : tensor.shape[-1] // 2]
-            ffn_fc = tensor[..., tensor.shape[-1] // 2 :]
+            ffn_fc = tensor[..., : tensor.shape[-1] // 2]
+            gate = tensor[..., tensor.shape[-1] // 2 :]
             ffn_fc_part = ffn_fc[..., tensor_parallel_rank * split_size : (tensor_parallel_rank + 1) * split_size]
             gate_part = gate[..., tensor_parallel_rank * split_size : (tensor_parallel_rank + 1) * split_size]
-            return paddle.concat([gate_part, ffn_fc_part], axis=-1)
+            return paddle.concat([ffn_fc_part, gate_part], axis=-1)
+
+        def merge_mlp_weights(tensor_parallel_degree, tensor):
+            split_size = tensor[0].shape[-1] // 2
+            merge_ffn_fc = tensor[0][..., :split_size]
+            merge_gate = tensor[0][..., split_size:]
+            is_ndarry = isinstance(tensor[0], np.ndarray)
+            for i in range(1, tensor_parallel_degree):
+                if is_ndarry:
+                    merge_ffn_fc = np.concatenate([merge_ffn_fc, tensor[i][..., :split_size]], axis=-1)
+                    merge_gate = np.concatenate([merge_gate, tensor[i][..., split_size:]], axis=-1)
+                else:
+                    merge_ffn_fc = paddle.concat([merge_ffn_fc, tensor[i][..., :split_size]], axis=-1)
+                    merge_gate = paddle.concat([merge_gate, tensor[i][..., split_size:]], axis=-1)
+            if is_ndarry:
+                return np.concatenate([merge_ffn_fc, merge_gate], axis=-1)
+            else:
+                return paddle.concat([merge_ffn_fc, merge_gate], axis=-1)
 
         fn = split_or_merge_func(
             is_split=is_split,
@@ -701,10 +728,10 @@ class ChatGLMPretrainedModel(PretrainedModel):
             base_actions = {
                 # Column Linear
                 "transformer.layers.0.mlp.dense_h_to_4h.bias": partial(
-                    split_mlp_weights, config.tensor_parallel_degree, config.tensor_parallel_rank
+                    split_or_merge_mlp_weights, config.tensor_parallel_degree, config.tensor_parallel_rank
                 ),
                 "transformer.layers.0.mlp.dense_h_to_4h.weight": partial(
-                    split_mlp_weights, config.tensor_parallel_degree, config.tensor_parallel_rank
+                    split_or_merge_mlp_weights, config.tensor_parallel_degree, config.tensor_parallel_rank
                 ),
                 "transformer.layers.0.attention.query_key_value.bias": partial(fn, is_column=True),
                 "transformer.layers.0.attention.query_key_value.weight": partial(fn, is_column=True),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
* The MLP.dense_h_to_4h segmentation of chatglmV1 is based on the default segmentation, resulting in the activation operation and the single card not aligned.
* Customize the segmentation strategy function in _get_tensor_parallel_mappings