### PR TITLE
fix reshard_qkv alltoall error

### DIFF
--- a/paddlenlp/transformers/segment_parallel_utils.py
+++ b/paddlenlp/transformers/segment_parallel_utils.py
@@ -78,7 +78,7 @@ def _reshard_qkv(x, group, split_axis=2, concat_axis=0):
 
     comm_tensor_list = paddle.split(x, nranks, axis=split_axis)
     output_list = [paddle.empty_like(comm_tensor_list[0]) for _ in comm_tensor_list]
-    dist.alltoall(comm_tensor_list, output_list, group=group)
+    dist.alltoall(output_list, comm_tensor_list, group=group)
     reshard_tensor = paddle.concat(output_list, axis=concat_axis)
 
     return reshard_tensor


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
ReshardQkv alltoall input_tensor 和out_tensor 位置放反了