### PR TITLE
[LLM Inference] add --use_fake_parameter option for ptq fake scales and fix compute error of total_max_length

### DIFF
--- a/csrc/generation/test_tune_cublaslt_gemm.py
+++ b/csrc/generation/test_tune_cublaslt_gemm.py
@@ -12,14 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddlenlp_ops import tune_cublaslt_gemm
 import paddle
+from paddlenlp_ops import tune_cublaslt_gemm
 
-M_tensor = paddle.to_tensor([1024])
-K_tensor = paddle.to_tensor([1024, 2048])
-N_tensor = paddle.to_tensor([4096, 8192])
+M_tensor = paddle.to_tensor([32768])
+
+# llama3.1-8b
+k1 = [4096, 4096, 4096, 14336]
+n1 = [6144, 4096, 28672, 4096]
+
+# llama3.1-405b mp=8
+k2 = [16384, 16384, 16384, 6656]
+n2 = [2560, 16384, 13312, 16384]
+
+# qwen2-1.5b
+k3 = [1536, 1536, 1536, 8960]
+n3 = [2048, 1536, 17920, 1536]
+
+# qwen2-7b
+k4 = [3584, 3584, 3584, 18944]
+n4 = [4608, 3584, 37888, 3584]
+
+K_tensor = paddle.to_tensor(k1 + k2 + k3 + k4)
+N_tensor = paddle.to_tensor(n1 + n2 + n3 + n4)
 
 Dtype = "int8"
-Path = "./search.csv"
+Path = "./cublaslt_gemm_search.csv"
 
 tune_cublaslt_gemm(M_tensor, K_tensor, N_tensor, Dtype, True, False, Path)

--- a/csrc/generation/tune_cublaslt_gemm.cu
+++ b/csrc/generation/tune_cublaslt_gemm.cu
@@ -759,6 +759,9 @@ void TuneCublasltGemm(const paddle::Tensor& M,
       case 1024:
         step = 1024;
         break;
+      case 8192:
+        step = 4096;
+        break;
     }
   }
 

--- a/llm/predict/export_model.py
+++ b/llm/predict/export_model.py
@@ -29,6 +29,15 @@ class ExportArgument:
     output_path: str = field(default=None, metadata={"help": "The output path of model."})
 
 
+def add_inference_args_to_config(model_config, args):
+    """Add export arguments to config."""
+    model_config.infer_model_block_size = args.block_size
+    model_config.infer_model_max_seq_len = args.total_max_length
+    model_config.infer_model_cachekv_int8_type = args.cachekv_int8_type
+    model_config.infer_model_dtype = args.dtype
+    model_config.infer_model_paddle_commit = paddle.version.commit
+
+
 def main():
     parser = PdArgumentParser((PredictorArgument, ModelArgument, ExportArgument))
     predictor_args, model_args, export_args = parser.parse_args_into_dataclasses()
@@ -60,6 +69,7 @@ def main():
             "cachekv_int8_type": predictor_args.cachekv_int8_type,
         },
     )
+    add_inference_args_to_config(predictor.model.config, predictor_args)
     predictor.model.config.save_pretrained(export_args.output_path)
     if predictor.generation_config is not None:
         predictor.generation_config.save_pretrained(export_args.output_path)

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -948,8 +948,7 @@ class DygraphBlockInferencePredictor(BlockInferencePredictorMixin):
         result_queue = mp.Queue()
         tensor_queue = mp.Queue()
 
-        output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64")
-        output_tensor = output_tensor.cpu()
+        output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64").cpu()
         tensor_queue.put(output_tensor)
 
         read_res_process = mp.Process(
@@ -1074,8 +1073,7 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin):
         result_queue = mp.Queue()
         tensor_queue = mp.Queue()
 
-        output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64")
-        output_tensor = output_tensor.cpu()
+        output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64").cpu()
         tensor_queue.put(output_tensor)
 
         read_res_process = mp.Process(
@@ -1108,10 +1106,11 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin):
 
 def get_ptq_multicards_num(directory):
     count = 0
-    prefix = "act_scales_"
-    for filename in os.listdir(directory):
-        if filename.startswith(prefix):
-            count += 1
+    if os.path.exists(directory):
+        prefix = "act_scales_"
+        for filename in os.listdir(directory):
+            if filename.startswith(prefix):
+                count += 1
     return count
 
 

--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -1076,6 +1076,7 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                         dim_head=self.hidden_size // self.num_attention_heads,
                         ffn_hidden_size=self.intermediate_size,
                         num_key_value_heads=self.num_key_value_heads,
+                        mp_size=self.config.tensor_parallel_degree,
                     )
                 self.transformer_block.act_scales = act_scale_loader.scale
 
