### PR TITLE
[FlashCheckpoint] support EMA

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -705,6 +705,7 @@ class Trainer:
                 worker_num=self.args.flash_workers_num,
                 pipeline_hooks_capacity=pipeline_hooks_capacity,
                 capacity_usage=self.args.flash_pipeline_hooks_capacity_usage,
+                use_expert_parallel=self.args.use_expert_parallel,
                 ema_coef=self.args.flash_save_ema_coef,
             )
             for i in range(unwrapped_model.forward_pipeline_parallel_hook_capacity):
@@ -721,6 +722,7 @@ class Trainer:
                 worker_num=self.args.flash_workers_num,
                 pipeline_hooks_capacity=pipeline_hooks_capacity,
                 capacity_usage=self.args.flash_pipeline_hooks_capacity_usage,
+                use_expert_parallel=self.args.use_expert_parallel,
                 ema_coef=self.args.flash_save_ema_coef,
             )
         _callback = FlashCheckpointCallback(

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -876,6 +876,10 @@ class TrainingArguments:
             "help": "Set pipeline hook capacity usage ratio. Lower value brings faster save speed but may effect calculation speed."
         },
     )
+    flash_save_ema_coef: Optional[float] = field(
+        default=0,
+        metadata={"help": "The coefficient of EMA parameters in flash save mode. if set to 0, skip EMA process"},
+    )
     save_tokenizer: Optional[bool] = field(
         default=True,
         metadata={"help": "Save tokenizer to output_dir."},

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -880,6 +880,10 @@ class TrainingArguments:
         default=0,
         metadata={"help": "The coefficient of EMA parameters in flash save mode. if set to 0, skip EMA process"},
     )
+    flash_ema_interval: Optional[int] = field(
+        default=1,
+        metadata={"help": "Interval between updating EMA parameters."},
+    )
     save_tokenizer: Optional[bool] = field(
         default=True,
         metadata={"help": "Save tokenizer to output_dir."},

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -877,7 +877,7 @@ class TrainingArguments:
         },
     )
     flash_save_ema_coef: Optional[float] = field(
-        default=0,
+        default=None,
         metadata={"help": "The coefficient of EMA parameters in flash save mode. if set to 0, skip EMA process"},
     )
     flash_ema_interval: Optional[int] = field(

--- a/paddlenlp/trainer/utils/flash_checkpoint.py
+++ b/paddlenlp/trainer/utils/flash_checkpoint.py
@@ -33,6 +33,7 @@ from paddle.incubate.tensor.manipulation import (
 )
 from paddle.optimizer.fusion_utils import FusionStorageHelper
 
+from paddlenlp.trainer.trainer_callback import TrainerCallback
 from paddlenlp.transformers.utils import device_guard
 from paddlenlp.utils.env import (
     CONFIG_NAME,
@@ -333,6 +334,14 @@ class ParamFusionStorageHelper:
         tensor.get_tensor()._set_dims(shape)
         tensor.name = name
         return tensor
+
+
+class FlashCheckpointCallback(TrainerCallback):
+    def __init__(self, flash_checkpoint_manager):
+        self.manager = flash_checkpoint_manager
+
+    def on_substep_end(self, args, state, control, **kwargs):
+        self.manager.flash_checkpoint_pipeline_hook(0)
 
 
 class FlashCheckpointManager:

--- a/paddlenlp/trainer/utils/flash_checkpoint.py
+++ b/paddlenlp/trainer/utils/flash_checkpoint.py
@@ -26,6 +26,7 @@ import paddle
 import paddle.autograd as imperative_base
 import paddle.distributed as dist
 from paddle.base import core
+from paddle.distributed.fleet import fleet
 from paddle.incubate.tensor.manipulation import (
     async_offload_with_offset,
     create_async_load,
@@ -374,7 +375,7 @@ class FlashCheckpointCallback(TrainerCallback):
             args.save_steps % args.flash_ema_interval == 0
         ), f"save_steps:{args.save_steps} must be divisible by flash_ema_interval:{args.flash_ema_interval}"
         self.flash_ema_interval = args.flash_ema_interval
-        if args.flash_save_ema_coef:
+        if args.flash_save_ema_coef is not None:
             assert args.flash_workers_num == 1, "[FC EMA] not support #worker > 1"
 
     def on_substep_end(self, args, state, control, **kwargs):
@@ -392,7 +393,7 @@ class FlashCheckpointCallback(TrainerCallback):
             f"check coef: {args.flash_save_ema_coef} {control.should_save}, {state.global_step}, {self.flash_ema_interval}"
         )
         if not control.should_save:
-            if args.flash_save_ema_coef and state.global_step % self.flash_ema_interval == 0:
+            if args.flash_save_ema_coef is not None and state.global_step % self.flash_ema_interval == 0:
                 self.maybe_update_flash_checkpoint_worker(args, model, optimizer)
                 self.manager.get_idle_worker_for_saving()  # prepare for dumping
         else:
@@ -467,7 +468,7 @@ class FlashCheckpointCallback(TrainerCallback):
 
 
 class FlashCheckpointManager:
-    def __init__(self, worker_num, pipeline_hooks_capacity, capacity_usage, ema_coef=None):
+    def __init__(self, worker_num, pipeline_hooks_capacity, capacity_usage, use_expert_parallel, ema_coef=None):
         assert worker_num > 0, "worker_num must be greater than 0"
         assert capacity_usage <= 1.0, "capacity_usage must be less than or equal to 1.0"
         self.cache_version = 0
@@ -484,6 +485,7 @@ class FlashCheckpointManager:
         )
         self.current_pipeline_hook_step = 0
         ctx = multiprocessing.get_context("spawn")
