### PR TITLE
Fix auto parallel CI exit -6

### DIFF
--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -164,8 +164,6 @@ function llm_qwen_case_list_auto() {
 
 function llama_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -236,8 +234,6 @@ function llama_dygraph_auto_bs8_fp32_DP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -308,8 +304,6 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -380,8 +374,6 @@ function llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -456,8 +448,6 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
-        export_env
-        cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
         export NVIDIA_TF32_OVERRIDE=0
@@ -557,8 +547,6 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
     echo IS_A100 is $IS_A100
     if [ $IS_A100 -ne 0 ]; then
         echo "=========== $FUNCNAME run begin ==========="
-        export_env
-        cd ${llama_case_path}
         export PYTHONPATH=$root_path/:$PYTHONPATH
         export FLAGS_call_stack_level=3
         export NVIDIA_TF32_OVERRIDE=0
@@ -656,8 +644,6 @@ function llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -752,8 +738,6 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
 
 function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export FLAGS_max_inplace_grad_add=100
@@ -850,8 +834,6 @@ function llama_pir_auto_fuse_ffn_attention_qkv_MP2() {
 
 function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export PYTHONPATH=/paddle/Paddle/build_gpu/python/:$PYTHONPATH
     export FLAGS_call_stack_level=3
@@ -947,8 +929,6 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP() {
 
 function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1041,8 +1021,6 @@ function llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1() {
 
 function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1142,8 +1120,6 @@ function llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1() {
 
 function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     # Only A100 support this case.
     if [ $IS_A100 -ne 0 ]; then
@@ -1253,8 +1229,6 @@ function llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4() {
 
 function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1362,8 +1336,6 @@ function llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4() {
 
 function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${llama_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1523,8 +1495,6 @@ function llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1595,8 +1565,6 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1669,8 +1637,6 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1744,8 +1710,6 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
 
 function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    export_env
-    cd ${gpt_case_path}
     export PYTHONPATH=$root_path/:$PYTHONPATH
     export FLAGS_call_stack_level=3
     export NVIDIA_TF32_OVERRIDE=0
@@ -1819,8 +1783,6 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2() {
-    export_env
-    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2.json"
@@ -1914,8 +1876,6 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2() {
-    export_env
-    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2.json"
@@ -2009,8 +1969,6 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2() {
-    export_env
-    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2_pp2.json"
@@ -2104,8 +2062,6 @@ EOF
 }
 
 function llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2() {
-    export_env
-    cd ${gpt_case_path}
     set -x
 
     config_json="pretrain_argument_for_ci_auto_dp2_mp2_pp2.json"
@@ -2372,9 +2328,15 @@ if [[ $status = "prepare_case" ]];then
 elif [[ $status = "exec_case" ]];then
     export FLAGS_install_deps=$3
     export FLAGS_download_data=$4
+    export_env
+    if [[ $2 =~ "gpt" ]];then
+        cd ${gpt_case_path}
+    elif [[ $2 =~ "llama" ]];then
+        cd ${llama_case_path}
+    fi
     $2
 else
-    echo -e "\033[31m ---- Invalid status $status \033[0m"
+    echo -e "\033[31m ---- Start executing  $status \033[0m"
     export exec_case=$1
     export FLAGS_install_deps=$2
     export FLAGS_download_data=$3

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -68,49 +68,96 @@ function track_case_status() {
     return 0
 }
 
-# NOTE: Please place the new tests as much as possible after the existing tests
-function llama_case_list_auto() {
-    # The test name must have "llama_" as a prefix, which will 
-    # be used for tracking the execution status of the case.
-    llama_dygraph_auto_bs8_fp32_DP2
-    llama_dygraph_auto_bs8_fp32_DP2-MP2
-    llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2
-    llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2
-    llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw
-    llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2
-    
-    llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1
-    llama_pir_auto_fuse_ffn_attention_qkv_MP2
-    llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1
-    llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP
-    llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP
-    llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1
-    llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4
-    llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4
-
-    track_case_status $FUNCNAME "llama_"
+function restore_func() {
+    fun_list=$1
+    cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; } 
+    if [ -e "functions.txt" ]; then
+        rm "functions.txt"
+        echo "Deleted existing functions.txt"
+    fi
+    for function in ${fun_list[@]};do
+        echo "$function" >> functions.txt
+    done
 }
 
-function llm_gpt_case_list_auto() {
-    # The test name must have "llm_gpt_dygraph_auto_" as a prefix, 
-    # which will be used for tracking the execution status of the case.
-    llm_gpt_dygraph_auto_bs8_fp32_DP2
-    llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
-    llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
-    llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
 
-    track_case_status $FUNCNAME "llm_gpt_dygraph_auto_"
+
+# NOTE: Please place the new tests as much as possible after the existing tests
+function llama_case_list_auto() {
+    fun_list=(
+        # The test name must have "llama_" as a prefix, which will 
+        # be used for tracking the execution status of the case.
+        llama_dygraph_auto_bs8_fp32_DP2
+        llama_dygraph_auto_bs8_fp32_DP2-MP2
+        llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2
+        llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2
+        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw
+        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2
+        llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1
+        llama_pir_auto_fuse_ffn_attention_qkv_MP2
+        llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1
+        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP
+        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP
+        llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1
+        llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4
+        llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4
+    )
+    if [ $1 -eq "prepare_case" ]; then
+        restore_func $fun_list  
+    elif [ $1 -eq "exec_case" ]; then
+        for fun in "${fun_list[@]}"; do
+            eval "$fun"
+        done
+        track_case_status $FUNCNAME "llama_"
+    else 
+        echo -e "\033[31m ---- Invalid status $1 \033[0m"
+        return 1
+    fi
+}
+
+
+function llm_gpt_case_list_auto() {
+    fun_list=(
+        # The test name must have "llm_gpt_dygraph_auto_" as a prefix, 
+        # which will be used for tracking the execution status of the case.
+        llm_gpt_dygraph_auto_bs8_fp32_DP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
+        llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
+    )
+    if [ $1 -eq "prepare_case" ]; then
+        restore_func $fun_list  
+    elif [ $1 -eq "exec_case" ]; then
+        for fun in "${fun_list[@]}"; do
+            eval "$fun"
+        done
+        track_case_status $FUNCNAME "llm_gpt_dygraph_auto_"
+    else 
+        echo -e "\033[31m ---- Invalid status $1 \033[0m"
+        return 1
+    fi
 }
 
 function llm_qwen_case_list_auto() {
-    # The test name must have "llm_qwen_dygraph_auto_" as a prefix, 
-    # which will be used for tracking the execution status of the case.
-    llm_qwen_dygraph_auto_bs1_fp32_DP2
-    llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2
-    llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2
-    llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2
-
-    track_case_status $FUNCNAME "llm_qwen_dygraph_auto_"
+    fun_list=(
+        # The test name must have "llm_qwen_dygraph_auto_" as a prefix, 
+        # which will be used for tracking the execution status of the case.
+        llm_qwen_dygraph_auto_bs1_fp32_DP2
+        llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2
+        llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2
+        llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2
+    )
+    if [ $1 -eq "prepare_case" ]; then
+        restore_func $fun_list  
+    elif [ $1 -eq "exec_case" ]; then
+        for fun in "${fun_list[@]}"; do
+            eval "$fun"
+        done
+        track_case_status $FUNCNAME "llm_qwen_dygraph_auto_"
+    else 
+        echo -e "\033[31m ---- Invalid status $1 \033[0m"
+        return 1
+    fi
 }
 
 ############ case start ############
@@ -2306,48 +2353,6 @@ function before_hook_for_llama() {
     fi
 }
 
-function restore_func() {
-    fun_list=$1
-    cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; } 
-    if [ -e "functions.txt" ]; then
-        rm "functions.txt"
-        echo "Deleted existing functions.txt"
-    fi
-    for function in ${fun_list[@]};do
-        echo "$function" >> functions.txt
-    done
-}
-
-function restore_llama_case_list_auto_func() {
-    fun_list=(
-        llama_dygraph_auto_bs8_fp32_DP2
-        llama_dygraph_auto_bs8_fp32_DP2-MP2
-        llama_dygraph_auto_bs8_fp32_DP2-MP2-PP2
-        llama_dygraph_auto_bs8_fp16_DP2-MP2-PP2
-        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2-VPP3_split_bw
-        llama_dy2st_auto_bs4_bf16_DP1-MP1-PP4-SD2
-        llama_align_dygraph_dy2st_auto_bs2_bf16_DP2-MP1-PP1
-        llama_pir_auto_fuse_ffn_attention_qkv_MP2
-        llama_convert_hybrid_ckpt_to_auto_parallel_bs2_fp32_DP2-MP1-PP1
-        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP
-        llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP2-SP
-        llama_align_dygraph_dy2st_pir_auto_grad_merge_bs2_fp32_DP1-MP1-PP1
-        llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4
-        llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4
-    )
-    restore_func $fun_list
-}
-
-function restore_llm_gpt_case_list_auto_func() {
-    fun_list=(
-        llm_gpt_dygraph_auto_bs8_fp32_DP2
-        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
-        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
-        llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
-    )
-    restore_func $fun_list  
-}
-
 
 
 
@@ -2356,11 +2361,11 @@ if [[ $status = "prepare_case" ]];then
     export FLAGS_install_deps=$3
     export FLAGS_download_data=$4
     if [[ $2 = "llama_case_list_auto" ]];then
-        before_hook_for_llama
-        restore_llama_case_list_auto_func
+        before_hook_for_llama 
+        llama_case_list_auto prepare_case
     elif [[ $2 = "llm_gpt_case_list_auto" ]];then
         before_hook_for_gpt
-        restore_llm_gpt_case_list_auto_func
+        llm_gpt_case_list_auto prepare_case
     else
         echo -e "\033[31m ---- Invalid exec_case $2 \033[0m"
     fi
@@ -2382,5 +2387,5 @@ else
     else
         echo -e "\033[31m ---- Invalid exec_case $exec_case \033[0m"
     fi
-    $1
+    $1 exec_case
 fi

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -102,9 +102,9 @@ function llama_case_list_auto() {
         llama_align_dy2st_fthenb_and_vpp_auto_bs2_fp32_DP1-MP1-PP4
         llama_align_dygraph_dy2st_pir_auto_pp_bs2_bf16_DP1-MP1-PP4
     )
-    if [ $1 -eq "prepare_case" ]; then
+    if [ $1 = "prepare_case" ]; then
         restore_func $fun_list  
-    elif [ $1 -eq "exec_case" ]; then
+    elif [ $1 = "exec_case" ]; then
         for fun in "${fun_list[@]}"; do
             eval "$fun"
         done
@@ -125,9 +125,9 @@ function llm_gpt_case_list_auto() {
         llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
         llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
     )
-    if [ $1 -eq "prepare_case" ]; then
+    if [ $1 = "prepare_case" ]; then
         restore_func $fun_list  
-    elif [ $1 -eq "exec_case" ]; then
+    elif [ $1 = "exec_case" ]; then
         for fun in "${fun_list[@]}"; do
             eval "$fun"
         done
@@ -147,9 +147,9 @@ function llm_qwen_case_list_auto() {
         llm_qwen_dygraph_auto_bs1_fp32_DP2-MP2-PP2
         llm_qwen_dygraph_auto_bs1_bf16_DP2-MP2-PP2
     )
-    if [ $1 -eq "prepare_case" ]; then
+    if [ $1 = "prepare_case" ]; then
         restore_func $fun_list  
-    elif [ $1 -eq "exec_case" ]; then
+    elif [ $1 = "exec_case" ]; then
         for fun in "${fun_list[@]}"; do
             eval "$fun"
         done

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -131,7 +131,6 @@ function llm_gpt_case_list_dygraph() {
 ############ case start ############
 function gpt_preprocess_data() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python ppfleetx/data/data_tools/gpt/raw_trans_to_json.py  \
         --input_path ./dataset/wikitext_103_en \
@@ -153,7 +152,6 @@ function gpt_preprocess_data() {
 
 function gpt_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python tools/train.py \
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_345M_single_card.yaml \
@@ -167,7 +165,6 @@ function gpt_345M_single() {
 
 function gpt_1.3B_dp() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_1.3B_dp8.yaml \
@@ -181,7 +178,6 @@ function gpt_1.3B_dp() {
 
 function gpt_6.7B_stage2_dp2_sharding4() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -198,7 +194,6 @@ function gpt_6.7B_stage2_dp2_sharding4() {
 
 function gpt_6.7B_stage3_dp2_sharding4() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -215,7 +210,6 @@ function gpt_6.7B_stage3_dp2_sharding4() {
 
 function gpt_6.7B_stage2_sharding8() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" \
         tools/train.py -c ppfleetx/configs/nlp/gpt/pretrain_gpt_6.7B_sharding16.yaml \
@@ -232,7 +226,6 @@ function gpt_6.7B_stage2_sharding8() {
 
 function gpt_175B_DP1_MP4_PP2() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -249,7 +242,6 @@ function gpt_175B_DP1_MP4_PP2() {
 
 function gpt_175B_DP1_MP4_PP2_sp() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -265,7 +257,6 @@ function gpt_175B_DP1_MP4_PP2_sp() {
 
 function gpt_175B_DP1_MP8_PP1() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -282,7 +273,6 @@ function gpt_175B_DP1_MP8_PP1() {
 
 function gpt_175B_DP1_MP8_PP1_sp() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -297,8 +287,6 @@ function gpt_175B_DP1_MP8_PP1_sp() {
 }
 
 function gpt_175B_DP1_MP1_PP8() {
-    echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/pretrain_gpt_175B_mp8_pp16.yaml \
@@ -317,7 +305,6 @@ function gpt_175B_DP1_MP1_PP8() {
 
 function gpt_345M_mp8_qat() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0,1,2,3,4,5,6,7" tools/train.py\
         -c ppfleetx/configs/nlp/gpt/qat_gpt_345M_mp8.yaml \
@@ -331,7 +318,6 @@ function gpt_345M_mp8_qat() {
 
 function gpt_generation_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python tasks/gpt/generation.py \
         -c ppfleetx/configs/nlp/gpt/generation_gpt_345M_single_card.yaml \
@@ -343,7 +329,6 @@ function gpt_generation_345M_single() {
 
 function gpt_generation_345M_hybrid() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python -m paddle.distributed.launch --devices "0" tasks/gpt/generation.py \
         -c ppfleetx/configs/nlp/gpt/generation_gpt_345M_dp8.yaml \
@@ -355,7 +340,6 @@ function gpt_generation_345M_hybrid() {
 
 function gpt_export_345M_mp1() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -377,7 +361,6 @@ function gpt_export_345M_mp1() {
 
 function gpt_export_345M_mp2() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -400,7 +383,6 @@ function gpt_export_345M_mp2() {
 
 function gpt_export_qat_345M() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     log_dir=log_export
     rm -rf $log_dir
     rm -rf output
@@ -420,7 +402,6 @@ function gpt_export_qat_345M() {
 
 function gpt_inference_345M_single() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     rm -rf output
     python tools/export.py \
@@ -436,7 +417,6 @@ function gpt_inference_345M_single() {
 
 function gpt_inference_345M_dp8() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     rm -rf output
     python -m paddle.distributed.launch --devices "0" tools/export.py \
@@ -453,7 +433,6 @@ function gpt_inference_345M_dp8() {
 
 function gpt_345M_single_finetune() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python ./tools/train.py \
         -c ./ppfleetx/configs/nlp/gpt/finetune_gpt_345M_single_card_glue.yaml \
@@ -471,7 +450,6 @@ function gpt_345M_single_finetune() {
 
 function gpt_eval_WikiText() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python ./tools/eval.py \
         -c ./ppfleetx/configs/nlp/gpt/eval_gpt_345M_single_card.yaml \
@@ -487,7 +465,6 @@ function gpt_eval_WikiText() {
 
 function gpt_eval_LAMBADA() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${gpt_case_path}
     rm -rf log
     python ./tools/eval.py \
         -c ./ppfleetx/configs/nlp/gpt/eval_gpt_345M_single_card.yaml \
@@ -503,7 +480,6 @@ function gpt_eval_LAMBADA() {
 
 function llm_gpt_recompute_bs32_bf16_MP2-SD4-stage1() {
     echo "=========== $FUNCNAME run begin ==========="
-    cd ${llm_gpt_case_path}
     export FLAGS_cudnn_deterministic=1
     export FLAGS_embedding_deterministic=1
     export PYTHONPATH=$root_path/:$PYTHONPATH
@@ -756,6 +732,11 @@ if [[ $status = "prepare_case" ]];then
 elif [[ $status = "exec_case" ]];then
     export FLAGS_install_deps=$3
     export FLAGS_download_data=$4
+    if [[ $2 =~ "llm_gpt" ]];then
+        cd ${llm_gpt_case_path}
+    elif [[ $2 =~ "gpt" ]];then
+        cd ${gpt_case_path}
+    else
     $2
 else
     echo -e "\033[31m ---- Start executing $1 \033[0m"

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -736,7 +736,7 @@ elif [[ $status = "exec_case" ]];then
         cd ${llm_gpt_case_path}
     elif [[ $2 =~ "gpt" ]];then
         cd ${gpt_case_path}
-    else
+    fi
     $2
 else
     echo -e "\033[31m ---- Start executing $1 \033[0m"

--- a/scripts/distribute/ci_case_dy.sh
+++ b/scripts/distribute/ci_case_dy.sh
@@ -96,9 +96,9 @@ function gpt_case_list_dygraph() {
         gpt_eval_WikiText
         gpt_eval_LAMBADA
     )
-    if [ $1 -eq "prepare_case" ]; then
+    if [ $1 = "prepare_case" ]; then
         restore_func $fun_list  
-    elif [ $1 -eq "exec_case" ]; then
+    elif [ $1 = "exec_case" ]; then
         for fun in "${fun_list[@]}"; do
             eval "$fun"
         done
@@ -115,9 +115,9 @@ function llm_gpt_case_list_dygraph() {
         # be used for tracking the execution status of the case.
         llm_gpt_recompute_bs32_bf16_MP2-SD4-stage1
     )
-    if [ $1 -eq "prepare_case" ]; then
+    if [ $1 = "prepare_case" ]; then
         restore_func $fun_list  
-    elif [ $1 -eq "exec_case" ]; then
+    elif [ $1 = "exec_case" ]; then
         for fun in "${fun_list[@]}"; do
             eval "$fun"
         done

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -174,7 +174,6 @@ function execute_func_list(){
                 let galobal_success_count++
             elif [ $result -eq 2 ]; then
                 echo -e "\033[31m verification failed!"
-                execute_num=1
                 let verification_fail_count++
                 galobal_verification_fail_arr+=("$func_name")
             elif [ $result -eq 250 ]; then

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -20,6 +20,12 @@ mkdir -p /workspace/case_logs
 export log_path=/workspace/case_logs
 export case_list=()
 
+galobal_total_count=0
+galobal_success_count=0
+galobal_exit_250_arr=()
+galobal_runtime_fail_arr=()
+galobal_verification_fail_arr=()
+
 target_lists_for_gpt=(
     "slm/model_zoo/gpt-3"
     "llm/auto_parallel/gpt-3"
@@ -84,58 +90,58 @@ IS_A100=$(is_a100)
 
 ####################################
 get_diff_TO_case(){
-cd ${nlp_dir}
-if [ $IS_A100 -ne 0 ];then
-    for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-        arr_file_name=(${file_name//// })
-        dir1=${arr_file_name[0]}
-        dir2=${arr_file_name[1]}
-        dir3=${arr_file_name[2]}
-        dir4=${arr_file_name[3]}
-        file_item=$dir1/$dir2/$dir3/$dir4
-        echo "file_name:"${file_name}, "path:"${file_item}
-        if [ ! -f ${file_name} ];then # 针对pr删掉文件
-            continue
-        elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-            continue
-        else
-            for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-                if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-                    case_list[${#case_list[*]}]=gpt-3_auto
-                    case_list[${#case_list[*]}]=gpt-3_dygraph
-                fi
-            done
-            for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
-                if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
-                    case_list[${#case_list[*]}]=llama_auto
-                fi
-            done
-        fi
-    done
-else
-    case_list[${#case_list[*]}]=gpt-3_auto
-    case_list[${#case_list[*]}]=llama_auto
-    for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-        arr_file_name=(${file_name//// })
-        dir1=${arr_file_name[0]}
-        dir2=${arr_file_name[1]}
-        dir3=${arr_file_name[2]}
-        dir4=${arr_file_name[3]}
-        file_item=$dir1/$dir2/$dir3/$dir4
-        echo "file_name:"${file_name}, "path:"${file_item}
-        if [ ! -f ${file_name} ];then # 针对pr删掉文件
-            continue
-        elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-            continue
-        else
-            for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-                if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-                    case_list[${#case_list[*]}]=gpt-3_dygraph
-                fi
-            done
-        fi
-    done
-fi
+    cd ${nlp_dir}
+    if [ $IS_A100 -ne 0 ];then
+        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+            arr_file_name=(${file_name//// })
+            dir1=${arr_file_name[0]}
+            dir2=${arr_file_name[1]}
+            dir3=${arr_file_name[2]}
+            dir4=${arr_file_name[3]}
+            file_item=$dir1/$dir2/$dir3/$dir4
+            echo "file_name:"${file_name}, "path:"${file_item}
+            if [ ! -f ${file_name} ];then # 针对pr删掉文件
+                continue
+            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+                continue
+            else
+                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+                        case_list[${#case_list[*]}]=gpt-3_auto
+                        case_list[${#case_list[*]}]=gpt-3_dygraph
+                    fi
+                done
+                for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
+                    if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
+                        case_list[${#case_list[*]}]=llama_auto
+                    fi
+                done
+            fi
+        done
+    else
+        case_list[${#case_list[*]}]=gpt-3_auto
+        case_list[${#case_list[*]}]=llama_auto
+        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+            arr_file_name=(${file_name//// })
+            dir1=${arr_file_name[0]}
+            dir2=${arr_file_name[1]}
+            dir3=${arr_file_name[2]}
+            dir4=${arr_file_name[3]}
+            file_item=$dir1/$dir2/$dir3/$dir4
+            echo "file_name:"${file_name}, "path:"${file_item}
+            if [ ! -f ${file_name} ];then # 针对pr删掉文件
+                continue
+            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+                continue
+            else
+                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+                        case_list[${#case_list[*]}]=gpt-3_dygraph
+                    fi
+                done
+            fi
+        done
+    fi
 }
 ####################################
 function contain_case(){
@@ -157,31 +163,37 @@ function execute_func_list(){
     exit_250_count=0
     while IFS= read -r func_name; do
         let total_count++
-        excute_num=1
+        let galobal_total_count++
+        execute_num=1
         while true; do
             bash $1 exec_case $func_name $FLAGS_install_deps $FLAGS_download_data  
             result=$?
             if [ $result -eq 0 ]; then
                 echo -e "\033[32m test success!"
                 let success_count++
+                let galobal_success_count++
             elif [ $result -eq 2 ]; then
                 echo -e "\033[31m verification failed!"
+                execute_num=1
                 let verification_fail_count++
+                galobal_verification_fail_arr+=("$func_name")
             elif [ $result -eq 250 ]; then
-                if [ $excute_num -eq 1 ]; then
+                if [ $execute_num -eq 1 ]; then
                     echo -e "\033[31m fist time execute failed, try again!"
-                    let excute_num++
+                    let execute_num++
                     continue
                 else
                     echo -e "\033[31m second time execute failed, exit!"
                     let exit_250_count++
+                    galobal_exit_250_arr+=("$func_name")
                 fi
             else
                 echo "test failed!"
-                mv ${log_path}/$func_name ${log_path}/$func_name_FAIL.log
+                mv ${log_path}/$func_name ${log_path}/${func_name}_FAIL.log
                 echo -e "\033[31m ${log_path}/$func_name_FAIL \033"
-                tail -15 ${log_path}/$func_name_FAIL.log
-                let runtime_fail_count++  
+                tail -15 ${log_path}/${func_name}_FAIL.log
+                let runtime_fail_count++ 
+                galobal_runtime_fail_arr+=("$func_name") 
             fi
             break
         done
@@ -193,36 +205,7 @@ function execute_func_list(){
     echo -e "\033[31m $(printf '\t')  verification fail tests :  $verification_fail_count \033"
     echo -e "\033[31m $(printf '\t')  exit 250 tests(intermittent issue) :  $exit_250_count \033"
 }
-####################################
-function track_case_status() {  
-    local case_name="$1"  
-    local prefix="$2"  
-    local original_path  
-  
-    original_path=$(pwd)  
-    cd ${log_path} || { echo "Failed to enter log_path: $log_path"; return 1; }  
-  
-    total_count=$(ls -1 "$prefix"* 2>/dev/null | grep -Ev 'result\.log|functions\.txt' | wc -l)
-    run_fail_count=$(ls -1 "$prefix"*_FAIL* 2>/dev/null | wc -l)  
-    loss_fail_count=$(grep 'check failed! ' result.log | awk -v prefix="$prefix" '{if ($2 ~ "^" prefix) print $2}'| wc -l)
-    
-    echo -e "\033[31m ---- $case_name total tests :  $total_count \033"
-    if [ $run_fail_count -eq 0 ] && [ $loss_fail_count  -eq 0 ]; then
-        echo -e "\033[32m ---- all cases Success  \033"
-    else
-        if [[ $run_fail_count -ne 0 ]] ; then
-            echo -e "\033[31m ---- $case_name runtime failed test  :  $run_fail_count \033"
-            ls -1 "$prefix"*_FAIL* 2>/dev/null | awk -v OFS="\t" '{print "\t" $0 "(failed)"}'
-        fi
-        if [[ $loss_fail_count -ne 0 ]] ; then
-            echo -e "\033[31m ---- $case_name verification failed test  :  $loss_fail_count \033"
-            grep 'check failed! ' result.log | awk -v prefix="$prefix" 'BEGIN {OFS="\t"} {if ($2 ~ "^" prefix) print "\t" $2 "(failed)"}'
-        fi
-        return 2
-    fi
-    cd "$original_path" || { echo "Failed to return to original path: $original_path"; return 1; }  
-    return 0
-} 
+
 ####################################
 get_diff_TO_case # 获取待执行case列表
 case_list=($(awk -v RS=' ' '!a[$1]++' <<< ${case_list[*]}))  # 去重并将结果存储回原列表
@@ -270,8 +253,28 @@ if [[ ${#case_list[*]} -ne 0 ]];then
     fi
     echo -e "\033[31m ---- end run case  \033"
 
-    track_case_status  $FUNCNAME ""
-    EXCODE=$?
+    echo -e "\033[31m ---- total tests :  $galobal_total_count \033"
+    if [ ${#galobal_exit_250_arr[@]} -ne 0 ]; then
+        echo -e "\033[32m ---- exit 250 test  :  ${#galobal_exit_250_arr[@]} \033"
+        for case in "${galobal_exit_250_arr[@]}"; do
+            echo -e "\t$case(exit 250)"
+        done
+    fi
+
+    if [ ${#galobal_runtime_fail_arr[@]} -eq 0 ] && [ ${#galobal_verification_fail_arr[@]} -eq 0 ]; then
+        echo -e "\033[32m ---- all cases Success  \033"
+        EXCODE=0
+    else 
+        echo -e "\033[32m ---- runtime failed test  :  ${#galobal_runtime_fail_arr[@]} \033"
+        for case in "${galobal_runtime_fail_arr[@]}"; do
+            echo -e "\t$case(failed)"
+        done
+        echo -e "\033[32m ---- verification failed test  :  ${#galobal_verification_fail_arr[@]} \033"
+        for case in "${galobal_verification_fail_arr[@]}"; do
+            echo -e "\t$case(failed)"
+        done
+        EXCODE=1
+    fi
 else
     echo -e "\033[32m Changed Not CI case, Skips \033"
     EXCODE=0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
1. 之前需要在每个 test 开始时候 `export_env` 和 `cd run/path`，现在转移到每个 `ci_case_*.dy` 的入口处
2. 之前为了兼容 Paddle CI，每个 case 脚本中包含两个函数列表操作函数，例如：`llama_case_list_auto` 和 `restore_llama_case_list_auto_func`，现在将两个函数合在一起，通过传参数执行不同的逻辑， Paddle CI 通过 `exec_case` 参数执行旧逻辑，PaddleNLP CI 通过`prepare_case` 参数执行新逻辑
3. CI 统计 test 执行情况的`track_case_status` 函数存在运行失败 test 检测不到的 bug，有些 test 运行出错后并不会产生类似`func_name_FAIL.log`的日志文件，因此，在通过日志名字统计失败 test 的方法存在 bug。现在通过全局变量 在 `execute_func_list` 中记录每个 case 的执行结果，将每个失败测试名字通过数组记录，在 CI 结束的时候汇总输出