@@ -1101,6 +1102,7 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                             dim_heads=self.hidden_size // self.num_attention_heads,
                             is_channel_wise=False,
                             num_key_value_heads=self.num_key_value_heads,
+                            mp_size=self.config.tensor_parallel_degree,
                         )
 
                     for k, v in cache_scales_loader.scale.items():

--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -43,7 +43,12 @@ from paddlenlp.experimental.transformers.generation_utils import (
     GenerationBlockInferenceModel,
     GenerationInferenceModel,
 )
-from paddlenlp.experimental.transformers.utils import infererence_model_from_pretrained
+from paddlenlp.experimental.transformers.utils import (
+    EmptyActScale,
+    EmptyCacheScale,
+    EmptyWeightScale,
+    infererence_model_from_pretrained,
+)
 from paddlenlp.transformers import LlamaConfig, LlamaPretrainedModel
 from paddlenlp.transformers.conversion_utils import split_param_func
 from paddlenlp.transformers.llama.modeling import LlamaLMHead
@@ -894,6 +899,22 @@ class LlamaInferenceModel(LlamaPretrainedModel):
 
             if "a8w8" in self.quant_type:
                 if self.shift_smooth_all_linears:
+                    if self.use_fake_parameter:
+                        if "llama.layers.{}.self_attn.o_proj.shift_bias".format(idx) not in state_dict:
+                            state_dict["llama.layers.{}.self_attn.o_proj.shift_bias".format(idx)] = paddle.zeros(
+                                shape=[self.num_attention_heads * (self.hidden_size // self.num_attention_heads)],
+                                dtype=paddle.get_default_dtype(),
+                            )
+                            state_dict["llama.layers.{}.self_attn.o_proj.smooth_weight".format(idx)] = paddle.ones(
+                                shape=[self.num_attention_heads * (self.hidden_size // self.num_attention_heads)],
+                                dtype=paddle.get_default_dtype(),
+                            )
+                            state_dict["llama.layers.{}.mlp.down_proj.shift_bias".format(idx)] = paddle.zeros(
+                                shape=[self.intermediate_size], dtype=paddle.get_default_dtype()
+                            )
+                            state_dict["llama.layers.{}.mlp.down_proj.smooth_weight".format(idx)] = paddle.ones(
+                                shape=[self.intermediate_size], dtype=paddle.get_default_dtype()
+                            )
                     self.transformer_block.linear_shifts[idx].set_value(
                         paddle.to_tensor(state_dict["llama.layers.{}.self_attn.o_proj.shift_bias".format(idx)])
                     )
@@ -908,6 +929,33 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                     )
 
                 if self.shift:
+                    if self.use_fake_parameter:
+                        if "llama.layers.{}.input_layernorm.bias".format(idx) not in state_dict:
+                            state_dict["llama.layers.{}.input_layernorm.bias".format(idx)] = paddle.zeros(
+                                shape=[self.hidden_size], dtype=paddle.get_default_dtype()
+                            )
+                            state_dict["llama.layers.{}.post_attention_layernorm.bias".format(idx)] = paddle.zeros(
+                                [self.hidden_size], dtype=paddle.get_default_dtype()
+                            )
+                            unfused_state_dict["self_attn.q_proj.bias"] = paddle.zeros(
+                                shape=[self.num_attention_heads * (self.hidden_size // self.num_attention_heads)],
+                                dtype=paddle.get_default_dtype(),
+                            )
+                            unfused_state_dict["self_attn.k_proj.bias"] = paddle.zeros(
+                                shape=[self.num_key_value_heads * (self.hidden_size // self.num_attention_heads)],
+                                dtype=paddle.get_default_dtype(),
+                            )
+                            unfused_state_dict["self_attn.v_proj.bias"] = paddle.zeros(
+                                shape=[self.num_key_value_heads * (self.hidden_size // self.num_attention_heads)],
+                                dtype=paddle.get_default_dtype(),
+                            )
+                            unfused_state_dict["mlp.gate_proj.bias"] = paddle.zeros(
+                                shape=[self.intermediate_size], dtype=paddle.get_default_dtype()
+                            )
+                            unfused_state_dict["mlp.up_proj.bias"] = paddle.zeros(
+                                shape=[self.intermediate_size], dtype=paddle.get_default_dtype()
+                            )
+
                     self.transformer_block.ln_biases[idx].set_value(
                         paddle.to_tensor(state_dict["llama.layers.{}.input_layernorm.bias".format(idx)])
                     )
@@ -948,6 +996,14 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                     self.transformer_block.ffn1_biases[idx].set_value(paddle.to_tensor(concated_ffn1_bias))
 
                     if self.shift_smooth_all_linears:
+                        if self.use_fake_parameter:
+                            if "llama.layers.{}.self_attn.o_proj.bias".format(idx) not in state_dict:
+                                state_dict["llama.layers.{}.self_attn.o_proj.bias".format(idx)] = paddle.zeros(
+                                    [self.hidden_size], dtype=paddle.get_default_dtype()
+                                )
+                                state_dict["llama.layers.{}.mlp.down_proj.layer.bias".format(idx)] = paddle.zeros(
+                                    [self.hidden_size], dtype=paddle.get_default_dtype()
+                                )
                         self.transformer_block.linear_biases[idx].set_value(
                             paddle.to_tensor(state_dict["llama.layers.{}.self_attn.o_proj.bias".format(idx)])
                         )
@@ -981,41 +1037,62 @@ class LlamaInferenceModel(LlamaPretrainedModel):
                 weight_scale_map_dict = scale_map_dict["weight_scale"]
                 cache_scale_map_dict = scale_map_dict["cachekv_scale"]
 
-                act_scale_json_path = os.path.join(self.quant_model_path, "act_scales.json")
-                weight_scale_json_path = os.path.join(self.quant_model_path, "weight_scales.json")
-                if self.config.tensor_parallel_degree > 1 and not self.config.single_card_ptq:
-                    act_scale_json_path = os.path.join(
-                        self.quant_model_path, f"act_scales_{self.config.tensor_parallel_rank}.json"
+                if not self.use_fake_parameter:
+                    act_scale_json_path = os.path.join(self.quant_model_path, "act_scales.json")
+                    weight_scale_json_path = os.path.join(self.quant_model_path, "weight_scales.json")
+                    if self.config.tensor_parallel_degree > 1 and not self.config.single_card_ptq:
+                        act_scale_json_path = os.path.join(
+                            self.quant_model_path, f"act_scales_{self.config.tensor_parallel_rank}.json"
+                        )
+                        weight_scale_json_path = os.path.join(
+                            self.quant_model_path, f"weight_scales_{self.config.tensor_parallel_rank}.json"
+                        )
+                    act_scale_loader = ActScalesLoader(
+                        act_scale_json_path, act_scale_map_dict, num_of_layers=self.config.num_hidden_layers
                     )
-                    weight_scale_json_path = os.path.join(
-                        self.quant_model_path, f"weight_scales_{self.config.tensor_parallel_rank}.json"
+                    weight_scales_loader = WeightScalesLoader(
+                        weight_scale_json_path,
+                        weight_scale_map_dict,
+                        num_of_layers=self.config.num_hidden_layers,
+                        concat_qkv=True,
+                        concat_ffn1=True,
                     )
-                act_scale_loader = ActScalesLoader(
-                    act_scale_json_path, act_scale_map_dict, num_of_layers=self.config.num_hidden_layers
-                )
+                else:
+                    act_scale_loader = EmptyActScale(act_scale_map_dict, num_of_layers=self.config.num_hidden_layers)
+                    weight_scales_loader = EmptyWeightScale(
+                        weight_scale_map_dict,
+                        num_of_layers=self.config.num_hidden_layers,
+                        num_head=self.num_attention_heads,
+                        dim_head=self.hidden_size // self.num_attention_heads,
+                        ffn_hidden_size=self.intermediate_size,
+                        num_key_value_heads=self.num_key_value_heads,
+                    )
                 self.transformer_block.act_scales = act_scale_loader.scale
 
-                weight_scales_loader = WeightScalesLoader(
-                    weight_scale_json_path,
-                    weight_scale_map_dict,
-                    num_of_layers=self.config.num_hidden_layers,
-                    concat_qkv=True,
-                    concat_ffn1=True,
-                )
-
                 if self.config.cachekv_int8_type == "static":
-                    cache_scale_json_path = os.path.join(self.quant_model_path, "cachekv_scales.json")
-                    if self.config.tensor_parallel_degree > 1 and not self.config.single_card_ptq:
-                        cache_scale_json_path = os.path.join(
-                            self.quant_model_path, f"cachekv_scales_{self.config.tensor_parallel_rank}.json"
+                    if not self.use_fake_parameter:
+                        cache_scale_json_path = os.path.join(self.quant_model_path, "cachekv_scales.json")
+                        if self.config.tensor_parallel_degree > 1 and not self.config.single_card_ptq:
+                            cache_scale_json_path = os.path.join(
+                                self.quant_model_path, f"cachekv_scales_{self.config.tensor_parallel_rank}.json"
+                            )
+                        cache_scales_loader = CacheScaleLoader(
+                            cache_scale_json_path,
+                            cache_scale_map_dict,
+                            num_of_layers=self.config.num_hidden_layers,
+                            num_heads=self.num_attention_heads // self.config.tensor_parallel_degree,
+                            num_key_value_heads=self.num_key_value_heads // self.config.tensor_parallel_degree,
                         )
-                    cache_scales_loader = CacheScaleLoader(
-                        cache_scale_json_path,
-                        cache_scale_map_dict,
-                        num_of_layers=self.config.num_hidden_layers,
-                        num_heads=self.num_attention_heads // self.config.tensor_parallel_degree,
-                        num_key_value_heads=self.num_key_value_heads // self.config.tensor_parallel_degree,
-                    )
+                    else:
+                        cache_scales_loader = EmptyCacheScale(
+                            cache_scale_map_dict,
+                            num_of_layers=self.config.num_hidden_layers,
+                            num_heads=self.num_attention_heads,
+                            dim_heads=self.hidden_size // self.num_attention_heads,
+                            is_channel_wise=False,
+                            num_key_value_heads=self.num_key_value_heads,
+                        )
+
                     for k, v in cache_scales_loader.scale.items():
                         for i_layer, weight_scale in enumerate(v):
                             weight_scale = weight_scale.astype("float32")

--- a/paddlenlp/experimental/transformers/utils.py
+++ b/paddlenlp/experimental/transformers/utils.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 
+import numpy as np
 import paddle
 
 from paddlenlp.transformers.model_utils import (
@@ -75,3 +76,84 @@ def infererence_model_from_pretrained(cls, pretrained_model_name_or_path, args, 
     model.set_state_dict(state_dict)
 
     return model
+
+
+class EmptyActScale:
+    """
+    For fake parameter
+    """
+
+    def __init__(
+        self,
+        key_map_dict=None,
+        num_of_layers=None,
+    ):
+        self.key_map = key_map_dict
+        self.scale = {}
+        for scale_type, key_template in self.key_map.items():
+            self.scale[scale_type] = np.full([num_of_layers], fill_value=0.1)
+
+
+class EmptyWeightScale:
+    """
+    For fake parameter
+    """
+
+    def __init__(
+        self,
+        key_map_dict,
+        num_of_layers,
+        num_head,
+        dim_head,
+        ffn_hidden_size,
+        num_key_value_heads=-1,
+        mp_size=1,
+    ):
+        self.key_map = key_map_dict
+        self.scale = {}
+
+        num_key_value_heads = num_key_value_heads
+        qkv_out_size = (
+            3 * num_head * dim_head if num_key_value_heads <= 0 else (num_head + 2 * num_key_value_heads) * dim_head
+        )
+
+        for scale_type, key_template in self.key_map.items():
+            if "qkv" in scale_type:
+                n = qkv_out_size // mp_size
+            elif "ffn1" in scale_type:
+                n = ffn_hidden_size * 2 // mp_size
+            else:
+                n = num_head * dim_head
+            self.scale[scale_type] = np.full([num_of_layers, n], fill_value=0.1, dtype="float32")
+
+
+class EmptyCacheScale:
+    """
+    For fake parameter
+    """
+
+    def __init__(
+        self,
+        key_map_dict=None,
+        num_of_layers=None,
+        num_heads=None,
+        dim_heads=None,
+        is_channel_wise=False,
+        mp_size=1,
+        num_key_value_heads=-1,
+    ):
+        self.key_map = key_map_dict
+        self.scale = {}
+
+        num_heads = num_heads // mp_size
+        num_key_value_heads = num_key_value_heads // mp_size
+        kv_num_head = num_heads if num_key_value_heads <= 0 else num_key_value_heads
+        for scale_type, key_template in self.key_map.items():
+            if "cache_k" in scale_type:
+                scale_type_out = "cache_k_out_scale"
+            else:
+                scale_type_out = "cache_v_out_scale"
+
+            col_dim = kv_num_head * dim_heads if is_channel_wise else kv_num_head
+            self.scale[scale_type] = np.full([num_of_layers, col_dim], fill_value=1.0)
+            self.scale[scale_type_out] = np.full([num_of_layers, col_dim], fill_value=1.0)

--- a/paddlenlp/utils/llm_utils.py
+++ b/paddlenlp/utils/llm_utils.py
@@ -769,7 +769,7 @@ def read_res(model_name_or_path: str, tensor_queue: mp.Queue, result_queue: mp.Q
             continue
         bsz = int(output_tensor[1, 0])
         output_numpy = output_tensor[2 : bsz + 2].numpy()
-        output_numpy[output_numpy == -1] = 2
+        output_numpy[output_numpy == -1] = tokenizer.eos_token_id
         outputs.append(output_numpy)
         if int(output_tensor[0, 0]) == -1:
             break


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- add --use_fake_parameter option for ptq fake scales 
- 修复src_length与max_length的问题，现在导出静态图模型时无须指定它们。
- 修复llama3/qwen2等模型输出尾部多余的“#”符号
- 更新tune_cublaslt_gemm示例，增加llama3.1/qwen2 tune示例