### PR TITLE
[AutoParallel] Fix recompute test running under `to_static=1`

### DIFF
--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -668,6 +668,10 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
 
     for to_static in "0" "1"; do
         for use_recompute in "1" "0"; do
+            if [ "$to_static" -eq "0" ] && [ "$use_recompute" -eq "1" ]; then
+                # The test for recompute only runs when `to_static = 1`.
+                continue
+            fi
             rm -rf $case_out_dir
             rm -rf $case_log_dir
             python -u -m paddle.distributed.launch \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Recompute test only need run under dy2st mode ( `to_static=1` )