### PR TITLE
[AutoParallel] Add test for PIR refined recompute

### DIFF
--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -642,6 +642,46 @@ Trainer 是一个简单，但功能完整的 Paddle 训练和评估模块，并�
 
                         (Type: `str`, optional, default: "")
 
+  --refined_ops_patterns
+                        静态图半自动并行精化重新计算参数，用于在GPU显存使用和计算速度之间寻求最佳平衡。
+                        此参数允许用户对重新计算过程进行细致控制，以优化资源利用。具体配置示例如下：
+                        `'[{"main_ops":["matmul"],"num":-1,"pre_ops":["softmax"],"suf_ops":[]},{"main_ops":["flash_attn"],"num":-1,"pre_ops":["matmul"],"suf_ops":[]}]'`
+
+                        在配置中，支持的参数包括：
+                            `main_ops`
+                            `num`
+                            `pre_ops`
+                            `suf_ops`
+
+                        `pattern = pre_ops + main_ops + suf_ops`会在 program 中进行匹配, `main_ops`决定了哪些操作会被重新计算,
+                        `pre_ops`和`suf_ops`只是起到辅助定位的作用。
+                        参数`num`决定了对应操作跳过重计算的次数。具体解释如下：
+                            `num` 为 `-1`：表示在所有阶段均不进行重新计算，从而最大化显存使用。
+                            `num` 为 `0`：表示在每个阶段都强制进行重新计算，以最小化显存使用。
+
+                        此外，您还可以将`num`设置为`[1, ..., num_layers]`范围内的任意值。若`num`超出`num_layers`，其行为将等同于设置为`-1`。
+
+                        (类型: `str`, 可选, 默认为: "")
+
+                        Static semi-automatic parallel refined recompute parameter for optimizing the balance between GPU memory usage and computational speed.
+                        This parameter allows fine-grained control over the recomputation process to optimize resource utilization. An example configuration is as follows:
+                        `'[{"main_ops":["matmul"],"num":-1,"pre_ops":["softmax"],"suf_ops":[]},{"main_ops":["flash_attn"],"num":-1,"pre_ops":["matmul"],"suf_ops":[]}]'`
+
+                        The supported parameters in the configuration include:
+                            `main_ops`
+                            `num`
+                            `pre_ops`
+                            `suf_ops`
+
+                        `Pattern = pre_ops + main_ops + suf_ops' will be matched in the program. `Main_ops' determines which operations will be recomputed, `Pre_ops and suf_ops only serve as auxiliary positioning tools
+                        The number following each parameter, `num`, determines the number of times to bypass recomputation for the specified operation. Specifically:
+                            `num of -1`: Indicates no recomputation across all stages, maximizing memory usage.
+                            `num of 0`: Enforces recomputation at every stage, minimizing memory usage.
+
+                        Additionally, you can set num to any value within the range `[1, ..., num_layers]`. If `num` exceeds `num_layers`, it will behave as if set to `-1`.
+
+                        (Type: `str`, optional, default: "")
+
   --minimum_eval_times
                         最少评估次数，如果当前设置的eval_steps，评估次数少于minimum_eval_times，
                         此选项会覆盖eval_steps参数。

--- a/llm/auto_parallel/gpt-3/run_pretrain_auto.py
+++ b/llm/auto_parallel/gpt-3/run_pretrain_auto.py
@@ -83,9 +83,7 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: Optional[List[str]] = field(
-        default=None, metadata={"help": "The pattern of refined recompute."}
-    )
+    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/llm/auto_parallel/gpt-3/run_pretrain_auto.py
+++ b/llm/auto_parallel/gpt-3/run_pretrain_auto.py
@@ -83,7 +83,6 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/llm/auto_parallel/llama/run_pretrain_auto.py
+++ b/llm/auto_parallel/llama/run_pretrain_auto.py
@@ -92,9 +92,7 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: Optional[List[str]] = field(
-        default=None, metadata={"help": "The pattern of refined recompute."}
-    )
+    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/llm/auto_parallel/llama/run_pretrain_auto.py
+++ b/llm/auto_parallel/llama/run_pretrain_auto.py
@@ -92,7 +92,6 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/llm/auto_parallel/qwen/run_pretrain_3D_auto.py
+++ b/llm/auto_parallel/qwen/run_pretrain_3D_auto.py
@@ -90,7 +90,6 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/llm/auto_parallel/qwen/run_pretrain_3D_auto.py
+++ b/llm/auto_parallel/qwen/run_pretrain_3D_auto.py
@@ -90,9 +90,7 @@ class PreTrainingArguments(AutoTrainingArguments):
         default="1F1B", metadata={"help": "The pipeline schedule mode, support FThenB, 1F1B, VPP and Eager-1F1B."}
     )
     sr: Optional[int] = field(default=0, metadata={"help": "The count of chunks without recompute."})
