### PR TITLE
[LLM INFER] not use gemm_dequant default and fix bug

### DIFF
--- a/paddlenlp/experimental/transformers/qwen2_moe/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen2_moe/modeling.py
@@ -292,7 +292,10 @@ class Qwen2MoeInferenceModel(Qwen2MoePretrainedModel):
         self.embed_tokens.weight.set_value(embed_tokens_weight)
         self.norm.weight.set_value(norm_weight)
 
+        if self.use_weight_only:
+            logger.info("weight only is enabled")
         for idx in range(self.num_layers):
+            logger.info(f"set state for layer {idx}")
             unfused_state_dict = {}
             ln_scale = paddle.to_tensor(state_dict["qwen2_moe.layers.{}.input_layernorm.weight".format(idx)]).cast(
                 self.transformer_block.ln_scales[idx].dtype


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
not use gemm_dequant default and fix bug

bug error:
```shell
line 265, in get_block_shape_and_split_kv_block
    outs = _C_ops._run_custom_op("get_block_shape_and_split_kv_block", seq_lens_encoder,seq_lens_decoder,max_enc_len_this_time,seq_lens_this_time,cum_offsets,encoder_block_shape_q,decoder_block_shape_q,group_size,block_size,decoder_step_token_num)
TypeError: (InvalidType) argument (position 11) must be int, but got tuple (at ../paddle/fluid/pybind/eager_utils.cc:185)
```