### PR TITLE
update dcu paddlenlp_ops

### DIFF
--- a/csrc/setup_hip.py
+++ b/csrc/setup_hip.py
@@ -50,6 +50,8 @@ setup(
             "./gpu/quant_int8.cu",
             "./gpu/dequant_int8.cu",
             "./gpu/flash_attn_bwd.cc",
+            "./gpu/update_inputs_v2.cu",
+            "./gpu/set_preids_token_penalty_multi_scores.cu",
         ],
         extra_compile_args={
             "cxx": ["-O3"],

--- a/csrc/setup_hip.py
+++ b/csrc/setup_hip.py
@@ -21,6 +21,7 @@ def update_git_submodule():
     except subprocess.CalledProcessError as e:
         print(f"Error occurred while updating git submodule: {str(e)}")
         raise
+
 update_git_submodule()
 setup(
     name="paddlenlp_ops",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
在develop PaddleNLP中，dcu在调用paddlenlp/experimental/transformers/generation_utils.py 中的paddlenlp_ops会出现找不到算子的情况