### PR TITLE
tool_helpers升级后可以支持32766个数据集.

### DIFF
--- a/legacy/model_zoo/ernie-1.0/data_tools/helpers.cpp
+++ b/legacy/model_zoo/ernie-1.0/data_tools/helpers.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 const int32_t LONG_SENTENCE_LEN = 512;
 
-void build_blending_indices(py::array_t<uint8_t>& dataset_index,
+void build_blending_indices(py::array_t<int16_t>& dataset_index,
                             py::array_t<int64_t>& dataset_sample_index,
                             const py::array_t<double>& weights,
                             const int32_t num_datasets,
@@ -73,7 +73,7 @@ void build_blending_indices(py::array_t<uint8_t>& dataset_index,
     }
 
     // Populate the indices.
-    dataset_index_ptr[sample_idx] = static_cast<uint8_t>(max_error_index);
+    dataset_index_ptr[sample_idx] = static_cast<int16_t>(max_error_index);
     dataset_sample_index_ptr[sample_idx] = current_samples[max_error_index];
 
     // Update the total samples.

--- a/paddlenlp/data/blendable_dataset.py
+++ b/paddlenlp/data/blendable_dataset.py
@@ -56,7 +56,7 @@ class BlendableDataset(paddle.io.Dataset):
             else:
                 assert (
                     num_datasets < 255
-                ), f"Detect num_datasets:({num_datasets})>=255. When 'tool_helpers<=0.1.1', num_datasets should be less than 255. To support num_datasets greater than 255, please upgrade tool_helpers>=0.1.1."
+                ), f"Detect num_datasets:({num_datasets})>=255. When 'tool_helpers<=0.1.1', num_datasets should be less than 255. To support num_datasets greater than 255, please upgrade `tool_helpers>=0.1.2`."
                 dataset_index = np.zeros(self.size, dtype=np.uint8)
             dataset_sample_index = np.zeros(self.size, dtype=np.int64)
 

--- a/paddlenlp/data/blendable_dataset.py
+++ b/paddlenlp/data/blendable_dataset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import hashlib
+import importlib.metadata
 import os
 import time
 
@@ -45,8 +46,18 @@ class BlendableDataset(paddle.io.Dataset):
         # Build indicies.
         def _build_indices():
             start_time = time.time()
-            assert num_datasets < 255
-            dataset_index = np.zeros(self.size, dtype=np.uint8)
+
+            tool_helpers_version = importlib.metadata.version("tool_helpers")
+            if tool_helpers_version > "0.1.1":
+                assert (
+                    num_datasets < 32767
+                ), f"Detect num_datasets({num_datasets})>=32767. Currently, num_datasets should be less than 32767."
+                dataset_index = np.zeros(self.size, dtype=np.int16)
+            else:
+                assert (
+                    num_datasets < 255
+                ), f"Detect num_datasets:({num_datasets})>=255. When 'tool_helpers<=0.1.1', num_datasets should be less than 255. To support num_datasets greater than 255, please upgrade tool_helpers>=0.1.1."
+                dataset_index = np.zeros(self.size, dtype=np.uint8)
             dataset_sample_index = np.zeros(self.size, dtype=np.int64)
 
             from tool_helpers import helpers


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
- 更新tool helpers版本，发布0.1.2，https://github.com/ZHUI/helpers
- 当小于等于0.1.1的时候仅支持254个数据集，当大于0.1.1的的时候支持32766个数据集.