### PR TITLE
[Auto Parallel] fix data stream bug of dist.to_static

### DIFF
--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -127,7 +127,12 @@ class AutoTrainer(Trainer):
         if self.args.to_static:
             unified_strategy = dist.Strategy()
             unified_strategy._from_legacy_strategy(self.args.strategy)
-            model = dist.to_static(model, dist_loader, self.criterion, self.optimizer, strategy=unified_strategy)
+            # dist.to_static() obtains the input spec information through next(dataloader), but this has side effects
+            # on the passed-in dataloader, altering the state of the sampler of the dataloader. In some cases, once
+            # the state of the sampler is changed, it cannot be reverted. Therefore, a temporary dataloader is
+            # constructed here to avoid side effects on the dataloader used for actual training.
+            temp_loader = self._wrap_for_dist_loader(self.get_train_dataloader())
+            model = dist.to_static(model, temp_loader, self.criterion, self.optimizer, strategy=unified_strategy)
 
         self.model_wrapped = model
         return model, dist_loader


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
to_static方法会对传入的dataloader调用next，以获取input的spec信息。但调用next方法会改变dataloader中sampler的状态。一些场景下，sampler的状态无法恢复，导致dataloader的数据流出现错乱。因此，这里构建一个临时的dataloader，避免对实际训练所用的dataloader产生副作用影响