+        assert hasattr(fleet, "_hcg"), "FlashCheckpoint Only support `use_hybrid_parallel`"
         for i in range(worker_num):
             worker_task_queue = ctx.Queue()
             worker_status = ctx.Value("i", FCWorkerStatus.IDLE.value)
@@ -496,6 +498,11 @@ class FlashCheckpointManager:
                 worker_task_queue,
                 worker_status,
                 worker_version,
+                use_expert_parallel,
+                fleet.get_hybrid_communicate_group().get_data_parallel_rank(),
+                fleet.get_hybrid_communicate_group().get_model_parallel_rank(),
+                fleet.get_hybrid_communicate_group()._get_pipe_parallel_id(),
+                fleet.get_hybrid_communicate_group().get_sharding_parallel_rank(),
                 ema_coef,
             )
             p = ctx.Process(target=worker_loop, args=(worker,))
@@ -613,7 +620,22 @@ def worker_loop(worker):
 
 
 class FlashCheckpointWorker:
-    def __init__(self, worker_id, device_id, global_rank, offload_chunks, task_queue, status, version, ema_coef=None):
+    def __init__(
+        self,
+        worker_id,
+        device_id,
+        global_rank,
+        offload_chunks,
+        task_queue,
+        status,
+        version,
+        use_expert_parallel,
+        dp_rank,
+        mp_rank,
+        pp_rank,
+        sd_rank,
+        ema_coef=None,
+    ):
         super().__init__()
         self.worker_id = worker_id
         self.device_id = device_id
@@ -623,6 +645,11 @@ class FlashCheckpointWorker:
         self.status = status
         self.version = version
         self.ema_coef = ema_coef
+        self.use_expert_parallel = use_expert_parallel
+        self.dp_rank = dp_rank
+        self.mp_rank = mp_rank
+        self.pp_rank = pp_rank
+        self.sd_rank = sd_rank
 
         # for dynamic objects saving
         self.optimizer_fusion_storage_helper = None
@@ -706,7 +733,7 @@ class FlashCheckpointWorker:
         if self.offloaded_numels == self.all_numel:
             self.optimizer_fusion_storage_helper.wait_all()
             self.param_fusion_storage_helper.wait_all()
-            if self.ema_coef:
+            if self.ema_coef is not None:
                 self.flash_ema_processor.ema_accumulate()
             self.status.value = FCWorkerStatus.DUMPING.value
 
@@ -744,6 +771,35 @@ class FlashCheckpointWorker:
                 need_report_error = True
         return need_report_error
 
