### PR TITLE
Reduce long duration for the `exit -6 re-run` process.

### DIFF
--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -117,6 +117,7 @@ function llm_qwen_case_list_auto() {
 
 function llama_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -187,6 +188,7 @@ function llama_dygraph_auto_bs8_fp32_DP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -257,6 +259,7 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -327,6 +330,7 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -401,6 +405,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
+        cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
         export NVIDIA_TF32_OVERRIDE=0
@@ -500,6 +505,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
+        cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
         export NVIDIA_TF32_OVERRIDE=0
@@ -597,6 +603,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -691,6 +698,7 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
 
 function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export FLAGS_max_inplace_grad_add=100
@@ -787,6 +795,7 @@ function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -882,6 +891,7 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
 
 function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -974,6 +984,8 @@ function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
 
 function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
+    export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
     export FLAGS_max_inplace_grad_add=3
@@ -1072,6 +1084,8 @@ function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
 
 function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
+    export PYTHONPATH=$root_path/:$PYTHONPATH
     # Only A100 support this case.
     if [ $IS_A100 -ne 0 ]; then
         export FLAGS_call_stack_level=3
@@ -1180,6 +1194,8 @@ function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
 
 function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
+    export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
     export FLAGS_max_inplace_grad_add=3
@@ -1286,6 +1302,7 @@ function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
 
 function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1445,6 +1462,7 @@ function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1515,6 +1533,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1587,6 +1606,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1660,6 +1680,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1733,6 +1754,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2() {
+    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2.json"
@@ -1826,6 +1848,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2() {
+    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2.json"
@@ -1919,6 +1942,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2() {
+    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2_pp2.json"
@@ -2012,6 +2036,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2() {
+    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2_pp2.json"
@@ -2125,12 +2150,12 @@ function check_result() {
     echo -e "$1" >> ${log_path}/result.log
     if [ $? -ne 0 ];then
         echo -e "\033[31m $1 run failed! \033[0m" | tee -a ${log_path}/result.log
-        return 0
+        exit 2
     fi
 
     if [ $# -ne 7 ] && [ $# -ne 8 ]; then
         echo -e "\033[31m $1 parameter transfer failed: $@ \033[0m" | tee -a ${log_path}/result.log
-        return 0
+        exit 2
     fi
 
     diff_loss=$(echo $2 $3|awk '{printf "%0.2f\n", ($2-$1)/$1*100}')
@@ -2138,13 +2163,13 @@ function check_result() {
     if [ $2 != $3 ];then
         if [ -z "$8" ] || [ $8 -ne 1 ] ;then
             echo -e "\033[31m $1 loss diff check failed! \033[0m" | tee -a ${log_path}/result.log
-            return 0
+            exit 2
         else
             diff=$(echo "$2 $3" | awk '{print $1-$2}')
             gt=$(echo "${diff#-} 1e-5" | awk '{print ($1>$2)?"1":"0"}')
             if [ $gt -eq 1 ];then
                 echo -e "\033[31m $1 loss diff check failed! \033[0m" | tee -a ${log_path}/result.log
-                exit -1
+                exit 2
             fi
         fi
     fi
@@ -2158,7 +2183,7 @@ function check_result() {
     fi
     if [[ $v2 == 0 ]];then
         echo -e "\033[31m $1 IPS diff check failed! \033[0m" | tee -a $log_path/result.log
-        return 0
+        exit 2
     fi
 
     diff_mem=$(echo $6 $7|awk '{printf "%0.2f\n", ($2-$1)/$1*100}')
@@ -2167,7 +2192,7 @@ function check_result() {
     w2=$(echo $diff_mem -5.0|awk '{print($1<=$2)?"0":"1"}')
     if [[ $w1 == 0 ]];then
         echo -e "\033[31m $1 MEM diff check failed! \033[0m" | tee -a $log_path/result.log
-        return 0
+        exit 2
     fi
     if [[ $w2 == 0 ]];then
         echo -e "$1 MEM decreases greater than 5%, not exit " | tee -a $log_path/result.log
@@ -2176,6 +2201,7 @@ function check_result() {
 
 function before_hook_for_gpt() {
     echo -e "\033[31m ---- Set FLAGS for GPT auto cases  \033[0m"
+    cd ${gpt_case_path}
     export FLAGS_new_executor_micro_batching=True  # True：打开新执行器
     export FLAGS_embedding_deterministic=1         # 1：关闭随机性
     export FLAGS_cudnn_deterministic=1             # 1：关闭随机性
@@ -2217,6 +2243,7 @@ function before_hook_for_gpt() {
 
 function before_hook_for_llama() {
     echo -e "\033[31m ---- Set FLAGS for LLaMA auto cases  \033[0m"
+    cd ${llama_case_path}
     export FLAGS_new_executor_micro_batching=True  # True：打开新执行器
     export FLAGS_embedding_deterministic=1         # 1：关闭随机性
     export FLAGS_cudnn_deterministic=1             # 1：关闭随机性
@@ -2245,19 +2272,81 @@ function before_hook_for_llama() {
     fi
 }
 
-echo -e "\033[31m ---- Start executing $1 \033[0m"
-export exec_case=$1
-export FLAGS_install_deps=$2
-export FLAGS_download_data=$3
+function restore_func() {
+    fun_list=$1
+    cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; } 
+    if [ -e "functions.txt" ]; then
+        rm "functions.txt"
+        echo "Deleted existing functions.txt"
+    fi
+    for function in ${fun_list[@]};do
+        echo "$function" >> functions.txt
+    done
+}
 
-if [[ $exec_case =~ "gpt" ]];then
-    cd ${gpt_case_path}
-    before_hook_for_gpt
-elif [[ $exec_case =~ "llama" ]];then
-    cd ${llama_case_path}
-    before_hook_for_llama
+function restore_llama_case_list_auto_func() {
+    fun_list=(
+        llama_dygraph_auto_bs8_fp32_DP2
+        llama_dygraph_auto_bs8_fp32_DP2-MP2
+        llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2
+        llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2
+        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw
+        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2
+        llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1
+        llama_pir_auto_fuse_ffn_attention_qkv_MP2
+        llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1
+        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP
+        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP
+        llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1
+        llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4
+        llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4
+    )
+    restore_func $fun_list
+}
+
+function restore_llm_gpt_case_list_auto_func() {
+    fun_list=(
+        llm_gpt_dygraph_auto_bs8_fp32_DP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
+        llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
+    )
+    restore_func $fun_list  
+}
+
+
+
+
+export status=$1
+if [[ $status = "prepare_case" ]];then
+    export FLAGS_install_deps=$3
+    export FLAGS_download_data=$4
+    if [[ $2 = "llama_case_list_auto" ]];then
+        before_hook_for_llama
+        restore_llama_case_list_auto_func
+    elif [[ $2 = "llm_gpt_case_list_auto" ]];then
+        before_hook_for_gpt
+        restore_llm_gpt_case_list_auto_func
+    else
+        echo -e "\033[31m ---- Invalid exec_case $2 \033[0m"
+    fi
+elif [[ $status = "exec_case" ]];then
+    export FLAGS_install_deps=$3
+    export FLAGS_download_data=$4
+    $2
 else
-    echo -e "\033[31m ---- Invalid exec_case $exec_case \033[0m"
+    echo -e "\033[31m ---- Invalid status $status \033[0m"
+    export exec_case=$1
+    export FLAGS_install_deps=$2
+    export FLAGS_download_data=$3
+    if [[ $status =~ "gpt" ]];then
+        cd ${gpt_case_path}
+        before_hook_for_gpt
+    elif [[ $status =~ "llama" ]];then
+        cd ${llama_case_path}
+        before_hook_for_llama
+    else
+        echo -e "\033[31m ---- Invalid exec_case $exec_case \033[0m"
+    fi
+    $1
 fi
-
-$1

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -46,7 +46,7 @@ function track_case_status() {
     original_path=$(pwd)  
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
-    total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
+    total_count=$(ls -1 "$prefix"* 2>/dev/null | grep -Ev 'result\.log|functions\.txt' | wc -l)
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
     loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -117,6 +117,7 @@ function llm_qwen_case_list_auto() {
 
 function llama_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -188,6 +189,7 @@ function llama_dygraph_auto_bs8_fp32_DP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -259,6 +261,7 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -330,6 +333,7 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -405,6 +409,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
+        export_env
         cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
@@ -505,6 +510,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
+        export_env
         cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
@@ -603,6 +609,7 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
@@ -698,6 +705,7 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
 
 function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -795,6 +803,7 @@ function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
@@ -891,6 +900,7 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
 
 function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -984,6 +994,7 @@ function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
 
 function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1084,6 +1095,7 @@ function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
 
 function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     # Only A100 support this case.
@@ -1194,6 +1206,7 @@ function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
 
 function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1302,6 +1315,7 @@ function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
 
 function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1462,6 +1476,7 @@ function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1533,6 +1548,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1606,6 +1622,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1680,6 +1697,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    export_env
     cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -1754,6 +1772,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2() {
+    export_env
     cd ${gpt_case_path}
     set -x
 
@@ -1848,6 +1867,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2() {
+    export_env
     cd ${gpt_case_path}
     set -x
 
@@ -1942,6 +1962,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2() {
+    export_env
     cd ${gpt_case_path}
     set -x
 
@@ -2036,6 +2057,7 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2() {
+    export_env
     cd ${gpt_case_path}
     set -x
 
@@ -2239,6 +2261,18 @@ function before_hook_for_gpt() {
     else
         echo -e "\033[31m ---- Skip download gpt data \033[0m"
     fi
+}
+
+function export_env() {
+    export FLAGS_new_executor_micro_batching=True  # True：打开新执行器
+    export FLAGS_embedding_deterministic=1         # 1：关闭随机性
+    export FLAGS_cudnn_deterministic=1             # 1：关闭随机性
+    export FLAGS_program_topo_reorder=1            # 1: 反向对齐动手拓扑排序
+    unset CUDA_MODULE_LOADING
+    env | grep FLAGS
+    export http_proxy=${proxy}
+    export https_proxy=${proxy}
+    export no_proxy=bcebos.com
 }
 
 function before_hook_for_llama() {

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -35,7 +35,7 @@ function track_case_status() {
     original_path=$(pwd)  
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
-    total_count=$(ls -1 "$prefix"* 2>/dev/null | wc -l)  
+    total_count=$(ls -1 "$prefix"* 2>/dev/null | grep -Ev 'result\.log|functions\.txt' | wc -l)
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
     loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -97,6 +97,7 @@ function llm_gpt_case_list_dygraph() {
 ############ case start ############
 function gpt_preprocess_data() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python ppfleetx/data/data_tools/gpt/raw_trans_to_json.py  \
         --input_path ./dataset/wikitext_103_en \
@@ -118,6 +119,7 @@ function gpt_preprocess_data() {
 
 function gpt_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python tools/train.py \
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_345M_single_card.yaml \
@@ -131,6 +133,7 @@ function gpt_345M_single() {
 
 function gpt_1.3B_dp() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_1.3B_dp8.yaml \
@@ -144,6 +147,7 @@ function gpt_1.3B_dp() {
 
 function gpt_6.7B_stage2_dp2_sharding4() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -160,6 +164,7 @@ function gpt_6.7B_stage2_dp2_sharding4() {
 
 function gpt_6.7B_stage3_dp2_sharding4() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -176,6 +181,7 @@ function gpt_6.7B_stage3_dp2_sharding4() {
 
 function gpt_6.7B_stage2_sharding8() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -192,6 +198,7 @@ function gpt_6.7B_stage2_sharding8() {
 
 function gpt_175B_DP1_MP4_PP2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -208,6 +215,7 @@ function gpt_175B_DP1_MP4_PP2() {
 
 function gpt_175B_DP1_MP4_PP2_sp() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -223,6 +231,7 @@ function gpt_175B_DP1_MP4_PP2_sp() {
 
 function gpt_175B_DP1_MP8_PP1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -239,6 +248,7 @@ function gpt_175B_DP1_MP8_PP1() {
 
 function gpt_175B_DP1_MP8_PP1_sp() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -254,6 +264,7 @@ function gpt_175B_DP1_MP8_PP1_sp() {
 
 function gpt_175B_DP1_MP1_PP8() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -272,6 +283,7 @@ function gpt_175B_DP1_MP1_PP8() {
 
 function gpt_345M_mp8_qat() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/qat_gpt_345M_mp8.yaml \
@@ -285,6 +297,7 @@ function gpt_345M_mp8_qat() {
 
 function gpt_generation_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python tasks/gpt/generation.py \
         -c ppfleetx/configs/nlp/gpt/generation_gpt_345M_single_card.yaml \
@@ -296,6 +309,7 @@ function gpt_generation_345M_single() {
 
 function gpt_generation_345M_hybrid() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0" tasks/gpt/generation.py \
         -c ppfleetx/configs/nlp/gpt/generation_gpt_345M_dp8.yaml \
@@ -307,6 +321,7 @@ function gpt_generation_345M_hybrid() {
 
 function gpt_export_345M_mp1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -328,6 +343,7 @@ function gpt_export_345M_mp1() {
 
 function gpt_export_345M_mp2() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -350,6 +366,7 @@ function gpt_export_345M_mp2() {
 
 function gpt_export_qat_345M() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -369,6 +386,7 @@ function gpt_export_qat_345M() {
 
 function gpt_inference_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     rm -rf output
     python tools/export.py \
@@ -384,6 +402,7 @@ function gpt_inference_345M_single() {
 
 function gpt_inference_345M_dp8() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     rm -rf output
     python -m paddle.distributed.launch --devices "0" tools/export.py \
@@ -400,6 +419,7 @@ function gpt_inference_345M_dp8() {
 
 function gpt_345M_single_finetune() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python ./tools/train.py \
         -c ./ppfleetx/configs/nlp/gpt/finetune_gpt_345M_single_card_glue.yaml \
@@ -417,6 +437,7 @@ function gpt_345M_single_finetune() {
 
 function gpt_eval_WikiText() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python ./tools/eval.py \
         -c ./ppfleetx/configs/nlp/gpt/eval_gpt_345M_single_card.yaml \
@@ -432,6 +453,7 @@ function gpt_eval_WikiText() {
 
 function gpt_eval_LAMBADA() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${gpt_case_path}
     rm -rf log
     python ./tools/eval.py \
         -c ./ppfleetx/configs/nlp/gpt/eval_gpt_345M_single_card.yaml \
@@ -447,6 +469,7 @@ function gpt_eval_LAMBADA() {
 
 function llm_gpt_recompute_bs32_bf16_MP2-SD4-stage1() {
     echo "=========== $FUNCNAME run begin ==========="
+    cd ${llm_gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     log_dir=mylog
     rm -rf $log_dir
@@ -547,6 +570,7 @@ function check_result() {
 
 function before_hook_for_gpt() {
     echo -e "\033[31m ---- Set FLAGS for GPT dygraph cases  \033[0m"
+    cd ${gpt_case_path}
     env | grep FLAGS
     export http_proxy=${proxy}
     export https_proxy=${proxy}
@@ -653,6 +677,7 @@ function before_hook_for_gpt() {
 
 function before_hook_for_llm_gpt() {
     echo -e "\033[31m ---- Set FLAGS for llm GPT cases  \033[0m"
+    cd ${llm_gpt_case_path}
     export FLAGS_cudnn_deterministic=1
     export FLAGS_embedding_deterministic=1
     env | grep FLAGS
@@ -678,20 +703,88 @@ function before_hook_for_llm_gpt() {
     fi
 }
 
-echo -e "\033[31m ---- Start executing $1 \033[0m"
+function restore_func() {
+    fun_list=$1
+    cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; } 
+    if [ -e "functions.txt" ]; then
+        rm "functions.txt"
+        echo "Deleted existing functions.txt"
+    fi
+    for function in ${fun_list[@]};do
+        echo "$function" >> functions.txt
+    done
+}
 
-export exec_case=$1
-export FLAGS_install_deps=$2
-export FLAGS_download_data=$3
+function restore_gpt_case_list_dygraph_func() {
+    fun_list=(
+        gpt_preprocess_data
+        gpt_345M_single
+        gpt_1.3B_dp
+        gpt_6.7B_stage2_dp2_sharding4
+        gpt_6.7B_stage3_dp2_sharding4
+        gpt_6.7B_stage2_sharding8
+        gpt_175B_DP1_MP4_PP2
+        gpt_175B_DP1_MP4_PP2_sp
+        gpt_175B_DP1_MP8_PP1
+        gpt_175B_DP1_MP8_PP1_sp
+        gpt_175B_DP1_MP1_PP8
+        gpt_generation_345M_single
+        gpt_generation_345M_hybrid
+        gpt_345M_mp8_qat
+        # gpt_export_345M_mp1
+        # gpt_export_345M_mp2
+        # gpt_export_qat_345M
+        # gpt_inference_345M_single
+        # gpt_inference_345M_dp8
+        gpt_345M_single_finetune
+        gpt_eval_WikiText
+        gpt_eval_LAMBADA
+    )
+    restore_func $fun_list  
+}
 
-if [[ $exec_case =~ "llm_gpt" ]];then
-    cd ${llm_gpt_case_path}
-    before_hook_for_llm_gpt
-elif [[ $exec_case =~ "gpt" ]];then
-    cd ${gpt_case_path}
-    before_hook_for_gpt
+function restore_llm_gpt_case_list_dygraph_func() {
+    fun_list=(
+        llm_gpt_recompute_bs32_bf16_MP2-SD4-stage1
+    )
+    restore_func $fun_list  
+}
+
+export status=$1
+
+if [[ $status = "prepare_case" ]];then
+    export FLAGS_install_deps=$3
+    export FLAGS_download_data=$4
+    if [[ $2 = "gpt_case_list_dygraph" ]];then
+        before_hook_for_gpt
+        restore_gpt_case_list_dygraph_func
+    elif [[ $2 = "llm_gpt_case_list_dygraph" ]];then
+        before_hook_for_llm_gpt
+        restore_llm_gpt_case_list_dygraph_func
+    else
+        echo -e "\033[31m ---- Invalid exec_case $2 \033[0m"
+    fi
+elif [[ $status = "exec_case" ]];then
+    export FLAGS_install_deps=$3
+    export FLAGS_download_data=$4
+    $2
 else
-    echo -e "\033[31m ---- Invalid exec_case $exec_case \033[0m"
+    echo -e "\033[31m ---- Start executing $1 \033[0m"
+
+    export exec_case=$1
+    export FLAGS_install_deps=$2
+    export FLAGS_download_data=$3
+
+    if [[ $exec_case =~ "llm_gpt" ]];then
+        cd ${llm_gpt_case_path}
+        before_hook_for_llm_gpt
+    elif [[ $exec_case =~ "gpt" ]];then
+        cd ${gpt_case_path}
+        before_hook_for_gpt
+    else
+        echo -e "\033[31m ---- Invalid exec_case $exec_case \033[0m"
+    fi
+
+    $1
 fi
 
-$1

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -470,6 +470,8 @@ function gpt_eval_LAMBADA() {
 function llm_gpt_recompute_bs32_bf16_MP2-SD4-stage1() {
     echo "=========== $FUNCNAME run begin ==========="
     cd ${llm_gpt_case_path}
+    export FLAGS_cudnn_deterministic=1
+    export FLAGS_embedding_deterministic=1
     export PYTHONPATH=$root_path/:$PYTHONPATH
     log_dir=mylog
     rm -rf $log_dir

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -138,31 +138,6 @@ else
 fi
 }
 ####################################
-print_info(){
-if [ $1 -eq 250 ];then
-    #解决异常退出-6的问题，CI中的偶现问题，无法复现
-    echo -e "\033[1;31m"  
-    echo -e "\033[1;31m The CI execution encountered an abnormal termination with error code exit -6. \033[0m"
-    echo -e "\033[1;31m This is an intermittent issue. \033[0m"
-    echo -e "\033[1;31m Please re-run the CI. \033[0m"
-    echo -e "\033[1;31m"  
-    exit 2
-fi
-if [[ $1 -ne 0 ]];then
-    EXCODE=2
-    if [ ! -f ${log_path}/$2 ];then
-        echo -e "\033[31m run $2 CI FAIL \033"
-    else
-        mv ${log_path}/$2 ${log_path}/$2_FAIL.log
-        echo -e "\033[31m ${log_path}/$2_FAIL \033"
-        tail -10 ${log_path}/$2_FAIL.log
-    fi
-    exit $EXCODE
-else
-    echo -e "\033[32m The $3 CI has completed \033"
-fi
-}
-####################################
 function contain_case(){
     local e
     for e in "${@:2}";do
@@ -212,11 +187,11 @@ function execute_func_list(){
         done
     done < functions.txt
     echo -e "\033[31m $2 test case has complicated \033"
-    echo -e "\033[31m {OFS="\t"}  total tests :  $total_count \033"
-    echo -e "\033[31m {OFS="\t"}  success tests :  $success_count \033"
-    echo -e "\033[31m {OFS="\t"}  runtime fail tests :  $runtime_fail_count \033"
-    echo -e "\033[31m {OFS="\t"}  verification fail tests :  $verification_fail_count \033"
-    echo -e "\033[31m {OFS="\t"}  exit 250 tests(intermittent issue) :  $exit_250_count \033"
+    echo -e "\033[31m $(printf '\t')  total tests :  $total_count \033"
+    echo -e "\033[31m $(printf '\t')  success tests :  $success_count \033"
+    echo -e "\033[31m $(printf '\t')  runtime fail tests :  $runtime_fail_count \033"
+    echo -e "\033[31m $(printf '\t')  verification fail tests :  $verification_fail_count \033"
+    echo -e "\033[31m $(printf '\t')  exit 250 tests(intermittent issue) :  $exit_250_count \033"
 }
 ####################################
 function track_case_status() {  
@@ -227,7 +202,7 @@ function track_case_status() {
     original_path=$(pwd)  
     cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
   
-    total_count=$(ls -1 "$prefix"* 2>/dev/null | grep -Ev 'result\.log|function\.txt' | wc -l)
+    total_count=$(ls -1 "$prefix"* 2>/dev/null | grep -Ev 'result\.log|functions\.txt' | wc -l)
     run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
     loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
     
@@ -288,7 +263,7 @@ if [[ ${#case_list[*]} -ne 0 ]];then
         echo -e "\033[31m ---- running case $case_num/${#case_list[*]}: gpt-3_dygraph \033"
         cmd=/workspace/PaddleNLP/scripts/distribute/ci_case_dy.sh
         bash $cmd prepare_case gpt_case_list_dygraph $FLAGS_install_deps $FLAGS_download_data
-        execute_func_list $cmdgpt-3_dygraph
+        execute_func_list $cmd gpt-3_dygraph
         export FLAGS_install_deps=1
         export FLAGS_download_data="gpt ""$FLAGS_download_data"
         let case_num++

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -162,18 +162,18 @@ function execute_func_list(){
             bash $1 exec_case $func_name $FLAGS_install_deps $FLAGS_download_data  
             result=$?
             if [ $result -eq 0 ]; then
-                echo "test success!"
+                echo -e "\033[32m test success!"
                 let success_count++
             elif [ $result -eq 2 ]; then
-                echo "verification failed!"
+                echo -e "\033[31m verification failed!"
                 let verification_fail_count++
             elif [ $result -eq 250 ]; then
                 if [ $excute_num -eq 1 ]; then
-                    echo "fist time execute failed, try again!"
+                    echo -e "\033[31m fist time execute failed, try again!"
                     let excute_num++
                     continue
                 else
-                    echo "second time execute failed, exit!"
+                    echo -e "\033[31m second time execute failed, exit!"
                     let exit_250_count++
                 fi
             else


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
线上自动并行 `PaddleNLP-CI-gpt-3` CI 会在测试执行结束后出现随机挂 `exit -6`的现象。原本的处理方法是结束CI，并提示用户通过`re-run`的方式来解决。但随机挂概率较高，导致用户负担较重。因此，本PR主要是通过自动`re-run`的方式解决该问题：

1.  执行`test_case` 需要通过子进程方式将test函数集合写入`function.txt`中，父进程读取`function.txt`中的函数名称，再通过子进程的方式进行调用执行。因此，父进程可以捕获每个测试的`ExitCode`
2. 子进程返回 `ExitCode = 250`则代表出现随机挂 `exit -6`，该测试会自动`re-run`一次，如果问题复现，则日志中只提示用户该测试多次出现随机挂问题，不再中断CI，继续执行剩余测试
3. 在`test_case`执行完后，统计当前`case`的总测试数目、成功测试数目、运行失败测试数目、精度校验失败测试数目、随机挂测试数目
