### PR TITLE
[CI] Fix tokenizer load in PRM

### DIFF
--- a/llm/alignment/rm/flashmask/run_reward.py
+++ b/llm/alignment/rm/flashmask/run_reward.py
@@ -19,10 +19,6 @@ import sys
 from functools import partial
 
 import paddle
-from reward_argument import DataArgument, ModelArgument, TrainingArguments
-from reward_model import LlamaModelForPRM, LlamaModelForScore, MistralModelForPRM
-from reward_trainer import RewardTrainer
-
 from data import (
     preference_collate_fn,
     preprocess_preference_data,
@@ -30,6 +26,10 @@ from data import (
     process_collate_fn,
     zero_padding_process_collate_fn,
 )
+from reward_argument import DataArgument, ModelArgument, TrainingArguments
+from reward_model import LlamaModelForPRM, LlamaModelForScore, MistralModelForPRM
+from reward_trainer import RewardTrainer
+
 from paddlenlp.datasets import (
     ZeroPaddingIterableDataset,
     ZeroPaddingMapDataset,
@@ -171,11 +171,6 @@ def main():
     if model_args.flash_mask and not model.config.use_flash_attention:
         logger.warning("`flash_mask` must use with zero padding and flash attention.")
         model.config.use_flash_attention = True
-
-    if model_args.tokenizer_name_or_path is not None:
-        tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name_or_path)
-    else:
-        tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
 
     # TODO: support chat template in next pr
     # tokenizer.chat_template = None


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Trainer
### Description
<!-- Describe what this PR does -->
Fix tokenizer load in PRM.

第一次加载后对pad_token_id有处理，但是第二次加载后没有，导致pad_token_id=None，进而导致dataloader加载时出现[0,1,2,3,4,5,None,None]的特殊类型。