### PR TITLE
Reduce the time spent on git downloading third-party libraries

### DIFF
--- a/csrc/setup_cuda.py
+++ b/csrc/setup_cuda.py
@@ -21,7 +21,7 @@ from paddle.utils.cpp_extension import CUDAExtension, setup
 
 def clone_git_repo(version, repo_url, destination_path):
     try:
-        subprocess.run(["git", "clone", "-b", version, "--single-branch", repo_url, destination_path], check=True)
+        subprocess.run(["git", "clone", "-b", version, "--single-branch", repo_url, destination_path, "--depth=1"], check=True)
         return True
     except subprocess.CalledProcessError as e:
         print(f"Git clone {repo_url} operation failed with the following error: {e}")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
git clone三方仓库时，仅拉取depth=1，以降低clone的耗时。