### PR TITLE
fix JambaModelIntegrationTest

### DIFF
--- a/tests/transformers/jamba/test_modeling.py
+++ b/tests/transformers/jamba/test_modeling.py
@@ -595,6 +595,7 @@ class JambaModelTest(ModelTesterMixin, unittest.TestCase):
         self.assertTrue(model.config.vocab_size == 65536)
 
 
+@slow
 class JambaModelIntegrationTest(unittest.TestCase):
     model = None
     tokenizer = None


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Tests
### Description
<!-- Describe what this PR does -->
github由于是外网机器，访问国内的BOS网络可能有问题，导致下载模型可能挂了，所以标记为slow。