### PR TITLE
[XPU] fp16/bf16 for multinomial op

### DIFF
--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1216,8 +1216,6 @@ class GenerationMixin(object):
                 probs = TopPProcess(probs, top_p, min_tokens_to_keep)
             if paddle.device.is_compiled_with_custom_device("gcu"):
                 probs = paddle.cast(probs, "float32")
-            if paddle.device.is_compiled_with_xpu():
-                probs = paddle.cast(probs, "float32")
 
             # multinomial already support fp16 and bf16 currently, fix issue: https://github.com/PaddlePaddle/Paddle/issues/51852
             next_tokens = paddle.multinomial(probs)


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Description

在较早的飞桨XPU版本中，`multinomial`算子不支持float16数据类型，所以在这个PR https://github.com/PaddlePaddle/PaddleNLP/pull/8787 中进行了一个特殊处理，进行了一次数据类型转换。

现在飞桨的develop分支下，XPU版本中，已经支持了float16和bfloat16数据类型，见这两个PR https://github.com/PaddlePaddle/Paddle/pull/69767 、https://github.com/PaddlePaddle/Paddle/pull/69898 ，因此在组网代码里面不再需要这个多出来的`cast`操作了。