+    def _filter_moe_no_sync_optimizer_params(self, model_meta, optimzier_state_dict):
+        """
+        filter optimizer params which should not sync, copy from paddlenlp.Trainer
+        """
+        filter_optimzier_state_dict = OrderedDict()
+        assert "master_weights" in optimzier_state_dict, optimzier_state_dict.keys()
+        param_names_in_master_weights = list(optimzier_state_dict["master_weights"].keys())
+        filter_optimzier_state_dict["master_weights"] = OrderedDict()
+        suffix = f"tp{self.mp_rank:0>2d}_pp{self.pp_rank:0>2d}"
+        dyname_to_pname = model_meta["sharding_metas"][suffix]["structure_name_mapping"]
+        dyname_to_meta = model_meta["sharding_metas"][suffix]["param_meta"]
+        for k, pname in dyname_to_pname.items():
+            shape, dtype, is_dist, is_no_sync = dyname_to_meta[k]
+            if is_no_sync:
+                if pname in param_names_in_master_weights:
+                    filter_optimzier_state_dict["master_weights"][pname] = optimzier_state_dict["master_weights"][
+                        pname
+                    ]
+                else:
+                    pass
+                    # logger.info(f"filter out master weight:{pname} -> {k}")
+                for op_k, op_v in optimzier_state_dict.items():
+                    if op_k.startswith(pname):
+                        filter_optimzier_state_dict[op_k] = op_v
+            else:
+                # logger.info(f"filter out key={k}, when dp!=0")
+                pass
+        return filter_optimzier_state_dict
+
     def process_dump_task_impl(self, output_dir):
         os.makedirs(output_dir, exist_ok=True)
         # Step1: save static objects
@@ -771,14 +827,28 @@ class FlashCheckpointWorker:
         # Step2: save dynamic objects
         # Step2.1: save model states
         model_states_name_path = os.path.join(output_dir, self.model_states_name_path)
-        paddle.save(self.param_fusion_storage_helper.state_dict(), model_states_name_path)
+        state_dict = self.param_fusion_storage_helper.state_dict()
 
         # Step2.2: save optimizer states
         optimizer_state_name_path = os.path.join(output_dir, self.optimizer_states_name_path)
-        paddle.save(self.optimizer_fusion_storage_helper.state_dict(), optimizer_state_name_path)
-        if self.ema_coef:
+        opt_state_dict = self.optimizer_fusion_storage_helper.state_dict()
+
+        if self.ema_coef is not None:
             ema_name_path = os.path.join(output_dir, self.optimizer_states_name_path).replace("optimizer", "ema")
-            paddle.save(self.flash_ema_processor.ema_state_dict(), ema_name_path)
+            ema_state_dict = self.flash_ema_processor.ema_state_dict()
+
+        if self.dp_rank <= 0 or self.use_expert_parallel:
+            if self.dp_rank > 0:  # ep
+                opt_state_dict = self._filter_moe_no_sync_optimizer_params(self.model_meta_content, opt_state_dict)
+                if self.ema_coef is not None:
+                    # non master-weights in `ema-state-dict` when dp >1 will be filterd, which is acceptable
+                    ema_state_dict = self._filter_moe_no_sync_optimizer_params(self.model_meta_content, ema_state_dict)
+
+            paddle.save(state_dict, model_states_name_path)
+            paddle.save(opt_state_dict, optimizer_state_name_path)
+            if self.ema_coef is not None:
+                paddle.save(ema_state_dict, ema_name_path)
+
         # Step2.3: save LR Scheduler (To be removed)
         lr_state_name_path = os.path.join(output_dir, SCHEDULER_NAME)
         if self.device_id == 0:

--- a/paddlenlp/trainer/utils/flash_checkpoint.py
+++ b/paddlenlp/trainer/utils/flash_checkpoint.py
@@ -141,16 +141,18 @@ class FlashEMAProcessor:
         master_min_offset = min(
             self.optimizer_fusion_storage_helper.master_weights_meta.values(), key=lambda i: i["start"]
         )["start"]
-        ema_buffer = paddle.Tensor(
-            self.optimizer_fusion_storage_helper.cpu_buffer._slice(master_min_offset, master_max_offset),
-            place=paddle.CPUPlace(),
-        )
-        # ema model params, only works on float32 model weights (aka, moe gates)
-        ema_buffer_model_params = {
-            k: cpu_buf.clone()
-            for k, (cuda_buf, cpu_buf) in self.param_fusion_storage_helper.inited_buffers.items()
-            if cuda_buf.dtype == paddle.float32
-        }
+        with device_guard("cpu"):
+            ema_buffer = paddle.zeros(
+                [master_max_offset - master_min_offset],
+                dtype="float32",
+            )
+            # ema model params, only works on float32 model weights (aka, moe gates)
+            ema_buffer_model_params = {
+                k: paddle.zeros_like(cpu_buf)
+                for k, (cuda_buf, cpu_buf) in self.param_fusion_storage_helper.inited_buffers.items()
+                if cuda_buf.dtype == paddle.float32
+            }
+        logger.info(f"[FC] build buffer done:{ema_buffer.dtype} {ema_buffer.place}")
         return ema_buffer, ema_buffer_model_params, master_min_offset, master_max_offset
 
     def ema_reset(self):
