### PR TITLE
[DCU] fix queue empty problem on DCU

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -970,6 +970,11 @@ class DygraphBlockInferencePredictor(BlockInferencePredictorMixin):
             output_tokens = []
             while len(outputs) < self.batch_size:
                 if paddle.core.is_compiled_with_rocm():
+                    """
+                    Due to the computing performance of the DCU platform, 
+                    too short timeout will cause queue empty problems, 
+                    so the timeout is temporarily increased.
+                    """
                     timeout=10
                 else:
                     timeout=1
@@ -1100,6 +1105,11 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin):
             output_tokens = []
             while len(outputs) < self.batch_size:
                 if paddle.core.is_compiled_with_rocm():
+                    """
+                    Due to the computing performance of the DCU platform, 
+                    too short timeout will cause queue empty problems, 
+                    so the timeout is temporarily increased.
+                    """
                     timeout=10
                 else:
                     timeout=1

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -969,7 +969,11 @@ class DygraphBlockInferencePredictor(BlockInferencePredictorMixin):
             outputs = []
             output_tokens = []
             while len(outputs) < self.batch_size:
-                result = result_queue.get(timeout=1)
+                if paddle.core.is_compiled_with_rocm():
+                    timeout=10
+                else:
+                    timeout=1
+                result = result_queue.get(timeout=timeout)
                 outputs.append(result[-1])
                 output_tokens.append(result[-2])
 
@@ -1095,7 +1099,11 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin):
             outputs = []
             output_tokens = []
             while len(outputs) < self.batch_size:
-                result = result_queue.get(timeout=1)
+                if paddle.core.is_compiled_with_rocm():
+                    timeout=10
+                else:
+                    timeout=1
+                result = result_queue.get(timeout=timeout)
                 outputs.append(result[-1])
                 output_tokens.append(result[-2])
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types

Bug fixes

### PR changes

Others

### Description

`result_queue`的超时时间对于DCU平台过短，会偶发queue empty的问题，故增大超时时间。