### PR TITLE
[BUG] fix pp eval shape bug

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -3293,6 +3293,8 @@ class Trainer:
             actual_batch_size = inputs.shape[0]
         model.micro_batch_size = 1
         model.accumulate_steps = actual_batch_size
+        # train & eval share the same p2p_helper, so clear it before and after each step
+        model._p2p_helper.clear_meta_cache()
 
         with paddle.no_grad():
             if has_labels:
@@ -3303,6 +3305,8 @@ class Trainer:
             else:
                 raise ValueError("pipeline mode eval need label!")
         model.micro_batch_size, model.accumulate_steps = model_config_backup
+        # train & eval share the same p2p_helper, so clear it before and after each step
+        model._p2p_helper.clear_meta_cache()
 
         return (loss, None, labels)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
修复pp eval的时候训练batch size跟eval batch size不一致导致的通信时候缓存的cache shape不一致的错误。
比如：训练的micro bs=2，评估的micro bs=1，此时，当训练到需要评估的时候（eval_batch），此时会使用训练的bs=2的缓存的shape，从而导致评估的时候报错。
![image](https://github.com/user-attachments/assets/f44776ee-d68c-4e05-856f-d80bc3149510)