@@ -165,47 +167,49 @@ class FlashEMAProcessor:
         """
         # logger.info(f'[FC EMA] wait all done, doing EMA w/ coef: {self.ema_coef}, status:{self.status()}')
         # do update: ema = alpha * ema + (1-alpha) * model
-        logger.info("[FC EMA] start")
-        cpu_master_weights = self.optimizer_fusion_storage_helper.cpu_buffer._slice(
-            self.master_min_offset, self.master_max_offset
-        ).cpu()
-        self.ema_buffer = self.ema_coef * self.ema_buffer + (1 - self.ema_coef) * cpu_master_weights
-        # logger.info(f'[FC EMA2] wait all done, doing EMA w/ coef: {self.ema_coef}, status:{self.status()}')
-        for index, ema_buf in self.ema_buffer_model_params.items():
-            _, cpu_buf = self.param_fusion_storage_helper.inited_buffers[index]
-            updated_ema = self.ema_coef * ema_buf + (1 - self.ema_coef) * cpu_buf
-            self.ema_buffer_model_params[index] = updated_ema
-        logger.info(f"[FC EMA] done, buffer type:{self.ema_buffer.dtype}")
+        logger.info(f"[FC EMA] accmulating, buffer type:{self.ema_buffer.place} {self.ema_buffer.dtype}")
+        with device_guard("cpu"):
+            cpu_master_weights = self.optimizer_fusion_storage_helper.cpu_buffer._slice(
+                self.master_min_offset, self.master_max_offset
+            ).cpu()
+            self.ema_buffer = self.ema_coef * self.ema_buffer + (1 - self.ema_coef) * cpu_master_weights
+            # logger.info(f'[FC EMA2] wait all done, doing EMA w/ coef: {self.ema_coef}, status:{self.status()}')
+            for index, ema_buf in self.ema_buffer_model_params.items():
+                _, cpu_buf = self.param_fusion_storage_helper.inited_buffers[index]
+                updated_ema = self.ema_coef * ema_buf + (1 - self.ema_coef) * cpu_buf
+                self.ema_buffer_model_params[index] = updated_ema
 
     @imperative_base.no_grad()
     def ema_state_dict(self):
         assert self.optimizer_fusion_storage_helper is not None
         logger.info("[FC EMA] convert ema master weights state dict")
-        ema_state_dict = {}
-        for k, tensor_meta in self.param_fusion_storage_helper.model_weights_metas.items():
-            shape = tensor_meta["shape"]
-            name = tensor_meta["name"]
-            start = tensor_meta["start"]
-            end = tensor_meta["end"]
-            if tensor_meta["buffer_index"] not in self.ema_buffer_model_params:
-                continue  # non fp32 has no `self.ema_buffer_model_params`
-            cpu_buffer = self.ema_buffer_model_params[tensor_meta["buffer_index"]]
-            tensor = cpu_buffer._slice(start, end)
-            tensor.get_tensor()._set_dims(shape)
-            tensor.name = name
-            ema_state_dict[k] = tensor
-        ema_state_dict_master_weights = {}
-        for k, meta in self.optimizer_fusion_storage_helper.master_weights_meta.items():
-            t = self.ema_buffer._slice(meta["start"] - self.master_min_offset, meta["end"] - self.master_min_offset)
-            t.get_tensor()._set_dims(meta["shape"])
-            t.name = meta["name"]
-            ema_state_dict_master_weights[k] = t
-        ema_state_dict["master_weights"] = ema_state_dict_master_weights
-        logger.info("[FC EMA] done covert")
+        with device_guard("cpu"):
+            ema_state_dict = {}
+            for k, tensor_meta in self.param_fusion_storage_helper.model_weights_metas.items():
+                shape = tensor_meta["shape"]
+                name = tensor_meta["name"]
+                start = tensor_meta["start"]
+                end = tensor_meta["end"]
+                if tensor_meta["buffer_index"] not in self.ema_buffer_model_params:
+                    continue  # non fp32 has no `self.ema_buffer_model_params`
+                cpu_buffer = self.ema_buffer_model_params[tensor_meta["buffer_index"]]
+                tensor = cpu_buffer._slice(start, end)
+                tensor.get_tensor()._set_dims(shape)
+                tensor.name = name
+                ema_state_dict[k] = tensor
+            ema_state_dict_master_weights = {}
+            for k, meta in self.optimizer_fusion_storage_helper.master_weights_meta.items():
+                t = self.ema_buffer._slice(
+                    meta["start"] - self.master_min_offset, meta["end"] - self.master_min_offset
+                )
+                t.get_tensor()._set_dims(meta["shape"])
+                t.name = meta["name"]
+                ema_state_dict_master_weights[k] = t
+            ema_state_dict["master_weights"] = ema_state_dict_master_weights
         return ema_state_dict
 
     def load_ema_state_dict(self, path):
-        with device_guard():
+        with device_guard("cpu"):
             logger.info(f"[FC EMA] load state dict from {path}")
             state_dict = paddle.load(path)
             for k, tensor_meta in self.param_fusion_storage_helper.model_weights_metas.items():

--- a/paddlenlp/trainer/utils/flash_checkpoint.py
+++ b/paddlenlp/trainer/utils/flash_checkpoint.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import atexit
+import copy
 import hashlib
 import json
-
-# import copy
 import multiprocessing
 import os
 import time
@@ -34,16 +33,25 @@ from paddle.incubate.tensor.manipulation import (
 from paddle.optimizer.fusion_utils import FusionStorageHelper
 
 from paddlenlp.trainer.trainer_callback import TrainerCallback
+from paddlenlp.transformers.model_utils import (
+    _add_variant,
+    get_parameter_dtype,
+    unwrap_model,
+)
 from paddlenlp.transformers.utils import device_guard
 from paddlenlp.utils.env import (
     CONFIG_NAME,
     MODEL_META_NAME,
+    PADDLE_OPTIMIZER_NAME,
+    PADDLE_WEIGHTS_NAME,
+    PREFIX_CHECKPOINT_DIR,
     SCHEDULER_NAME,
     TRAINER_STATE_NAME,
     TRAINING_ARGS_NAME,
 )
 from paddlenlp.utils.fault_tolerance import FC_DUMP_ERROR, PC_DUMP_ERROR
 from paddlenlp.utils.log import logger
+from paddlenlp.utils.pdc_sdk import FLASH_DEVICE
 
 
 def md5(tensor):
@@ -62,7 +70,7 @@ class FCTaskType(Enum):
     PREPARE = 1
     OFFLOAD = 2
     FINISH = 3
-    SET_EMA_STATE_DICT = 4
+    SET_EMA_STATE_DICT = 5
 
 
 class FCWorkerStatus(Enum):
@@ -156,6 +164,7 @@ class FlashEMAProcessor:
         """
         # logger.info(f'[FC EMA] wait all done, doing EMA w/ coef: {self.ema_coef}, status:{self.status()}')
         # do update: ema = alpha * ema + (1-alpha) * model
