### PR TITLE
[AutoParallel]:fix ernine auto_trainer error

### DIFF
--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -105,7 +105,15 @@ class AutoTrainer(Trainer):
         model = kwargs["model"]
         for param in model.parameters():
             if not param._is_initialized():
-                param.initialize()
+                try:
+                    param.initialize()
+                except Exception as e:
+                    # NOTE(zhangwl):maybe param is not initialized and param init_func is set in later.user need set_init_func before auto_trainer
+                    logger.warning(
+                        f"AutoTrainer requires all parameters to be initialized when auto_trainer init, but failed to initialize parameter {param.name} {param}.\n"
+                        + "Please check param init func.\n"
+                        + f"The original exception message is:\n{str(e)}"
+                    )
         kwargs["model"] = model
 
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
目前中层api和基础api统一用lazy gurd，在auto_trainer创建时初始化param以保证中层api和基础api的初始化权重一致。
可能存在场景：param在auto_trainer创建时还未初始化，且在auto_trainer创建后分配init_func，导致Ernie_ci error。
本pr用warning代替assert，减少代码error的场景。