### PR TITLE
add check total_max_length for generate_func

### DIFF
--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -904,7 +904,7 @@ class GenerationMixin(object):
             "max_position_embeddings",
             "max_sequence_length",
             "seq_length",
-        ]    
+        ]
         for name in names:
             total_max_length = self.config.get(name, None)
             if total_max_length is not None:

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -897,6 +897,33 @@ class GenerationMixin(object):
         min_len = input_len + min_length
         max_len = input_len + max_length
 
+        total_max_length = None
+        names = [
+            "total_max_length",
+            "max_seq_len",
+            "max_position_embeddings",
+            "max_sequence_length",
+            "seq_length",
+        ]    
+        for name in names:
+            total_max_length = self.config.get(name, None)
+            if total_max_length is not None:
+                break
+        if total_max_length is None:
+            total_max_length = input_len + max_length
+            logger.warning(
+                f"Can not retrieval `total_max_length` from config.json, use default value {total_max_length}"
+            )
+        else:
+            if max_len > total_max_length:
+                max_len = total_max_length
+                logger.warning(
+                    f"The sum of src_length<{input_len}> and "
+                    f"max_new_tokens<{max_length}> is large than "
+                    f"the total_max_length size<{total_max_length}>"
+                    f"can only generate a sequence with a length of {total_max_length}"
+                )
+
         logits_processors = self.get_logits_processor(
             min_length=min_len if min_length > 0 else None,
             max_length=max_len,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
该pr在generate函数中添加了对`total_max_length`的判定，解决当`total_max_length` < `input_len` + `max_new_tokens`时，可能出现的Error: ../paddle/phi/kernels/funcs/gather.cu.h:60 Assertion `index_value >= 0 && index_value < input_dims[j]` failed. The index is out of bounds, please check whether the dimensions of index and input meet the requirements. It should be less than [8192] and greater than or equal to 0, but received [8192]的相关问题