### PR TITLE
解决类型注解Python版本兼容性问题

### DIFF
--- a/paddlenlp/trainer/utils/ckpt_converter.py
+++ b/paddlenlp/trainer/utils/ckpt_converter.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 from functools import reduce
+from typing import List, Union
 
 import paddle
 from paddle.distributed.checkpoint.load_state_dict import (
@@ -29,7 +30,7 @@ from paddle.distributed.checkpoint.metadata import (
 )
 from paddle.distributed.checkpoint.utils import flatten_state_dict
 from paddle.distributed.fleet.utils.log_util import logger
-from typing import Union, List
+
 MODEL_WEIGHT_SUFFIX = ".pdparams"
 OPTIMIZER_WEIGHT_SUFFIX = ".pdopt"
 SCHEDULER_NAME = "scheduler.pdparams"
@@ -47,7 +48,7 @@ class CheckpointConverter:
         parameter_to_structured_name,
         trainging_args=None,
         patch_dict=None,
-        local_view_pattern: Union[ List, bool] = None
+        local_view_pattern: Union[List, bool] = None,
     ):
         self.use_dist = True if paddle.distributed.get_world_size() > 1 else False
         self.path = hybrid_parallel_ckpt_path

--- a/paddlenlp/trainer/utils/ckpt_converter.py
+++ b/paddlenlp/trainer/utils/ckpt_converter.py
@@ -29,7 +29,7 @@ from paddle.distributed.checkpoint.metadata import (
 )
 from paddle.distributed.checkpoint.utils import flatten_state_dict
 from paddle.distributed.fleet.utils.log_util import logger
-
+from typing import Union, List
 MODEL_WEIGHT_SUFFIX = ".pdparams"
 OPTIMIZER_WEIGHT_SUFFIX = ".pdopt"
 SCHEDULER_NAME = "scheduler.pdparams"
@@ -47,7 +47,7 @@ class CheckpointConverter:
         parameter_to_structured_name,
         trainging_args=None,
         patch_dict=None,
-        local_view_pattern: list | bool = None,
+        local_view_pattern: Union[ List, bool] = None
     ):
         self.use_dist = True if paddle.distributed.get_world_size() > 1 else False
         self.path = hybrid_parallel_ckpt_path


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
在Python 3.10之前，类型注解中的联合类型使用Union，而不是|操作符。python3.9及以下版本在跑llama模型时，会因为该注解出错，因此需做修改进行兼容
