### PR TITLE
【Inference】optimize top_p_sampling_reject

### DIFF
--- a/csrc/gpu/sample_kernels/top_p_sampling_reject.cu
+++ b/csrc/gpu/sample_kernels/top_p_sampling_reject.cu
@@ -16,7 +16,8 @@
 #include "sample_kernels/sampling.cuh"
 
 std::vector<paddle::Tensor> TopPSamplingReject(const paddle::Tensor& probs,
-                                               const paddle::Tensor& top_p) {
+                                               const paddle::Tensor& top_p,
+                                               int seed) {
   std::vector<int64_t> probs_shape = probs.shape();
   unsigned int batch_size = probs_shape[0];
   unsigned int vocab_size = probs_shape[1];
@@ -24,33 +25,54 @@ std::vector<paddle::Tensor> TopPSamplingReject(const paddle::Tensor& probs,
   // default is 32
   unsigned int max_top_p_rounds = 32;
   std::vector<int64_t> uniform_samples_shape = {batch_size, max_top_p_rounds};
-  paddle::Tensor uniform_samples = paddle::experimental::uniform(
-      uniform_samples_shape, paddle::DataType::FLOAT32, 0, 1, 0, probs.place());
+  paddle::Tensor uniform_samples =
+      paddle::experimental::uniform(uniform_samples_shape,
+                                    paddle::DataType::FLOAT32,
+                                    0,
+                                    1,
+                                    seed,
+                                    probs.place());
 
-  // todo: add parameter for deterministic, now default is true
-  bool deterministic = true;
-  paddle::Tensor probs_input;
-
-  probs_input = paddle::experimental::cast(probs, paddle::DataType::FLOAT32);
   auto cu_stream = probs.stream();
 
   auto samples =
-      paddle::full({batch_size}, 0, paddle::DataType::INT32, probs.place());
+      paddle::full({batch_size, 1}, 0, paddle::DataType::INT32, probs.place());
   auto success =
-      paddle::full({batch_size}, 0, paddle::DataType::BOOL, probs.place());
+      paddle::full({batch_size, 1}, 0, paddle::DataType::BOOL, probs.place());
 
-  cudaError_t status =
-      sampling::TopPSamplingFromProb<float, int>(probs_input.data<float>(),
-                                                 uniform_samples.data<float>(),
-                                                 samples.data<int>(),
-                                                 success.data<bool>(),
-                                                 nullptr,
-                                                 batch_size,
-                                                 top_p.data<float>(),
-                                                 vocab_size,
-                                                 max_top_p_rounds,
-                                                 deterministic,
-                                                 cu_stream);
+  auto top_p_host =
+      paddle::experimental::copy_to(top_p, paddle::CPUPlace(), true);
+  float top_p_val = top_p_host.data<float>()[0];
+  cudaError_t status;
+  if (top_p_val == 0.0) {
+    // top_p is 0，use top_k sampling
+    status = sampling::TopKSamplingFromProb<float, int>(
+        const_cast<float*>(probs.data<float>()),
+        uniform_samples.data<float>(),
+        samples.data<int>(),
+        success.data<bool>(),
+        nullptr,
+        batch_size,
+        1,
+        vocab_size,
+        max_top_p_rounds,
+        true,
+        cu_stream);
+  } else {
+    status = sampling::TopPSamplingFromProb<float, int>(
+        const_cast<float*>(probs.data<float>()),
+        uniform_samples.data<float>(),
+        samples.data<int>(),
+        success.data<bool>(),
+        nullptr,
+        batch_size,
+        top_p.data<float>(),
+        vocab_size,
+        max_top_p_rounds,
+        true,
+        cu_stream);
+  }
+
   PD_CHECK(status == cudaSuccess,
            "SamplingFromProbs failed with error code " +
                std::string(cudaGetErrorString(status)));
@@ -69,12 +91,13 @@ std::vector<std::vector<int64_t>> TopPSamplingRejectInferShape(
 
 std::vector<paddle::DataType> TopPSamplingRejectInferDtype(
     const paddle::DataType& probs_dtype, const paddle::DataType& top_p_shape) {
-  return {probs_dtype};
+  return {paddle::DataType::INT64};
 }
 
 PD_BUILD_OP(top_p_sampling_reject)
     .Inputs({"probs", "top_p"})
     .Outputs({"samples"})
+    .Attrs({"seed: int"})
     .SetKernelFn(PD_KERNEL(TopPSamplingReject))
     .SetInferShapeFn(PD_INFER_SHAPE(TopPSamplingRejectInferShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(TopPSamplingRejectInferDtype));

--- a/csrc/gpu/sample_kernels/top_p_sampling_reject.cu
+++ b/csrc/gpu/sample_kernels/top_p_sampling_reject.cu
@@ -45,7 +45,7 @@ std::vector<paddle::Tensor> TopPSamplingReject(const paddle::Tensor& probs,
   float top_p_val = top_p_host.data<float>()[0];
   cudaError_t status;
   if (top_p_val == 0.0) {
-    // top_p is 0，use top_k sampling
+    // top_p is 0，use top_k sampling .
     status = sampling::TopKSamplingFromProb<float, int>(
         const_cast<float*>(probs.data<float>()),
         uniform_samples.data<float>(),

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 from typing import List, Union
 
 import paddle
@@ -21,6 +22,7 @@ import paddle.nn.functional as F
 from paddlenlp.generation import GenerationMixin, LogitsProcessor, LogitsProcessorList
 
 __all__ = ["GenerationInferenceModel", "GenerationBlockInferenceModel", "GenerationAvxInferenceModel"]
+use_top_p_sampling_reject = os.getenv("USE_TOP_P_SAMPLING_REJECT")
 
 
 class ForcedDecodingEOSTokenLogitsProcessor(LogitsProcessor):
@@ -330,11 +332,11 @@ class GenerationInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            try:
+            if use_top_p_sampling_reject:
                 from paddlenlp_ops import top_p_sampling_reject
 
                 next_tokens = top_p_sampling_reject(probs, top_p, 0)
-            except:
+            else:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:
@@ -674,11 +676,11 @@ class GenerationBlockInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            try:
+            if use_top_p_sampling_reject:
                 from paddlenlp_ops import top_p_sampling_reject
 
                 next_tokens = top_p_sampling_reject(probs, top_p, 0)
-            except:
+            else:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import os
 from typing import List, Union
 
 import paddle
@@ -22,7 +21,6 @@ import paddle.nn.functional as F
 from paddlenlp.generation import GenerationMixin, LogitsProcessor, LogitsProcessorList
 
 __all__ = ["GenerationInferenceModel", "GenerationBlockInferenceModel", "GenerationAvxInferenceModel"]
-use_top_p_sampling_reject = os.getenv("USE_TOP_P_SAMPLING_REJECT")
 
 
 class ForcedDecodingEOSTokenLogitsProcessor(LogitsProcessor):
@@ -332,11 +330,11 @@ class GenerationInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            if use_top_p_sampling_reject:
+            try:
                 from paddlenlp_ops import top_p_sampling_reject
 
                 next_tokens = top_p_sampling_reject(probs, top_p, 0)
-            else:
+            except:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:
@@ -676,11 +674,11 @@ class GenerationBlockInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            if use_top_p_sampling_reject:
+            try:
                 from paddlenlp_ops import top_p_sampling_reject
 
                 next_tokens = top_p_sampling_reject(probs, top_p, 0)
-            else:
+            except:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:

--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 from typing import List, Union
 
 import paddle
@@ -21,6 +22,7 @@ import paddle.nn.functional as F
 from paddlenlp.generation import GenerationMixin, LogitsProcessor, LogitsProcessorList
 
 __all__ = ["GenerationInferenceModel", "GenerationBlockInferenceModel", "GenerationAvxInferenceModel"]
+use_top_p_sampling_reject = os.getenv("USE_TOP_P_SAMPLING_REJECT")
 
 
 class ForcedDecodingEOSTokenLogitsProcessor(LogitsProcessor):
@@ -330,11 +332,11 @@ class GenerationInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            try:
+            if use_top_p_sampling_reject:
                 from paddlenlp_ops import top_p_sampling_reject
 
-                next_tokens = top_p_sampling_reject(probs, top_p)
-            except:
+                next_tokens = top_p_sampling_reject(probs, top_p, 0)
+            else:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:
@@ -674,11 +676,11 @@ class GenerationBlockInferenceModel(GenerationMixin):
             probs = F.softmax(logits)
 
             # compute next_tokens
-            try:
+            if use_top_p_sampling_reject:
                 from paddlenlp_ops import top_p_sampling_reject
 
-                next_tokens = top_p_sampling_reject(probs, top_p)
-            except:
+                next_tokens = top_p_sampling_reject(probs, top_p, 0)
+            else:
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
DLTP-86942
https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-86942/show

1.支持传入seed。

2.该top_p_sampling_reject算子在TopP的值为0的时候，无出现无法采样成功的问题，返回值不正确。解决办法，当TopP为0，使用TopK进行采样，与vllm的方式类似。

3.fix一些之前未测试出来的小bug。