### PR TITLE
Modify paddlenlp_ops && fix get_output  bugs

### DIFF
--- a/csrc/gpu/get_output.cc
+++ b/csrc/gpu/get_output.cc
@@ -54,7 +54,8 @@ void GetOutputFunc(MsgData<SIZE>& msg_rcv,  // NOLINT
     return;
   }
 
-  for (int64_t i = 0; i < SIZE; i++) {
+  int bsz = msg_rcv.mtext[1];
+  for (int64_t i = 0; i < bsz + 2; i++) {
     out_data[i] = (int64_t)msg_rcv.mtext[i];
   }
 

--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -23,14 +23,6 @@ import paddle.nn.functional as F
 from paddle import nn
 from paddle.distributed import fleet
 from paddle.nn.quant import weight_quantize
-from paddlenlp_ops import (
-    save_output,
-    speculate_get_output_padding_offset,
-    speculate_get_seq_lens_output,
-    speculate_set_value_by_flags_and_idx,
-    speculate_verify_and_update,
-    top_p_candidates,
-)
 
 from paddlenlp.experimental.model_utils import (
     ActScalesLoader,
@@ -2000,6 +1992,11 @@ class LlamaForCausalLMSpeculateInferenceModel(LlamaForCausalLMBlockInferenceMode
         In the senerio of speculate decoding, the length of output token after rebuild_padding is no longer bsz.
         So we need to calculate the output_padding_offset after rebuild_padding.
         """
+        from paddlenlp_ops import (
+            speculate_get_output_padding_offset,
+            speculate_get_seq_lens_output,
+        )
+
         seq_lens_output = speculate_get_seq_lens_output(seq_lens_this_time, seq_lens_encoder, seq_lens_decoder)
         out_token_num = paddle.sum(seq_lens_output)
         output_cum_offsets_tmp = paddle.cumsum(self.max_seq_len - seq_lens_output)
@@ -2081,6 +2078,12 @@ class LlamaForCausalLMSpeculateInferenceModel(LlamaForCausalLMBlockInferenceMode
             logits = paddle.cast(outputs, paddle.float32)
 
             # TODO(Wanglongzhi2001): get_token_penalty_multi_scores_v2 don't support seqlen > 1
+            from paddlenlp_ops import (
+                save_output,
+                speculate_set_value_by_flags_and_idx,
+                speculate_verify_and_update,
+                top_p_candidates,
+            )
 
             # sample
             probs = F.softmax(logits)

--- a/paddlenlp/experimental/transformers/proposers.py
+++ b/paddlenlp/experimental/transformers/proposers.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 import paddle
-from paddlenlp_ops import ngram_match
 
 
 class Proposer(ABC):
@@ -72,6 +71,8 @@ class InferenceWithReferenceProposer(Proposer):
         seq_lens_this_time = kargs["seq_lens_this_time"].cpu()
         seq_lens_encoder = model_inputs["seq_lens_encoder"].cpu()
         seq_lens_decoder = model_inputs["seq_lens_decoder"].cpu()
+        from paddlenlp_ops import ngram_match
+
         ngram_match(
             self.input_ids_cpu,
             self.input_ids_len.cpu(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
Bug fixes

### PR changes
Others

### Description
1. 新特性开发增加gpu自定义算子时，由于多硬件未适配新特性，会导致自定义算子编译失败。因此修改自定义算子全局导包，暂时下放。后续若多硬件适配相关特征，可以考虑增加环境变量或其他方式，对不同硬件自定义算子进行判断。
2. 非投机解码推理会出现推理结果hang的问题，对get_output算子进行修复。