### PR TITLE
Fix eval hang

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -2657,6 +2657,9 @@ class Trainer:
 
         if self.args.pipeline_parallel_degree > 1:
             # Only accept wrapped model for pipeline_parallel mode
+            if self.model is self.model_wrapped:
+                # NOTE(gongenlei): when do_train=False, do_eval=True, we need to wrap model for pipeline
+                self.model_wrapped = fleet.distributed_model(self.model_wrapped)
             model = self.model_wrapped
         else:
             model = self.model

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -1500,7 +1500,7 @@ class Trainer:
                     eval_dataset,
                     batch_sampler=eval_sampler,
                     collate_fn=self.data_collator,
-                    num_workers=self.args.dataloader_num_workers,
+                    num_workers=0,
                     eval=True,
                 )
             else:
@@ -1508,7 +1508,7 @@ class Trainer:
                     eval_dataset,
                     batch_sampler=eval_sampler,
                     collate_fn=self.data_collator,
-                    num_workers=self.args.dataloader_num_workers,
+                    num_workers=0,
                 )
 
     def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
- 当eval dataloader_num_works>0时，eval会出现hang住的情况。