+        logger.info("[FC EMA] start")
         cpu_master_weights = self.optimizer_fusion_storage_helper.cpu_buffer._slice(
             self.master_min_offset, self.master_max_offset
         ).cpu()
@@ -337,11 +346,124 @@ class ParamFusionStorageHelper:
 
 
 class FlashCheckpointCallback(TrainerCallback):
-    def __init__(self, flash_checkpoint_manager):
+    """
+    call FlashCheckpointManager during training in following order:
+
+    on_step_end:
+        *  call get_idle_worker_for_saving, set manager.current_worker
+        *  call maybe_update_flash_checkpoint_worker
+
+    * on_substep_end(call `gradient_accumulate` times): call flash_checkpoint_pipeline_hook (in non-pp model)
+    * (when offload done, dump model)
+    on_optimizer_begin: call sync_offload_status, unset set manager.current_worker
+    """
+
+    def __init__(self, args, flash_checkpoint_manager, timer, sharding_io):
         self.manager = flash_checkpoint_manager
+        self.runtime_timer = timer
+        self.user_file_list = []
+        self.manipulated_state_dict = None
+        self.manipulated_config_to_save = None
+        self.manipulated_weight_suffix = None
+        self.model_meta = None
+        self.sharding_io = sharding_io
+        assert (
+            args.flash_save_steps % args.flash_ema_interval == 0
+        ), f"flash_save_steps:{args.flash_save_steps} must be divisible by flash_ema_interval:{args.flash_ema_interval}"
+        assert (
+            args.save_steps % args.flash_ema_interval == 0
+        ), f"save_steps:{args.save_steps} must be divisible by flash_ema_interval:{args.flash_ema_interval}"
+        self.flash_ema_interval = args.flash_ema_interval
+        if args.flash_save_ema_coef:
+            assert args.flash_workers_num == 1, "[FC EMA] not support #worker > 1"
 
     def on_substep_end(self, args, state, control, **kwargs):
         self.manager.flash_checkpoint_pipeline_hook(0)