-    refined_ops_patterns: Optional[List[str]] = field(
-        default=None, metadata={"help": "The pattern of refined recompute."}
-    )
+    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
     virtual_pipeline_seg_method: str = field(
         default="LlamaDecoderLayerAuto", metadata={"help": "The seg method of spliting pp layer for virtual pipeline."}
     )

--- a/paddlenlp/trainer/auto_training_args.py
+++ b/paddlenlp/trainer/auto_training_args.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 from dataclasses import dataclass, field
 
 from .trainer_utils import split_parallel_config
@@ -48,6 +48,8 @@ class AutoTrainingArguments(TrainingArguments):
         },
     )
 
+    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
+
     def __post_init__(self):
         super().__post_init__()
         assert self.enable_auto_parallel
@@ -73,3 +75,14 @@ class AutoTrainingArguments(TrainingArguments):
         mp_configs = split_parallel_config(self.tensor_parallel_config)
         if "replace_with_parallel_cross_entropy" in mp_configs:
             self.strategy.mp_optimization.replace_with_parallel_cross_entropy = True
+
+        if self.recompute:
+            recompute = self.strategy.recompute
+            recompute.enable = True
+            recompute.refined_ops_patterns = []
+            if type(self.refined_ops_patterns) == str:
+                recompute.refined_ops_patterns = json.loads(self.refined_ops_patterns)
+            else:
+                recompute.refined_ops_patterns = (
+                    self.refined_ops_patterns if self.refined_ops_patterns is not None else []
+                )

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -763,6 +763,7 @@ class TrainingArguments:
             "If a parameter is omitted, it defaults to `xxx:0`."
         },
     )
+    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
 
     scale_loss: float = field(default=2**15, metadata={"help": "The value of initial scale_loss for fp16."})
 
@@ -1680,9 +1681,12 @@ class TrainingArguments:
                 recompute.enable = True
                 recompute.sr = self.sr if self.sr is not None else 0
                 recompute.refined_ops_patterns = []
-                if self.refined_ops_patterns is not None:
-                    for pattern in self.refined_ops_patterns:
-                        recompute.refined_ops_patterns.append(eval(pattern))
+                if type(self.refined_ops_patterns) == str:
+                    recompute.refined_ops_patterns = json.loads(self.refined_ops_patterns)
+                else:
+                    recompute.refined_ops_patterns = (
+                        self.refined_ops_patterns if self.refined_ops_patterns is not None else []
+                    )
 
             self.strategy = strategy
             if self.hybrid_parallel_topo_order == "pp_first":
@@ -2209,7 +2213,7 @@ class TrainingArguments:
         """
         Serializes this instance to a JSON string.
         """
