### PR TITLE
fix import in speculate_decoding

### DIFF
--- a/paddlenlp/experimental/transformers/proposers.py
+++ b/paddlenlp/experimental/transformers/proposers.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 import paddle
-from paddlenlp_ops import ngram_match
 
 
 class Proposer(ABC):
@@ -72,6 +71,9 @@ class InferenceWithReferenceProposer(Proposer):
         seq_lens_this_time = kargs["seq_lens_this_time"].cpu()
         seq_lens_encoder = model_inputs["seq_lens_encoder"].cpu()
         seq_lens_decoder = model_inputs["seq_lens_decoder"].cpu()
+
+        from paddlenlp_ops import ngram_match
+
         ngram_match(
             self.input_ids_cpu,
             self.input_ids_len.cpu(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
海光等未支持投机解码特性的设备，不会编译 ngram_match 等投机解码的自定义算子，因此直接在外面 import 会让他们报错.