+
+    def on_optimizer_begin(self, args, state, control, **kwargs):
+        if args.enable_flash_save_mode and self.manager.current_worker is not None:
+            logger.info("Start syncing flash checkpoints")
+            self.manager.sync_offload_status()
+            logger.info("Synced flash checkpoints.")
+
+    def on_step_end(self, args, state, control, model, lr_scheduler, optimizer, **kwargs):
+        self.manager.flash_checkpoint_pipeline_hook(0)
+        logger.info(
+            f"check coef: {args.flash_save_ema_coef} {control.should_save}, {state.global_step}, {self.flash_ema_interval}"
+        )
+        if not control.should_save:
+            if args.flash_save_ema_coef and state.global_step % self.flash_ema_interval == 0:
+                self.maybe_update_flash_checkpoint_worker(args, model, optimizer)
+                self.manager.get_idle_worker_for_saving()  # prepare for dumping
+        else:
+            self.runtime_timer.start("checkpoint saving time")
+            self.maybe_update_flash_checkpoint_worker(args, model, optimizer)
+            checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}"
+            save_infos = self._get_save_infos_based_on_steps(state, args, checkpoint_folder)
+            non_cached_objects = (lr_scheduler.state_dict(), state)
+            self.manager.get_idle_worker_for_saving((save_infos, non_cached_objects))
+            self.runtime_timer.stop()
+            control.should_save = False  # avoid regular saving
+
+    def _get_save_infos_based_on_steps(self, state, args, checkpoint_folder):
+        flash_checkpoint_dir = None
+        persistent_checkpoint_dir = None
+        if args.flash_save_steps > 0 and state.global_step % args.flash_save_steps == 0:
+            flash_checkpoint_dir = os.path.join(FLASH_DEVICE, checkpoint_folder)
+        if args.save_steps > 0 and state.global_step % args.save_steps == 0:
+            persistent_checkpoint_dir = os.path.join(args.output_dir, checkpoint_folder)
+        return (flash_checkpoint_dir, persistent_checkpoint_dir)
+
+    def maybe_update_flash_checkpoint_worker(self, args, model, optimizer):
+        # logger.info(f'check should update :{optimizer.fused_buffer_version} vs {self.manager.cache_version}')
+        if optimizer.fused_buffer_version == self.manager.cache_version:
+            return
+
+        logger.info("Flash checkpoint workers need upgrade.")
+        self._cache_meta_for_sharded_save(model)
+        param_mappings, ipc_meta_mappings = get_fused_param_mappings(optimizer, self.manipulated_state_dict)
+        optimizer_states_meta = (
+            optimizer.fused_states_accumulators_meta,
+            optimizer.fused_states_master_weights_meta,
+            None,
+            optimizer.fused_states_buffer_ipc_meta,
+        )
+        model_states_meta = (param_mappings, ipc_meta_mappings)
+        optimizer_states_name_path = _add_variant(PADDLE_OPTIMIZER_NAME, args.optimizer_name_suffix)
+        model_states_name_path = _add_variant(PADDLE_WEIGHTS_NAME, self.manipulated_weight_suffix)
+
+        dynamic_objecs = {}
+        dynamic_objecs["optimizer_states_meta"] = optimizer_states_meta
+        dynamic_objecs["model_states_meta"] = model_states_meta
+        dynamic_objecs["optimizer_states_name_path"] = optimizer_states_name_path
+        dynamic_objecs["model_states_name_path"] = model_states_name_path
+
+        static_objects = {}
+        static_objects["model_config"] = self.manipulated_config_to_save
+        static_objects["training_args"] = args
+        static_objects["model_meta"] = self.model_meta
+        static_objects["user_file"] = self.user_file_list
+
+        self.manager.update_flash_workers(optimizer.fused_buffer_version, dynamic_objecs, static_objects)
+
+    def _cache_meta_for_sharded_save(self, model):
+        logger.info("Start caching metas for sharded save...")
+        (
+            self.manipulated_state_dict,
+            self.manipulated_config_to_save,
+            self.manipulated_weight_suffix,
+        ) = self.sharding_io.manipulate_state_dict_and_config(model, merge_tensor_parallel=False)
+        logger.info("Cache manipulated static dict done.")
+        if self.manipulated_config_to_save is None:
+            model_to_save = unwrap_model(model)
+            dtype = get_parameter_dtype(model_to_save)
+            model_to_save.config.dtype = str(dtype).split(".")[1]
+            self.manipulated_config_to_save = copy.deepcopy(model_to_save.config)
+            self.manipulated_config_to_save.architectures = [model_to_save.__class__.__name__]
+            self.manipulated_config_to_save = self.manipulated_config_to_save.to_json_string(use_diff=True)
+            logger.info("Cache manipulated model config done")
+        self.model_meta = self.sharding_io.gather_distributed_model_meta()
+        logger.info("Cache distributed model meta done.")
 
 
 class FlashCheckpointManager:
