### PR TITLE
Fix the bug in tiny_fused_bloom::test_wint8 with pir mode 

### DIFF
--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -520,7 +520,7 @@ class InferencePredictorMixin(BasePredictor):
             alibi_slopes = llm_utils.get_alibi_slopes(self.model_config.n_head)
             inputs["position_ids"] = paddle.to_tensor(alibi_slopes, dtype="float32")
             arange_tensor_encoder = paddle.arange(self.config.total_max_length, dtype=self.config.dtype)
-            alibi = alibi_slopes[None, :, None, None] * arange_tensor_encoder
+            alibi = (alibi_slopes[None, :, None, None] * arange_tensor_encoder).astype(self.config.dtype)
 
             if self.model_config.tensor_parallel_degree > 1:
                 block_size = self.model_config.n_head // self.model_config.tensor_parallel_degree

--- a/tests/llm/test_predictor.py
+++ b/tests/llm/test_predictor.py
@@ -113,7 +113,6 @@ class PredictorTest(LLMTest, unittest.TestCase):
         else:
             self.assertEqual(full_match / len(result_0), 1.0)
 
-    @skip("Skip and wait to fix.")
     def test_wint8(self):
         self.run_predictor(
             {"inference_model": True, "quant_type": "weight_only_int8", "src_length": 512, "max_length": 48}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

修复单测 llm_test tests/llm/test_predictor.py::PredictorTest_1___internal_testing___tiny_fused_bloom::test_wint8
