### PR TITLE
[Tokenizer] Fix TokenizerFast missing clean_up_tokenization_spaces

### DIFF
--- a/paddlenlp/transformers/tokenizer_utils_base.py
+++ b/paddlenlp/transformers/tokenizer_utils_base.py
@@ -1371,6 +1371,9 @@ class PretrainedTokenizerBase(SpecialTokensMixin):
 
         self.model_input_names = kwargs.pop("model_input_names", self.model_input_names)
 
+        # By default, cleaning tokenization spaces for both fast and slow tokenizers
+        self.clean_up_tokenization_spaces = kwargs.pop("clean_up_tokenization_spaces", False)
+
         # By default, do not split special tokens for both fast and slow tokenizers
         self.split_special_tokens = kwargs.pop("split_special_tokens", False)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug Fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
问题：使用LLamaTokenizerFast出现问题

复现代码
```
from paddlenlp.transformers import LlamaTokenizerFast
tokenizer = LlamaTokenizerFast.from_pretrained('meta-llama/Llama-2-13b')
output = tokenizer._decode([0, 3, 2, 1])
```

结果：
```
Traceback (most recent call last):
  File "test_tokenizer.py", line 6, in <module>
    output = tokenizer._decode([0, 3, 2, 1])
  File "/workspace/mnt/PaddleNLP/paddlenlp/transformers/tokenizer_utils_fast.py", line 653, in _decode
    else self.clean_up_tokenization_spaces
AttributeError: 'LlamaTokenizerFast' object has no attribute 'clean_up_tokenization_spaces'
```

修复参考链接：https://github.com/huggingface/transformers/blob/e5d14f39ad82475f238cad41279a5d61ac5db287/src/transformers/tokenization_utils_base.py/#L1616