### PR TITLE
[Auto Parallel] Adding align mode

### DIFF
--- a/paddlenlp/utils/align_utils.py
+++ b/paddlenlp/utils/align_utils.py
@@ -1,0 +1,21 @@
+#   Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+
+def float_to_md5(f):
+    byte_representation = str(f).encode('utf-8')
+    hash_object = hashlib.md5(byte_representation)
+    hex_dig = hash_object.hexdigest()
+    return hex_dig


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
增加对齐模式支持，若 export FLAGS_auto_parallel_align_mode=1：
1. 自动并行下，loss为对全局求平均；动手下，loss为对当前dp/sharding求平均。因此，开启对齐模式后，在跑动手时，将每路dp/sharding的loss除以dp/sharding的degree，以使权重的梯度和自动并行模式下对齐，与此同时取消在fused_allreduce_gradients中的scale。
2. 开启对齐模式后，会在每个step打印loss的md5