### PR TITLE
[Auto Parallel] Adding shard_optimizer for non-sharding parallel, fix…

### DIFF
--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -123,8 +123,6 @@ class AutoTrainer(Trainer):
             self.optimizer = dist.shard_optimizer(self.optimizer, dist.ShardingStage2())
         elif ShardingOption.FULL_SHARD in self.args.sharding:
             self.optimizer = dist.shard_optimizer(self.optimizer, dist.ShardingStage3())
-        else:
-            self.optimizer = dist.shard_optimizer(self.optimizer)
 
         if self.args.to_static:
             unified_strategy = dist.Strategy()

--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -123,6 +123,8 @@ class AutoTrainer(Trainer):
             self.optimizer = dist.shard_optimizer(self.optimizer, dist.ShardingStage2())
         elif ShardingOption.FULL_SHARD in self.args.sharding:
             self.optimizer = dist.shard_optimizer(self.optimizer, dist.ShardingStage3())
+        else:
+            self.optimizer = dist.shard_optimizer(self.optimizer)
 
         if self.args.to_static:
             unified_strategy = dist.Strategy()

--- a/paddlenlp/trainer/utils/ckpt_converter.py
+++ b/paddlenlp/trainer/utils/ckpt_converter.py
@@ -148,11 +148,8 @@ class CheckpointConverter:
 
             # In this scenario, the data type of the model state is bfloat16.
             for param_name, param_value in model_params.items():
-                if param_value.is_dist():
-                    master_weight = self.auto_parallel_state_dict[param_name + ".master_weight"]
-                    cast_master_weight = paddle.cast(master_weight._local_value(), param_value.dtype)
-                    paddle.assign(cast_master_weight, param_value._local_value())
-                else:
+                if param_value._is_initialized():
+                    # These codes are compatible for both dense tensor and dist tensor
                     master_weight = self.auto_parallel_state_dict[param_name + ".master_weight"]
                     cast_master_weight = paddle.cast(master_weight, param_value.dtype)
                     paddle.assign(cast_master_weight, param_value)


### PR DESCRIPTION
… ckpt converter to spport sharding stage1

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. 自动并行场景下，即使不使用sharding，也应该调用dist.shard_optimizer，以保持优化器状态和参数的分布式属性一致。
2. sharding stage1/2场景下，ckpt转换工具存在缺陷。优化器状态中的 master_weight 为 Shard(0)，但param应该为 Replicate()。不能直接将 master_weight 的 local_value 赋值给 param 的 local_value