### PR TITLE
[Auto Parallel] fix adapt_stale_fwd_patch for to_static mode

### DIFF
--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -167,6 +167,8 @@ def adapt_stale_fwd_patch(self, name, value):
             "StaticFunction"
         ):
             return value
+        if type(value).__name__.endswith("WeakMethod") or self.forward.__class__.__name__.endswith("WeakMethod"):
+            return value
 
         # NOTE(changwenbin & zhoukangkang):
         # When use model = paddle.incubate.jit.inference(model), it reportes errors, we fix it here.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/pull/68850 的修改导致动转静时，转出来的函数类名称可能变为`WeakMethod`，因此需要在 adapt_stale_fwd_patch 这个方法里做对应的适配。