### PR TITLE
Compatible with Tensor.to change to out_of_place.

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -1886,7 +1886,10 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
             for name, param in model.named_parameters():
                 if any(module_to_keep_in_fp32 in name for module_to_keep_in_fp32 in keep_in_fp32_modules):
                     if param.dtype != paddle.float32:
-                        param = param.to(dtype=paddle.float32)
+                        param_fp32 = param.cast(dtype=paddle.float32)
+                        param_fp32_tensor = param_fp32.value().get_tensor()
+                        param_tensor = param.value().get_tensor()
+                        param_tensor._share_data_with(param_fp32_tensor)
 
         # Make sure we are able to load base models as well as derived models (with heads)
         start_prefix = ""


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Compatible with Tensor.to change to out_of_place. 

Paddle has updated the Tensor.to operation to an out-of-place operation (https://github.com/PaddlePaddle/Paddle/pull/68992), which subsequently affects the _keep_in_fp32_modules within PaddleNLP.