@@ -355,7 +477,6 @@ class FlashCheckpointManager:
         self.current_worker = None
         self.device_id = int(os.getenv("FLAGS_selected_gpus"))
         self.pipeline_hooks_steps = max(int(pipeline_hooks_capacity * capacity_usage), 1)
-        self.ema_coef = ema_coef
         logger.info(
             f"[FC manager] pipeline hooks capacity: {pipeline_hooks_capacity}; "
             f"pipeline hooks steps for offloading: {self.pipeline_hooks_steps} "
@@ -412,7 +533,10 @@ class FlashCheckpointManager:
         logger.info("[FC manager] update all flash workers done")
         self.ready_to_save = True
 
-    def get_idle_worker_for_saving(self, save_infos, non_cached_objects):
+    def get_idle_worker_for_saving(self, save_infos_and_non_cached_objects=None):
+        """
+        if `save_infos_and_non_cached_objects` is None, do offload without dumping.
+        """
         self.report_error_worker()
         assert self.current_worker is None, "[FC manager] current_worker must be None"
         found_worker = False
@@ -424,12 +548,16 @@ class FlashCheckpointManager:
                     break
             if found_worker:
                 break
-            logger.info("[FC manager] Waiting for idle worker...")
+            logger.info("[FC manager] Waiting for idle worker..., consider increse `save-step` or `global-batch-size`")
             time.sleep(1)
-        task = (FCTaskType.PREPARE, (save_infos, non_cached_objects))
-        logger.info("[FC manager] before putting task for prepare")
+        task = (FCTaskType.PREPARE, save_infos_and_non_cached_objects)
+        logger.info(
+            f"[FC manager] before putting task for prepare, dumping={save_infos_and_non_cached_objects is not None}"
+        )
         self.current_worker.task_queue.put(task)
-        logger.info("[FC manager] after putting task for prepare")
+        logger.info(
+            f"[FC manager] after putting task for prepare, dumping={save_infos_and_non_cached_objects is not None}"
+        )
 
     def sync_offload_status(self):
         self.report_error_worker()
@@ -542,13 +670,15 @@ class FlashCheckpointWorker:
         self.version.value = version
 
     def process_prepare_task(self, prepares):
-        save_infos, non_cached_objects = prepares
         self.offloaded_numels = 0
         self.status.value = FCWorkerStatus.OFFLOADING.value
+        if prepares is None:  # when `prepares` is None, not dumping
+            return
+        save_infos, non_cached_objects = prepares
         self.flash_save_dir, self.persistent_save_dir = save_infos
         self.lr_scheduler, self.trainer_state = non_cached_objects
 
-    def process_offload_task(self):
+    def process_offload_task(self, dump):
         actual_offload_size = (
             min(self.offloaded_numels + self.chunk_size_in_numel, self.all_numel) - self.offloaded_numels
         )
@@ -582,12 +712,12 @@ class FlashCheckpointWorker:
 
         # continue to process dumping task at the last chunk
         if self.offloaded_numels == self.all_numel:
-            need_report_error = self.process_dump_task()
-            self.offloaded_numels = 0
-            if need_report_error:
-                self.status.value = FCWorkerStatus.ERROR.value
+            if dump:
+                need_report_error = self.process_dump_task()
             else:
-                self.status.value = FCWorkerStatus.IDLE.value
+                need_report_error = False
+            self.offloaded_numels = 0
+            self.status.value = FCWorkerStatus.ERROR.value if need_report_error else FCWorkerStatus.IDLE.value
 
     def process_dump_task(self):
         """
@@ -669,6 +799,7 @@ class FlashCheckpointWorker:
         paddle.set_device(f"gpu:{self.device_id}")
         logger.info(f"[FC worker{self.worker_id}] Worker{self.worker_id} started.")
         ema_ckpt_path = None
+        save_info_tuple = None  # save dir...
         try:
             while True:
                 task = self.task_queue.get()
@@ -686,9 +817,10 @@ class FlashCheckpointWorker:
                         self.flash_ema_processor.load_ema_state_dict(ema_ckpt_path)
                     ema_ckpt_path = None
                 elif task_type == FCTaskType.PREPARE:
+                    save_info_tuple = task_body
                     self.process_prepare_task(task_body)
                 elif task_type == FCTaskType.OFFLOAD:
-                    self.process_offload_task()
+                    self.process_offload_task(dump=save_info_tuple is not None)
                 elif task_type == FCTaskType.SET_EMA_STATE_DICT:
                     ema_ckpt_path = task_body  # mark ema state dict path
                 else:

--- a/paddlenlp/trainer/utils/sharding_io.py
+++ b/paddlenlp/trainer/utils/sharding_io.py
@@ -321,6 +321,8 @@ class ShardingIO:
             one_shard_opt_state_dict = None
 
         logger.info("reshard optimizer state")
+        if self.args.flash_save_ema_coef is not None:
+            raise ValueError("flash save EMA do not support reshard")  # TODO: suport FC-ema reshard
 
         def load_model_slices():
             model_state = reshard_util.NodeModelState()

--- a/paddlenlp/trainer/utils/sharding_io.py
+++ b/paddlenlp/trainer/utils/sharding_io.py
@@ -597,7 +597,8 @@ class ShardingIO:
         for k, v in model.state_dict().items():
             structure_name_mapping[k] = v.name
             is_distributed = getattr(v, "is_distributed", False)
-            param_meta[k] = (v.shape, int(v.dtype), is_distributed)
+            no_sync = getattr(v, "no_sync", False)
+            param_meta[k] = (v.shape, int(v.dtype), is_distributed, no_sync)
 
         sharding_metas = {}
         sharding_meta = {}


### PR DESCRIPTION
在 FlashCheckpoint 中对 model param 和 optimizer param直接进行 EMA 操作。实现异步 EMA。具体来说：

* 全程异步在 CPU 端进行，没有不阻塞训练。没有额外开销。
* 新增：支持非 Pipeline 网络，支持 dp-moe，纯 sharding 等其他分布式策略。
* EMA 的 buffer 由FlashCheckpointWorker 持有，在 resume 的时候支持加载之前 EMA的状态。
* EMA 只对 Optimizer中的 master_weights和 model_param 中的 **dtype == float32** 的 param 进行。
* 新增的 EMA 状态会保存在 checkpoint目录中的`ema...` 文件中，存储格式示例如下：

```shell
output/mini-4p5v-resume/checkpoint-10/
├── config.json
├── ema.tp00_pp00_shard00.pdopt
├── ema.tp00_pp00_shard01.pdopt
├── ema.tp00_pp01_shard00.pdopt
├── ema.tp00_pp01_shard01.pdopt
├── ema.tp01_pp00_shard00.pdopt
├── ema.tp01_pp00_shard01.pdopt
├── ema.tp01_pp01_shard00.pdopt
├── ema.tp01_pp01_shard01.pdopt
├── model_meta.json
├── model_state.tp00_pp00_shard00.pdparams
├── model_state.tp00_pp00_shard01.pdparams
├── model_state.tp00_pp01_shard00.pdparams
├── model_state.tp00_pp01_shard01.pdparams
├── model_state.tp01_pp00_shard00.pdparams
├── model_state.tp01_pp00_shard01.pdparams
├── model_state.tp01_pp01_shard00.pdparams
├── model_state.tp01_pp01_shard01.pdparams
├── optimizer.tp00_pp00_shard00.pdopt
├── optimizer.tp00_pp00_shard01.pdopt
├── optimizer.tp00_pp01_shard00.pdopt
├── optimizer.tp00_pp01_shard01.pdopt
├── optimizer.tp01_pp00_shard00.pdopt
├── optimizer.tp01_pp00_shard01.pdopt
├── optimizer.tp01_pp01_shard00.pdopt
├── optimizer.tp01_pp01_shard01.pdopt
├── saved_signal_0
├── saved_signal_1
├── saved_signal_2
├── saved_signal_3
├── saved_signal_4
├── saved_signal_5
├── saved_signal_6
├── saved_signal_7
├── scheduler.pdparams
├── trainer_state.json
└── training_args.bin
``` 

目前已知的局限性:
* reshard 改变 `sharding-degree`后，无法EMA 部分无法加载之前的状态。（目前会报错）
