### PR TITLE
[AutoParallel] Fix `EXCODE` bug of AutoParallel CI

### DIFF
--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -47,24 +47,25 @@ function track_case_status() {
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
-    run_fail_count=$(ls -1 "$prefix"*_FAIL 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
+    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
-    # return original path 
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
-        echo -e "\033[32m ---- $case_name all cases Success  \033"
+        echo -e "\033[32m ---- all cases Success  \033"
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'
+            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
         fi
+        return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
+    return 2
 } 
 
 # NOTE: Please place the new tests as much as possible after the existing tests

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -48,7 +48,7 @@ function track_case_status() {
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
@@ -56,17 +56,17 @@ function track_case_status() {
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL* 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null | awk -v OFS="\t" '{print "\t" $0 "(failed)"}'
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
-            echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
+            echo -e "\033[31m ---- $case_name verification failed test  :  $loss_fail_count \033"
+            grep 'check failed! ' result.log | awk -v prefix="$prefix" 'BEGIN {OFS="\t"} {if ($2 ~ "^" prefix) print "\t" $2 "(failed)"}'
         fi
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
     return 0
-} 
+}
 
 # NOTE: Please place the new tests as much as possible after the existing tests
 function llama_case_list_auto() {

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -65,7 +65,7 @@ function track_case_status() {
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
-    return 2
+    return 0
 } 
 
 # NOTE: Please place the new tests as much as possible after the existing tests

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -37,7 +37,7 @@ function track_case_status() {
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
@@ -45,17 +45,17 @@ function track_case_status() {
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL* 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null | awk -v OFS="\t" '{print "\t" $0 "(failed)"}'
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
-            echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
+            echo -e "\033[31m ---- $case_name verification failed test  :  $loss_fail_count \033"
+            grep 'check failed! ' result.log | awk -v prefix="$prefix" 'BEGIN {OFS="\t"} {if ($2 ~ "^" prefix) print "\t" $2 "(failed)"}'
         fi
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
     return 0
-} 
+}
 
 function gpt_case_list_dygraph(){
     # The test name must have "gpt_" as a prefix, which will 

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -36,24 +36,25 @@ function track_case_status() {
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
-    run_fail_count=$(ls -1 "$prefix"*_FAIL 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
+    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
-    # return original path 
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
-        echo -e "\033[32m ---- $case_name all cases Success  \033"
+        echo -e "\033[32m ---- all cases Success  \033"
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'
+            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
         fi
+        return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
+    return 2
 } 
 
 function gpt_case_list_dygraph(){

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -54,7 +54,7 @@ function track_case_status() {
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
-    return 2
+    return 0
 } 
 
 function gpt_case_list_dygraph(){

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -183,7 +183,7 @@ function track_case_status() {
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
@@ -191,11 +191,11 @@ function track_case_status() {
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL* 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null | awk -v OFS="\t" '{print "\t" $0 "(failed)"}'
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
-            echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
+            echo -e "\033[31m ---- $case_name verification failed test  :  $loss_fail_count \033"
+            grep 'check failed! ' result.log | awk -v prefix="$prefix" 'BEGIN {OFS="\t"} {if ($2 ~ "^" prefix) print "\t" $2 "(failed)"}'
         fi
         return 2
     fi

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -139,8 +139,16 @@ fi
 }
 ####################################
 print_info(){
-#解决异常退出-6的问题，CI中的偶现问题，无法复现
-if [[ $1 -ne 0 ]] && [[ $1 -ne 250 ]];then
+if [ $1 -eq 250 ];then
+    #解决异常退出-6的问题，CI中的偶现问题，无法复现
+    echo -e "\033[1;31m"  
+    echo -e "\033[1;31m The CI execution encountered an abnormal termination with error code exit -6. \033[0m"
+    echo -e "\033[1;31m This is an intermittent issue. \033[0m"
+    echo -e "\033[1;31m Please re-run the CI. \033[0m"
+    echo -e "\033[1;31m"  
+    exit 2
+fi
+if [[ $1 -ne 0 ]];then
     EXCODE=2
     if [ ! -f ${log_path}/$2 ];then
         echo -e "\033[31m run $2 CI FAIL \033"
@@ -151,7 +159,7 @@ if [[ $1 -ne 0 ]] && [[ $1 -ne 250 ]];then
     fi
     exit $EXCODE
 else
-    echo -e "\033[32m run $3 CI SUCCESS \033"
+    echo -e "\033[32m The $3 CI has completed \033"
 fi
 }
 ####################################

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -192,7 +192,7 @@ function track_case_status() {
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
-    return 2
+    return 0
 } 
 ####################################
 get_diff_TO_case # 获取待执行case列表

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -190,8 +190,10 @@ function track_case_status() {
             echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
             grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'
         fi
+        return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
+    return 0
 } 
 ####################################
 get_diff_TO_case # 获取待执行case列表
@@ -238,6 +240,7 @@ if [[ ${#case_list[*]} -ne 0 ]];then
     echo -e "\033[31m ---- end run case  \033"
 
     track_case_status  $FUNCNAME ""
+    EXCODE=$?
 else
     echo -e "\033[32m Changed Not CI case, Skips \033"
     EXCODE=0

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -174,26 +174,25 @@ function track_case_status() {
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
     total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
-    run_fail_count=$(ls -1 "$prefix"*_FAIL 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
+    run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
+    loss_fail_count=$(grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
-    # return original path 
     echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
     if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
-        echo -e "\033[32m ---- $case_name all cases Success  \033"
+        echo -e "\033[32m ---- all cases Success  \033"
     else
         if [[ $run_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL 2>/dev/null
+            ls -1 "$prefix"*_FAIL* 2>/dev/null
         fi
         if [[ $loss_fail_count -ne 0 ]] ; then
             echo -e "\033[31m ---- $case_name loss verification failed test  :  $loss_fail_count \033"
-            grep 'check failed! ' result.log | awk -v prefix="$prefix_var" '{if ($2 ~ "^" prefix) print $2}'
+            grep 'loss diff check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'
         fi
         return 2
     fi
     cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
-    return 0
+    return 2
 } 
 ####################################
 get_diff_TO_case # 获取待执行case列表


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
When `track_case_status` func has fail tests, fixing `EXCODE` value setting.