### PR TITLE
fix setup.py for llm inference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,7 @@ try:
             "paddlenlp.transformers.layoutxlm": get_package_data_files(
                 "paddlenlp.transformers.layoutxlm", ["visual_backbone.yaml"]
             ),
+            "paddlenlp.experimental": get_package_data_files("paddlenlp.experimental", ["transformers"]),
         },
         setup_requires=["cython", "numpy"],
         install_requires=REQUIRED_PACKAGES,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
之前PaddleNLP/paddlenlp/experimental/transformers/llama/ptq_scales_map_shift_smooth.json类似的文件通过python setup.py install后并没有copy过去，fix it。