### PR TITLE
[LLM]: fix block_size setting for llama.

### DIFF
--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -1431,6 +1431,7 @@ class LlamaBlockInferenceModel(LlamaInferenceModel):
         kwargs["cu_seqlens_k"] = cu_seqlens_k
         kwargs["padding_offsets"] = padding_offset
         kwargs["max_input_length"] = self.max_seq_len
+        kwargs["block_size"] = self.block_size
 
         inputs_embeds = self.embed_tokens(ids_remove_padding)
 


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes.

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models. 

### Description
<!-- Describe what this PR does -->
Enable llama to run with block_size according to the specified by the command line, because some custom devices kernel do not support default block_size (64), like on sdaa.
