### PR TITLE
[Bugfix] fix multi-gpu infer

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -993,7 +993,8 @@ class DygraphBlockInferencePredictor(BlockInferencePredictorMixin):
 
         output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64").cpu()
         tensor_queue.put(output_tensor)
-        done_event.wait()
+        if self.tensor_parallel_rank == 0:
+            done_event.wait()
         s_time = time.time()
         while self.model_inputs["not_need_stop"]:
             self._infer(self.model_inputs)
@@ -1119,7 +1120,8 @@ class StaticBlockInferencePredictor(BlockInferencePredictorMixin):
             read_res_process.start()
         output_tensor = paddle.full(shape=[MAX_BSZ + 2, 1], fill_value=2, dtype="int64").cpu()
         tensor_queue.put(output_tensor)
-        done_event.wait()
+        if self.tensor_parallel_rank == 0:
+            done_event.wait()
         s_time = time.time()
         while self.model_inputs["not_need_stop"]:
             self.predictor.run(list(self.model_inputs.values()))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

修复了由于https://github.com/PaddlePaddle/PaddleNLP/pull/9080 导致的多卡推理hang住的问题