### PR TITLE
[ZeroPadding] revert zero_padding #8973

### DIFF
--- a/llm/run_finetune.py
+++ b/llm/run_finetune.py
@@ -517,14 +517,19 @@ def main():
         model.print_trainable_parameters()
 
     # Create trainer
-    max_length = (
-        data_args.max_length
-        if training_args.pipeline_parallel_degree > 1 or training_args.autotuner_benchmark
-        else None
-    )  # NOTE(gongenlei): new add autotuner_benchmark
-    padding = (
-        "max_length" if training_args.pipeline_parallel_degree > 1 or training_args.autotuner_benchmark else True
-    )  # NOTE(gongenlei): new add autotuner_benchmark
+
+    if (
+        training_args.pipeline_parallel_degree > 1
+        or training_args.sequence_parallel
+        or training_args.autotuner_benchmark
+    ):
+        # NOTE(gongenlei): new add autotuner_benchmark
+        max_length = data_args.max_length
+        padding = "max_length"
+    else:
+        max_length = None
+        padding = True
+
     if training_args.pipeline_parallel_degree > 1:
         metrics = None
     elif data_args.eval_with_do_generation:

--- a/paddlenlp/datasets/zero_padding_dataset.py
+++ b/paddlenlp/datasets/zero_padding_dataset.py
@@ -53,42 +53,7 @@ class ZeroPadding:
     ]
 
     @classmethod
-    def _pad_batch_records_to_max_length(cls, batch_records, max_length, pad_token=0):
-        # confirm the at least one item in the pack
-        if len(batch_records) == 0:
-            return batch_records
-        # count all records total length
-        total_length = sum([len(record["input_ids"]) for record in batch_records])
-        reserved_length = max_length - total_length
-
-        # append padding to the max_length
-        if "attn_mask_startend_row_indices" in batch_records[0]:
-            # attn_mask_startend_row_indices is a list of row indices `0`,
-            # which indicates that all tokens are masked.
-            batch_records.append(
-                {
-                    "input_ids": [pad_token] * reserved_length,
-                    "labels": [-100] * reserved_length,
-                    "attn_mask_startend_row_indices": [0] * reserved_length,
-                }
-            )
-        elif "attention_mask" in batch_records[0]:
-            # attention_mask is a fullly masked attention matrix (all False)
-            # which indicates that all tokens are masked.
-            batch_records.append(
-                {
-                    "input_ids": [pad_token] * reserved_length,
-                    "labels": [-100] * reserved_length,
-                    "attention_mask": np.zeros((reserved_length, reserved_length), dtype=bool),
-                }
-            )
-
-        return batch_records
-
-    @classmethod
-    def _pad_batch_records(cls, batch_records, max_length):
-        batch_records = cls._pad_batch_records_to_max_length(batch_records, max_length)
-
+    def _pad_batch_records(cls, batch_records):
         # Only consider supported input keys
         input_keys = [key for key in batch_records[0].keys() if key in cls.supported_input_keys]
         if "attn_mask_startend_row_indices" not in input_keys and "attention_mask" not in input_keys:
@@ -157,7 +122,7 @@ class ZeroPaddingMapDataset(ZeroPadding, Dataset):
                     cur_len_so_far += len(record["input_ids"])
                 else:
                     # exceed max length
-                    padded_list = self._pad_batch_records(batch_records, self.max_length)
+                    padded_list = self._pad_batch_records(batch_records)
                     total_data.append(padded_list)
                     # reset
                     batch_records = []
@@ -168,7 +133,7 @@ class ZeroPaddingMapDataset(ZeroPadding, Dataset):
 
             # remaining data
             if batch_records:
-                padded_list = self._pad_batch_records(batch_records, self.max_length)
+                padded_list = self._pad_batch_records(batch_records)
                 total_data.append(padded_list)
         else:
             examples = []
@@ -185,7 +150,7 @@ class ZeroPaddingMapDataset(ZeroPadding, Dataset):
                     generate_packs = generate_greedy_packs(examples, self.max_length)
                     for batch_records in generate_packs:
                         if len(batch_records) > 0:
-                            padded_list = self._pad_batch_records(batch_records, self.max_length)
+                            padded_list = self._pad_batch_records(batch_records)
                             total_data.append(padded_list)
                     examples = [record]
                     i = 1
@@ -193,7 +158,7 @@ class ZeroPaddingMapDataset(ZeroPadding, Dataset):
                 generate_packs = generate_greedy_packs(examples, self.max_length)
                 for batch_records in generate_packs:
                     if len(batch_records) > 0:
-                        padded_list = self._pad_batch_records(batch_records, self.max_length)
+                        padded_list = self._pad_batch_records(batch_records)
                         total_data.append(padded_list)
 
         return total_data
@@ -225,7 +190,7 @@ class ZeroPaddingIterableDataset(ZeroPadding, IterableDataset):
                     cur_len_so_far += len(record["input_ids"])
                 else:
                     # exceed max length
-                    padded_list = self._pad_batch_records(batch_records, self.max_length)
+                    padded_list = self._pad_batch_records(batch_records)
                     yield padded_list
                     # reset
                     batch_records = []
@@ -235,7 +200,7 @@ class ZeroPaddingIterableDataset(ZeroPadding, IterableDataset):
                     self.zero_padding_global_step += 1
                     cur_len_so_far += len(record["input_ids"])
             if batch_records:
-                padded_list = self._pad_batch_records(batch_records, self.max_length)
+                padded_list = self._pad_batch_records(batch_records)
                 yield padded_list
         else:
             examples = []
@@ -253,7 +218,7 @@ class ZeroPaddingIterableDataset(ZeroPadding, IterableDataset):
                     generate_packs = generate_greedy_packs(examples, self.max_length)
                     for batch_records in generate_packs:
                         if len(batch_records) > 0:
-                            padded_list = self._pad_batch_records(batch_records, self.max_length)
+                            padded_list = self._pad_batch_records(batch_records)
                             yield padded_list
                     examples = [record]
                     self.zero_padding_global_step += 1
@@ -262,5 +227,5 @@ class ZeroPaddingIterableDataset(ZeroPadding, IterableDataset):
                 generate_packs = generate_greedy_packs(examples, self.max_length)
                 for batch_records in generate_packs:
                     if len(batch_records) > 0:
-                        padded_list = self._pad_batch_records(batch_records, self.max_length)
+                        padded_list = self._pad_batch_records(batch_records)
                         yield padded_list


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. Revert commit #8973.
2. Set padding to `max_length` for `sequence_parallel` in `llm/run_finetune.py`.
3. Update test cases.