### PR TITLE
[Auto Parallel] Fix data stream bug for auto trainer

### DIFF
--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -279,8 +279,6 @@ class AutoTrainer(Trainer):
         self.state.is_local_process_zero = self.is_local_process_zero()
         self.state.is_world_process_zero = self.is_world_process_zero()
 
-        self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
-
         tr_loss = paddle.to_tensor(0.0)
         self._total_loss_scalar = 0.0
         self._globalstep_last_logged = self.state.global_step
@@ -291,6 +289,9 @@ class AutoTrainer(Trainer):
             npu_accelerate_plugin(self.optimizer)
 
         model, dist_loader = self._wrap_for_auto(model, train_dataloader)
+
+        self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
+
         train_dataloader = dist_loader()
 
         if resume_from_checkpoint is not None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
修复自动并行动转静热启时数据流错乱的问题。
bug根因在于，_wrap_for_auto创建了ShardDataloader，train_dataloader = dist_loader()这一句话通过调用ShardDataloader的__call__方法创建了迭代器。在创建迭代器之后，无法再通过callback_handler.on_train_begin设置迭代器中的sampler的consumed_samples。所以，目前auto_trainer中，对sampler的consumed_samples的设置是无效的，导致热启时数据流不正确。
因此，需要在创建ShardDataloader之后且产生迭代器之前调用callback_handler.on_train_begin。