### PR TITLE
[Tokenizer] Support for loading added_tokens_decoder

### DIFF
--- a/paddlenlp/transformers/gemma/tokenizer.py
+++ b/paddlenlp/transformers/gemma/tokenizer.py
@@ -111,6 +111,18 @@ class GemmaTokenizer(PretrainedTokenizer):
         """Returns vocab size"""
         return self.sp_model.get_piece_size()
 
+    def __len__(self):
+        """
+        Returns the vocabulary size. added_tokens_encoder has to be added in the sp_model
+        """
+        added_size = 0
+
+        for id in self.added_tokens_decoder:
+            if id >= self.sp_model.get_piece_size():
+                added_size += 1
+
+        return self.vocab_size + added_size
+
     # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer.get_vocab
     def get_vocab(self):
         """Returns vocab as a dict"""
@@ -127,11 +139,15 @@ class GemmaTokenizer(PretrainedTokenizer):
     # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer._convert_token_to_id
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""
-        return self.sp_model.piece_to_id(token)
+        if token in self.added_tokens_encoder:
+            return self.added_tokens_encoder[token]
+        return self.sp_model.PieceToId(token)
 
     # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer._convert_id_to_token
     def _convert_id_to_token(self, index):
         """Converts an index (integer) in a token (str) using the vocab."""
+        if index in self.added_tokens_decoder:
+            return self.added_tokens_decoder[index]
         token = self.sp_model.IdToPiece(index)
         return token
 

--- a/paddlenlp/transformers/llama/tokenizer.py
+++ b/paddlenlp/transformers/llama/tokenizer.py
@@ -80,6 +80,18 @@ class LlamaTokenizer(PretrainedTokenizer):
         """Returns vocab size"""
         return self.sp_model.get_piece_size()
 
+    def __len__(self):
+        """
+        Returns the vocabulary size. added_tokens_encoder has to be added in the sp_model
+        """
+        added_size = 0
+
+        for id in self.added_tokens_decoder:
+            if id >= self.sp_model.get_piece_size():
+                added_size += 1
+
+        return self.vocab_size + added_size
+
     @property
     def bos_token_id(self) -> Optional[int]:
         return self.sp_model.bos_id()
@@ -100,10 +112,14 @@ class LlamaTokenizer(PretrainedTokenizer):
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""
+        if token in self.added_tokens_encoder:
+            return self.added_tokens_encoder[token]
         return self.sp_model.piece_to_id(token)
 
     def _convert_id_to_token(self, index):
         """Converts an index (integer) in a token (str) using the vocab."""
+        if index in self.added_tokens_decoder:
+            return self.added_tokens_decoder[index]
         token = self.sp_model.IdToPiece(index)
         return token
 

--- a/paddlenlp/transformers/llama/tokenizer.py
+++ b/paddlenlp/transformers/llama/tokenizer.py
@@ -112,15 +112,11 @@ class LlamaTokenizer(PretrainedTokenizer):
 
     def _convert_token_to_id(self, token):
         """Converts a token (str) in an id using the vocab."""
-        if token in self.added_tokens_encoder:
-            return self.added_tokens_encoder[token]
         return self.sp_model.piece_to_id(token)
 
     def _convert_id_to_token(self, index):
         """Converts an index (integer) in a token (str) using the vocab."""
-        if index in self.added_tokens_decoder:
-            return self.added_tokens_decoder[index]
-        token = self.sp_model.IdToPiece(index)
+        token = self.sp_model.id_to_piece(index)
         return token
 
     def convert_tokens_to_string(self, tokens):

