### PR TITLE
Fix boe_download on non-exist directory

### DIFF
--- a/paddlenlp/utils/download/bos_download.py
+++ b/paddlenlp/utils/download/bos_download.py
@@ -214,6 +214,9 @@ def bos_download(
             # Even if returning early like here, the lock will be released.
             return file_path
 
+        if not os.path.exists(file_path):
+               os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
         if resume_download:
             incomplete_path = file_path + ".incomplete"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

APIs

### Description
<!-- Describe what this PR does -->

This bug can be reproduced in the latest version of [PaddleMix](https://github.com/PaddlePaddle/PaddleMIX/tree/559ee9841f2ad879f3b1f8d861e91a2666d8e6e7). During the evaluation of stable diffusion in [PaddleMix](https://github.com/PaddlePaddle/PaddleMIX/tree/559ee9841f2ad879f3b1f8d861e91a2666d8e6e7/ppdiffusers/examples/stable_diffusion), the boe_download function fails to create the directory for pre-trained parameters, resulting in the following error:


```log
/mydir/.local/lib/python3.10/site-packages/_distutils_hack/__init__.py:32: UserWarning: Setuptools is replacing distutils. Support for replacing an already imported distutils is deprecated. In the future, this condition will fail. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
  warnings.warn(
W1204 15:56:44.221465 2242829 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 8.9, Driver API Version: 12.6, Runtime API Version: 12.3
W1204 15:56:44.222669 2242829 gpu_resources.cc:164] device: 0, cuDNN Version: 9.0.

Loading pipeline components...:   0%|          | 0/6 [00:00<?, ?it/s][skkkk] lock_path: /mydir/.cache/paddlenlp/ppdiffusers/.locks/CompVis/stable-diffusion-v1-4/feature_extractor/preprocessor_config.json.lock


(…)ature_extractor/preprocessor_config.json:   0%|          | 0.00/342 [00:00<?, ?B/s][A
(…)ature_extractor/preprocessor_config.json: 100%|██████████| 342/342 [00:00<00:00, 3.25MB/s]

Loading pipeline components...:   0%|          | 0/6 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/usr/lib/python3.10/shutil.py", line 816, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/mydir/.cache/paddlenlp/ppdiffusers/tmpg97lonv4' -> '/mydir/.cache/paddlenlp/ppdiffusers/CompVis/stable-diffusion-v1-4/feature_extractor/preprocessor_config.json'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/media/4T/mydir/repos/PaddleMIX/ppdiffusers/examples/stable_diffusion/eval.py", line 5, in <module>
    pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", safety_checker=None, unet=unet)
  File "/mydir/.local/lib/python3.10/site-packages/ppdiffusers/pipelines/pipeline_utils.py", line 1112, in from_pretrained
    loaded_sub_model = load_sub_model(
  File "/mydir/.local/lib/python3.10/site-packages/ppdiffusers/pipelines/pipeline_utils.py", line 416, in load_sub_model
    loaded_sub_model = load_method(cached_folder, **loading_kwargs)
  File "/mydir/.local/lib/python3.10/site-packages/paddlenlp/transformers/image_processing_utils.py", line 160, in from_pretrained
    image_processor_dict, kwargs = cls.get_image_processor_dict(pretrained_model_name_or_path, **kwargs)
  File "/mydir/.local/lib/python3.10/site-packages/paddlenlp/transformers/image_processing_utils.py", line 325, in get_image_processor_dict
    resolved_image_processor_file = resolve_file_path(
  File "/mydir/.local/lib/python3.10/site-packages/paddlenlp/utils/download/__init__.py", line 259, in resolve_file_path
    cached_file = bos_download(**download_kwargs)
  File "/mydir/.local/lib/python3.10/site-packages/paddlenlp/utils/download/bos_download.py", line 254, in bos_download
    _chmod_and_replace(temp_file.name, file_path)
  File "/mydir/.local/lib/python3.10/site-packages/paddlenlp/utils/download/common.py", line 235, in _chmod_and_replace
    shutil.move(src, dst)
  File "/usr/lib/python3.10/shutil.py", line 836, in move
    copy_function(src, real_dst)
  File "/usr/lib/python3.10/shutil.py", line 434, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.10/shutil.py", line 256, in copyfile
    with open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '/mydir/.cache/paddlenlp/ppdiffusers/CompVis/stable-diffusion-v1-4/feature_extractor/preprocessor_config.json'
```

The issue is caused by the function `boe_download` not handling the scenario where the `file_path` does not exist. The fix ensures that the directory exists on the file system before proceeding. The relevant code change is:

```python
# the code with issues:
213:      if os.path.exists(file_path) and not force_download:
214:            # Even if returning early like here, the lock will be released.
215:            return file_path


diff --git a/paddlenlp/utils/download/bos_download.py b/paddlenlp/utils/download/bos_download.py
index 1edb1b1ac826..cca0f56c41ca 100644
--- a/paddlenlp/utils/download/bos_download.py
+++ b/paddlenlp/utils/download/bos_download.py
@@ -214,6 +214,9 @@ def bos_download(
             # Even if returning early like here, the lock will be released.
             return file_path
 
+        if not os.path.exists(file_path):
+               os.makedirs(os.path.dirname(file_path), exist_ok=True)

         if resume_download:
             incomplete_path = file_path + ".incomplete"
 
```