-        return json.dumps(self.to_dict(), indent=2)
+        return json.dumps(str(self.to_dict()), indent=2)
 
     def to_sanitized_dict(self) -> Dict[str, Any]:
         """

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -763,7 +763,6 @@ class TrainingArguments:
             "If a parameter is omitted, it defaults to `xxx:0`."
         },
     )
-    refined_ops_patterns: str = field(default=None, metadata={"help": "The pattern of refined recompute."})
 
     scale_loss: float = field(default=2**15, metadata={"help": "The value of initial scale_loss for fp16."})
 
@@ -1675,18 +1674,6 @@ class TrainingArguments:
                 amp.init_loss_scaling = self.scale_loss
                 amp.custom_black_list = self.amp_custom_black_list if self.amp_custom_black_list is not None else []
                 amp.custom_white_list = self.amp_custom_white_list if self.amp_custom_white_list is not None else []
-
-            if self.recompute:
-                recompute = strategy.recompute
-                recompute.enable = True
-                recompute.sr = self.sr if self.sr is not None else 0
-                recompute.refined_ops_patterns = []
-                if type(self.refined_ops_patterns) == str:
-                    recompute.refined_ops_patterns = json.loads(self.refined_ops_patterns)
-                else:
-                    recompute.refined_ops_patterns = (
-                        self.refined_ops_patterns if self.refined_ops_patterns is not None else []
-                    )
 
             self.strategy = strategy
             if self.hybrid_parallel_topo_order == "pp_first":

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -83,9 +83,9 @@ function restore_func() {
     mapfile -t blacklist < "$blacklist_file"
     for function in ${fun_list[@]};do
         if [[ " ${blacklist[@]} " == *" ${function} "* ]]; then
-        echo "\033 ---- Function '$function' is blacklisted and will be skipped. \033"
+            echo "\033 ---- Function '$function' is blacklisted and will be skipped. \033"
         else
-        echo "$function" >> functions.txt
+            echo "$function" >> functions.txt
         fi
     done
 }

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -83,9 +83,9 @@ function restore_func() {
     mapfile -t blacklist < "$blacklist_file"
     for function in ${fun_list[@]};do
         if [[ " ${blacklist[@]} " == *" ${function} "* ]]; then
-            echo "\033 ---- Function '$function' is blacklisted and will be skipped. \033"
+        echo "\033 ---- Function '$function' is blacklisted and will be skipped. \033"
         else
-            echo "$function" >> functions.txt
+        echo "$function" >> functions.txt
         fi
     done
 }
@@ -755,82 +755,90 @@ function llama_align_dygraph_dy2st_pir_auto_bs2_bf16_DP2-MP2-PP1-SP() {
                 # The test for recompute only runs when `to_static = 1`.
                 continue
             fi
-            rm -rf $case_out_dir
-            rm -rf $case_log_dir
-            python -u -m paddle.distributed.launch \
-                --gpus "0,1,2,3" \
-                --log_dir $case_log_dir \
-                run_pretrain_auto.py \
-                --model_type "llama" \
-                --model_name_or_path "facebook/llama-7b" \
-                --tokenizer_name_or_path "facebook/llama-7b" \
-                --input_dir "./data" \
-                --output_dir $case_out_dir \
-                --split 949,50,1 \
-                --weight_decay 0.01 \
-                --warmup_ratio 0.01 \
-                --max_grad_norm 0.0 \
-                --learning_rate 3e-05 \
-                --min_learning_rate 3e-06 \
-                --max_steps 10 \
-                --logging_steps 10 \
-                --eval_steps 1000 \
-                --save_steps 50000 \
-                --continue_training 0 \
-                --do_train true \
-                --do_eval false \
-                --do_predict false \
-                --disable_tqdm true \
-                --skip_profile_timer true \
-                --save_total_limit 2 \
-                --device gpu \
-                --disable_tqdm true \
-                --dataloader_num_workers 1 \
-                --enable_auto_parallel 1 \
-                --per_device_train_batch_size 1 \
-                --gradient_accumulation_steps 1 \
-                --per_device_eval_batch_size 2 \
-                --recompute ${use_recompute} \
-                --bf16 1\
-                --fp16_opt_level "O2"  \
-                --amp_custom_black_list "reduce_sum" "c_softmax_with_cross_entropy" \
-                --amp_custom_white_list "lookup_table" "lookup_table_v2" \
-                --amp_master_grad 1 \
-                --fuse_attention_ffn false \
-                --fuse_attention_qkv false \
-                --fuse_sequence_parallel_allreduce false \
-                --use_flash_attention 0 \
-                --use_fused_rope false \
-                --use_fused_rms_norm 0 \
-                --max_seq_length 4096 \
-                --sep_parallel_degree 1 \
-                --sequence_parallel true \
-                --pipeline_parallel_degree 1 \
-                --sharding_parallel_degree 1 \
-                --tensor_parallel_degree 2 \
-                --virtual_pp_degree 1 \
-                --sharding "" \
-                --to_static ${to_static} \
-                --num_hidden_layers 4 \
-                >>${log_path}/$FUNCNAME 2>&1
-            loss=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'loss: ' '{print $2}' | awk -F ',' '{print $1}'`
-            loss_md5=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'loss_md5: ' '{print $2}' | awk -F ',' '{print $1}'`
-            ips=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'interval_tokens_per_second_per_device: ' '{print $2}' | awk -F ',' '{print $1}'`
-            mem=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'max_memory_reserved: ' '{print $2}' | awk -F ',' '{print $1}'`
-            echo "result: to_static=$to_static loss=$loss ips=$ips mem=$mem"
-            loss_base=9.16783295
-            loss_md5_base=8ea72495fba4e1b9ba004b4431e27218
-            if [ $IS_A100 -ne 0 ] && [ $to_static -eq 0 ];then
-                loss_base=9.37966919
-            elif [ $IS_A100 -ne 0 ] && [ $to_static -eq 1 ];then
-                loss_base=9.38012543
+            refined_rcs=(' ')
+            if [ "$to_static" -eq "1" ] && [ "$use_recompute" -eq "1" ]; then
+                # Add test for refined recompute in dy2st mode.
+                refined_rcs+=('--refined_ops_patterns [{"main_ops":["matmul"],"num":-1,"pre_ops":["softmax"],"suf_ops":[]}]')
             fi
-            ips=-1
-            mem=-1
-            ips_base=-1
-            mem_base=-1
-            check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
-            # check_md5_result $FUNCNAME ${loss_md5_base} ${loss_md5}
+                for refined_rc in "${refined_rcs[@]}"; do
+                rm -rf $case_out_dir
+                rm -rf $case_log_dir
+                python -u -m paddle.distributed.launch \
+                    --gpus "0,1,2,3" \
+                    --log_dir $case_log_dir \
+                    run_pretrain_auto.py \
+                    --model_type "llama" \
+                    --model_name_or_path "facebook/llama-7b" \
+                    --tokenizer_name_or_path "facebook/llama-7b" \
+                    --input_dir "./data" \
+                    --output_dir $case_out_dir \
+                    --split 949,50,1 \
+                    --weight_decay 0.01 \
+                    --warmup_ratio 0.01 \
+                    --max_grad_norm 0.0 \
+                    --learning_rate 3e-05 \
+                    --min_learning_rate 3e-06 \
+                    --max_steps 10 \
+                    --logging_steps 10 \
+                    --eval_steps 1000 \
+                    --save_steps 50000 \
+                    --continue_training 0 \
+                    --do_train true \
+                    --do_eval false \
+                    --do_predict false \
+                    --disable_tqdm true \
+                    --skip_profile_timer true \
+                    --save_total_limit 2 \
+                    --device gpu \
+                    --disable_tqdm true \
+                    --dataloader_num_workers 1 \
+                    --enable_auto_parallel 1 \
+                    --per_device_train_batch_size 1 \
+                    --gradient_accumulation_steps 1 \
+                    --per_device_eval_batch_size 2 \
+                    --recompute ${use_recompute} \
+                    ${refined_rc} \
+                    --bf16 1\
+                    --fp16_opt_level "O2"  \
+                    --amp_custom_black_list "reduce_sum" "c_softmax_with_cross_entropy" \
+                    --amp_custom_white_list "lookup_table" "lookup_table_v2" \
+                    --amp_master_grad 1 \
+                    --fuse_attention_ffn false \
+                    --fuse_attention_qkv false \
+                    --fuse_sequence_parallel_allreduce false \
+                    --use_flash_attention 0 \
+                    --use_fused_rope false \
+                    --use_fused_rms_norm 0 \
+                    --max_seq_length 4096 \
+                    --sep_parallel_degree 1 \
+                    --sequence_parallel true \
+                    --pipeline_parallel_degree 1 \
+                    --sharding_parallel_degree 1 \
+                    --tensor_parallel_degree 2 \
+                    --virtual_pp_degree 1 \
+                    --sharding "" \
+                    --to_static ${to_static} \
+                    --num_hidden_layers 4 \
+                    >>${log_path}/$FUNCNAME 2>&1
+                loss=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'loss: ' '{print $2}' | awk -F ',' '{print $1}'`
+                loss_md5=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'loss_md5: ' '{print $2}' | awk -F ',' '{print $1}'`
+                ips=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'interval_tokens_per_second_per_device: ' '{print $2}' | awk -F ',' '{print $1}'`
+                mem=`cat $case_log_dir/workerlog.0 | grep 'global_step: 10' | awk -F 'max_memory_reserved: ' '{print $2}' | awk -F ',' '{print $1}'`
+                echo "result: to_static=$to_static use_recompute=$use_recompute refined_rc=$refined_rc loss=$loss ips=$ips mem=$mem"
+                loss_base=9.16783295
+                loss_md5_base=8ea72495fba4e1b9ba004b4431e27218
+                if [ $IS_A100 -ne 0 ] && [ $to_static -eq 0 ];then
+                    loss_base=9.37966919
+                elif [ $IS_A100 -ne 0 ] && [ $to_static -eq 1 ];then
+                    loss_base=9.38012543
+                fi
+                ips=-1
+                mem=-1
+                ips_base=-1
+                mem_base=-1
+                check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
+                # check_md5_result $FUNCNAME ${loss_md5_base} ${loss_md5}
+            done
         done
     done
     echo "=========== $FUNCNAME run  end ==========="


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Judge `refined_ops_patterns` training args.
Add test for PIR refined recompute. 



在 `yaml` 文件中的调用举例：   
```c++
 enable_auto_parallel: 1
 to_static: 1
 recompute: 1
 refined_ops_patterns:
        - {main_ops: [flash_attn], num: -1, pre_ops: [], suf_ops: []}
        - {main_ops: [matmul], num: 2, pre_ops: [], suf_ops: [add]}
``` 

在`python`命令行参数中的调用举例
```c++
python -u -m paddle.distributed.launch \
                    --gpus "0,1,2,3" \
                    --log_dir $case_log_dir \
                    run_pretrain_auto.py \
                    --to_static \
                    --enable_auto_parallel 1 \ 
                    --recompute 1 \
                    --refined_ops_patterns '[{"main_ops":["matmul"],"num":-1,"pre_ops":["softmax"],"suf_ops":[]}]' \
                   ...
``` 
