### PR TITLE
[XPU] rename SP Layer name to enable checkpoint loading from GPU

### DIFF
--- a/paddlenlp/transformers/linear_utils.py
+++ b/paddlenlp/transformers/linear_utils.py
@@ -67,8 +67,10 @@ elif get_env_device() == "xpu":
         from paddle_xpu.layers.nn import Linear as XPULinear
         from paddle_xpu.layers.nn import RowParallelLinear as XPURowParallelLinear
         from paddle_xpu.layers.nn.sequence_parallel import (
-            XPUColumnSequenceParallelLinear,
-            XPURowSequenceParallelLinear,
+            ColumnSequenceParallelLinear as XPUColumnSequenceParallelLinear,
+        )
+        from paddle_xpu.layers.nn.sequence_parallel import (
+            RowSequenceParallelLinear as XPURowSequenceParallelLinear,
         )
 
         Linear = XPULinear


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. fix the name mismatch of sequence parallel layers between GPU and XPU. The problem would cause error when loading GPU checkpoint on XPU.