--- a/paddlenlp/transformers/mamba/tokenizer.py
+++ b/paddlenlp/transformers/mamba/tokenizer.py
@@ -158,6 +158,12 @@ class MambaTokenizer(PretrainedTokenizer):
         """
         return len(self.encoder)
 
+    def __len__(self):
+        """
+        Size of the full vocabulary with the added tokens.
+        """
+        return len(dict(self.encoder, **self.added_tokens_encoder))
+
     def bpe(self, token):
         if token in self.cache:
             return self.cache[token]

--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -1842,9 +1842,7 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
             token_ids = token_ids.tolist()
         self._decode_use_source_tokenizer = kwargs.pop("use_source_tokenizer", False)
         filtered_tokens = self.convert_ids_to_tokens(token_ids, skip_special_tokens=skip_special_tokens)
-        legacy_added_tokens = set(self.added_tokens_encoder.keys()) - set(self.all_special_tokens) | {
-            token for token in self.additional_special_tokens if self.convert_tokens_to_ids(token) >= self.vocab_size
-        }
+
         # To avoid mixing byte-level and unicode for byte-level BPT
         # we need to build string separately for added tokens and byte-level tokens
         # cf. https://github.com/huggingface/transformers/issues/1133
@@ -1853,7 +1851,7 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
         for token in filtered_tokens:
             if skip_special_tokens and token in self.all_special_ids:
                 continue
-            if token in legacy_added_tokens:
+            if token in self.added_tokens_encoder:
                 if current_sub_text:
                     sub_texts.append(self.convert_tokens_to_string(current_sub_text))
                     current_sub_text = []

--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -989,7 +989,7 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
         """
         Size of the full vocabulary with the added tokens.
         """
-        return self.vocab_size + len(self.added_tokens_encoder)
+        return len(dict(self.encoder, **self.added_tokens_encoder))
 
     def _add_tokens(self, new_tokens: Union[List[str], List[AddedToken]], special_tokens: bool = False) -> int:
         """
@@ -1213,7 +1213,9 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
     def convert_ids_to_tokens(self, ids, skip_special_tokens=False):
         if isinstance(ids, int):
             if ids in self.added_tokens_decoder:
-                return self.added_tokens_decoder[ids].content
+                token = self.added_tokens_decoder[ids]
+                token = token.content if isinstance(token, AddedToken) else token
+                return token
             else:
                 return self._convert_id_to_token(ids)
         tokens = []
@@ -1222,7 +1224,9 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
             if skip_special_tokens and index in self.all_special_ids:
                 continue
             if index in self.added_tokens_decoder:
-                tokens.append(self.added_tokens_decoder[index].content)
+                token = self.added_tokens_decoder[index]
+                token = token.content if isinstance(token, AddedToken) else token
+                tokens.append(token)
             else:
                 tokens.append(self._convert_id_to_token(index))
         return tokens

--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -989,7 +989,7 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
         """
         Size of the full vocabulary with the added tokens.
         """
