### PR TITLE
fix auto tokenizer

### DIFF
--- a/paddlenlp/transformers/auto/factory.py
+++ b/paddlenlp/transformers/auto/factory.py
@@ -79,7 +79,7 @@ class _LazyAutoMapping(OrderedDict):
     def _load_attr_from_module(self, model_type, attr):
         module_name = model_type_to_module_name(model_type)
         if module_name not in self._modules:
-            if "Tokenizer" in model_type:
+            if any(["Tokenizer" in name for name in [model_type, attr]]):
                 try:
                     self._modules[module_name] = importlib.import_module(
                         f".{module_name}.tokenizer", "paddlenlp.transformers"
@@ -87,7 +87,7 @@ class _LazyAutoMapping(OrderedDict):
                 except ImportError:
                     pass
             if module_name not in self._modules:
-                if "Config" in model_type:
+                if any(["Tokenizer" in name for name in [model_type, attr]]):
                     try:
                         self._modules[module_name] = importlib.import_module(
                             f".{module_name}.configuration", "paddlenlp.transformers"

--- a/paddlenlp/transformers/auto/factory.py
+++ b/paddlenlp/transformers/auto/factory.py
@@ -87,7 +87,7 @@ class _LazyAutoMapping(OrderedDict):
                 except ImportError:
                     pass
             if module_name not in self._modules:
-                if any(["Tokenizer" in name for name in [model_type, attr]]):
+                if any(["Config" in name for name in [model_type, attr]]):
                     try:
                         self._modules[module_name] = importlib.import_module(
                             f".{module_name}.configuration", "paddlenlp.transformers"

--- a/paddlenlp/transformers/auto/tokenizer.py
+++ b/paddlenlp/transformers/auto/tokenizer.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 import importlib
 import io
-import json
 import os
+import json
+import inspect
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
@@ -460,7 +461,7 @@ class AutoTokenizer:
                 return tokenizer_class_fast.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
             else:
                 if tokenizer_class_py is not None:
-                    if isinstance(tokenizer_class_py, str):
+                    if inspect.isclass(tokenizer_class_py):
                         return tokenizer_class_py.from_pretrained(pretrained_model_name_or_path, *model_args, **kwargs)
                     else:
                         # Use the first tokenizer class in the list


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

---

AutoTokenizer自动初始化在找相关`class`时候使用错误的`module`位置

----

original:
```python
>>> from paddlenlp.transformers import AutoTokenizer
/usr/local/lib/python3.10/dist-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils. Support for replacing an already imported distutils is deprecated. In the future, this condition will fail. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
  warnings.warn(
>>> tokenizer = AutoTokenizer.from_pretrained('DeepFloyd/t5-v1_1-xxl')
[2025-01-02 16:33:31,091] [    INFO] - Loading configuration file /root/.paddlenlp/models/DeepFloyd/t5-v1_1-xxl/config.json
Traceback (most recent call last):
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/factory.py", line 35, in getattribute_from_module
    return getattribute_from_module(paddlenlp_module, attr)
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/factory.py", line 39, in getattribute_from_module
    raise ValueError(f"Could not find {attr} in {paddlenlp_module}!")
ValueError: Could not find T5Tokenizer in <module 'paddlenlp' from '/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/__init__.py'>!

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/tokenizer.py", line 454, in from_pretrained
    tokenizer_class_py = TOKENIZER_MAPPING[type(config)]
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/factory.py", line 69, in __getitem__
    return self._load_attr_from_module(model_type, model_name)
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/factory.py", line 100, in _load_attr_from_module
    return getattribute_from_module(self._modules[module_name], attr)
  File "/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/auto/factory.py", line 37, in getattribute_from_module
    raise ValueError(f"Could not find {attr} neither in {module} nor in {paddlenlp_module}!")
ValueError: Could not find T5Tokenizer neither in <module 'paddlenlp.transformers.t5' from '/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/transformers/t5/__init__.py'> nor in <module 'paddlenlp' from '/root/paddlejob/workspace/env_run/lvwenyu01/PaddleNLP/paddlenlp/__init__.py'>!
```

fixed:
```python
>>> from paddlenlp.transformers import AutoTokenizer
/usr/local/lib/python3.10/dist-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils. Support for replacing an already imported distutils is deprecated. In the future, this condition will fail. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
  warnings.warn(
>>> tokenizer = AutoTokenizer.from_pretrained('DeepFloyd/t5-v1_1-xxl')
[2025-01-02 16:29:06,221] [    INFO] - Loading configuration file /root/.paddlenlp/models/DeepFloyd/t5-v1_1-xxl/config.json
>>> print(type(tokenizer))
<class 'paddlenlp.transformers.t5.tokenizer.T5Tokenizer'>
```