### PR TITLE
fix hang when Flag_dataloader_use_file_descriptor=True

### DIFF
--- a/paddlenlp/utils/llm_utils.py
+++ b/paddlenlp/utils/llm_utils.py
@@ -750,14 +750,14 @@ def get_model_max_position_embeddings(config: PretrainedConfig) -> Optional[int]
     return None
 
 
-def read_res(model_name_or_path: str, tensor_queue: mp.Queue, result_queue: mp.Queue):
+def read_res(model_name_or_path: str, tensor_queue: mp.Queue, result_queue: mp.Queue, done_event: mp.Event):
     tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
 
     paddle.device.set_device("cpu")
     paddle.disable_static()
     outputs = []
     output_tensor = tensor_queue.get(timeout=1)
-
+    done_event.set()
     logger.info("Start read result message")
     logger.info(f"Current path is {os.getcwd()}")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
修复开启Flag_dataloader_use_file_descriptor，导致test_predictor.py hang的问题