-        return len(dict(self.encoder, **self.added_tokens_encoder))
+        return self.vocab_size + len(self.added_tokens_encoder)
 
     def _add_tokens(self, new_tokens: Union[List[str], List[AddedToken]], special_tokens: bool = False) -> int:
         """

--- a/paddlenlp/transformers/tokenizer_utils.py
+++ b/paddlenlp/transformers/tokenizer_utils.py
@@ -940,8 +940,10 @@ class PretrainedTokenizer(ChatTemplateMixin, PretrainedTokenizerBase):
         init_dict.pop("self", None)
         super(PretrainedTokenizer, self).__init__(**init_dict)
 
-        self.added_tokens_encoder: Dict[str, int] = {}
-        self.added_tokens_decoder: Dict[int, str] = {}
+        self.added_tokens_decoder: Dict[int, AddedToken] = {}
+        self.added_tokens_decoder.update(kwargs.pop("added_tokens_decoder", {}))
+        self.added_tokens_encoder: Dict[str, int] = {k.content: v for v, k in self.added_tokens_decoder.items()}
+
         self.unique_no_split_tokens: List[str] = []
         self.tokens_trie = Trie()
 

--- a/paddlenlp/transformers/tokenizer_utils_base.py
+++ b/paddlenlp/transformers/tokenizer_utils_base.py
@@ -1543,7 +1543,6 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
         else:
             init_kwargs = init_configuration
 
-        pass_special_tokens_map_file = False
         pass_added_tokens_file = False
         # Handle tokenizer serialization of added and special tokens
         added_tokens_decoder: Dict[int, AddedToken] = {}
@@ -1560,7 +1559,6 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
                     )
             init_kwargs["added_tokens_decoder"] = added_tokens_decoder
 
-            pass_special_tokens_map_file = True
             pass_added_tokens_file = True
 
         # position args are stored in kwargs, maybe better not include
@@ -1618,7 +1616,6 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
             tokenizer.init_chat_template(chat_template)
 
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
-        special_tokens_map_file = None if pass_special_tokens_map_file else special_tokens_map_file
         if special_tokens_map_file is not None:
             with open(special_tokens_map_file, encoding="utf-8") as special_tokens_map_handle:
                 special_tokens_map = json.load(special_tokens_map_handle)

--- a/paddlenlp/transformers/tokenizer_utils_base.py
+++ b/paddlenlp/transformers/tokenizer_utils_base.py
@@ -1543,6 +1543,8 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
         else:
             init_kwargs = init_configuration
 
+        pass_special_tokens_map_file = False
+        pass_added_tokens_file = False
         # Handle tokenizer serialization of added and special tokens
         added_tokens_decoder: Dict[int, AddedToken] = {}
         # if we have info on the slow added tokens
@@ -1557,6 +1559,9 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
                         f"Found a {token.__class__} in the saved `added_tokens_decoder`, should be a dictionary or an AddedToken instance"
                     )
             init_kwargs["added_tokens_decoder"] = added_tokens_decoder
+
+            pass_special_tokens_map_file = True
+            pass_added_tokens_file = True
 
         # position args are stored in kwargs, maybe better not include
         init_args = init_kwargs.pop("init_args", ())
@@ -1585,7 +1590,6 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
             if model_max_length is not None and isinstance(model_max_length, (int, float)):
                 init_kwargs["model_max_length"] = min(init_kwargs.get("model_max_length", int(1e30)), model_max_length)
 
-        added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
         # Merge resolved_vocab_files arguments in init_kwargs if not including.
         # Maybe need more ways to load resources.
         for args_name, file_path in resolved_vocab_files.items():
@@ -1612,7 +1616,9 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
         chat_template = init_kwargs.pop("chat_template", None)
         if chat_template is not None:
             tokenizer.init_chat_template(chat_template)
+
         special_tokens_map_file = resolved_vocab_files.pop("special_tokens_map_file", None)
+        special_tokens_map_file = None if pass_special_tokens_map_file else special_tokens_map_file
         if special_tokens_map_file is not None:
             with open(special_tokens_map_file, encoding="utf-8") as special_tokens_map_handle:
                 special_tokens_map = json.load(special_tokens_map_handle)
@@ -1620,16 +1626,17 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
                 if key in kwargs and kwargs[key]:
                     # This value has already been redefined by the kwargs
                     # We keep this new value and ignore the one stored in the special_tokens_map_file
-
                     continue
-
                 if isinstance(value, dict):
                     value = AddedToken(**value)
                 elif isinstance(value, list):
                     value = [AddedToken(**token) if isinstance(token, dict) else token for token in value]
                 setattr(tokenizer, key, value)
+
         # Add supplementary tokens.
         special_tokens = tokenizer.all_special_tokens
+        added_tokens_file = resolved_vocab_files.pop("added_tokens_file", None)
+        added_tokens_file = None if pass_added_tokens_file else added_tokens_file
         if added_tokens_file is not None:
             with open(added_tokens_file, encoding="utf-8") as added_tokens_handle:
                 added_tok_encoder = json.load(added_tokens_handle)
@@ -1726,6 +1733,15 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
 
         # add_type_field=True to allow dicts in the kwargs / differentiate from AddedToken serialization
         tokenizer_config = convert_added_tokens(tokenizer_config, add_type_field=True)
+
+        # Process added tokens seperatly: allows previous versions to ignore it!
+        added_tokens = {}
+        for key, value in self.added_tokens_decoder.items():
+            if isinstance(value, AddedToken):
+                added_tokens[key] = value.__getstate__()
+            else:
+                added_tokens[key] = AddedToken(value).__getstate__()
+        tokenizer_config["added_tokens_decoder"] = added_tokens
 
         # Add tokenizer class to the tokenizer config to be able to reload it with from_pretrained
         tokenizer_class = self.__class__.__name__


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
The new tokenizer_config.json now includes the added_tokens_decoder, and we load them in the PretrainedTokenizer _pre_init.

1. 解决llama、gemma、mamba无法添加token的问题。
2. 当前添加的token和原始的added_token_decoder最后都会保存在added_token_decoder:dict中，可下次加载并且序号不变。
3. 当前added_token_decoder可被from_pretrained加载，保证tokenizer_config.json中序号不变。