### PR TITLE
[ZeroPadding] padding to max_length for sequence parallel

### DIFF
--- a/paddlenlp/datasets/zero_padding_dataset.py
+++ b/paddlenlp/datasets/zero_padding_dataset.py
@@ -63,6 +63,8 @@ class ZeroPadding:
 
         # append padding to the max_length
         if "attn_mask_startend_row_indices" in batch_records[0]:
+            # attn_mask_startend_row_indices is a list of row indices `0`,
+            # which indicates that all tokens are masked.
             batch_records.append(
                 {
                     "input_ids": [pad_token] * reserved_length,
@@ -71,6 +73,8 @@ class ZeroPadding:
                 }
             )
         elif "attention_mask" in batch_records[0]:
+            # attention_mask is a fullly masked attention matrix (all False)
+            # which indicates that all tokens are masked.
             batch_records.append(
                 {
                     "input_ids": [pad_token] * reserved_length,

--- a/paddlenlp/datasets/zero_padding_dataset.py
+++ b/paddlenlp/datasets/zero_padding_dataset.py
@@ -53,32 +53,31 @@ class ZeroPadding:
     ]
 
     @classmethod
-    def _pad_batch_records_to_max_length(cls, batch_records, max_length):
-        for records in batch_records:
-            # confirm the at least one item in the pack
-            if len(records) == 0:
-                continue
-            # count all records total length
-            total_length = sum([len(record["input_ids"]) for record in records])
-            reserved_length = max_length - total_length
+    def _pad_batch_records_to_max_length(cls, batch_records, max_length, pad_token=0):
+        # confirm the at least one item in the pack
+        if len(batch_records) == 0:
+            return batch_records
+        # count all records total length
+        total_length = sum([len(record["input_ids"]) for record in batch_records])
+        reserved_length = max_length - total_length
 
-            # append padding to the max_length
-            if "attn_mask_startend_row_indices" in records[0]:
-                records.append(
-                    {
-                        "input_ids": [-100] * reserved_length,
-                        "labels": [-100] * reserved_length,
-                        "attn_mask_startend_row_indices": [0] * reserved_length,
-                    }
-                )
-            elif "attention_mask" in records[0]:
-                records.append(
-                    {
-                        "input_ids": [-100] * reserved_length,
-                        "labels": [-100] * reserved_length,
-                        "attention_mask": [True] * reserved_length,
-                    }
-                )
+        # append padding to the max_length
+        if "attn_mask_startend_row_indices" in batch_records[0]:
+            batch_records.append(
+                {
+                    "input_ids": [pad_token] * reserved_length,
+                    "labels": [-100] * reserved_length,
+                    "attn_mask_startend_row_indices": [0] * reserved_length,
+                }
+            )
+        elif "attention_mask" in batch_records[0]:
+            batch_records.append(
+                {
+                    "input_ids": [pad_token] * reserved_length,
+                    "labels": [-100] * reserved_length,
+                    "attention_mask": np.zeros((reserved_length, reserved_length), dtype=bool),
+                }
+            )
 
         return batch_records
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
This PR addresses the issue where zero padding packs `input_ids` into a new sequence with varying lengths, which may not be divisible by `tensor_parallel_degree`. It enables padding the sequence to `max_length` with a fixed length.
