### PR TITLE
fix(export_model): fix export_model.py python path

### DIFF
--- a/llm/predict/export_model.py
+++ b/llm/predict/export_model.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass, field
 
 import paddle
 from paddle.distributed import fleet
-from predict.predictor import ModelArgument, PredictorArgument, create_predictor
 
+from llm.predict.predictor import ModelArgument, PredictorArgument, create_predictor
 from paddlenlp.trainer import PdArgumentParser
 from paddlenlp.trl import llm_utils
 


### PR DESCRIPTION
1.fix python path to paddlenlp project

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
fix python path to use it easier

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
adapt python path in export_model.py to paddlenlp projects default path, usr can use at any catalogue in paddlenlp projects after nlp setup or pythonpath setted
