### PR TITLE
[Unified Checkpoint] Fix generation config save

### DIFF
--- a/paddlenlp/trainer/plugins/unified_checkpoint.py
+++ b/paddlenlp/trainer/plugins/unified_checkpoint.py
@@ -355,6 +355,9 @@ class UnifiedCheckpointHandler:
             config_to_save.architectures = [model_to_save.__class__.__name__]
         if self.args.should_save:
             config_to_save.save_pretrained(save_directory)
+            # save generation config
+            if model_to_save.can_generate():
+                model_to_save.generation_config.save_pretrained(save_directory)
         paddle.device.cuda.empty_cache()
 
         if strtobool(os.getenv("FLAG_LLM_PDC", "False")) and self.args.should_save:
@@ -638,6 +641,10 @@ class UnifiedCheckpointHandler:
         config_to_save = save_config(model_to_save)
         config_to_save.architectures = [model_to_save.__class__.__name__]
         config_to_save.save_pretrained(output_dir)
+
+        # save generation config
+        if model_to_save.can_generate():
+            model_to_save.generation_config.save_pretrained(output_dir)
 
     def save_single_card_optimizer(self, model, optimizer, output_dir):
         """ "Save optimizer for non-distributed environment."""


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
**Fix generation config save.**
* When `use_unified_checkpoint=False`, the model is saved by `model.save_from_pretrained`, in which the `generation_config.json` is saved. 
* When `use_unified_checkpoint=False`, the model is saved by  UC, which ignores saving `generation_config.json`.