### PR TITLE
[custom device]: replace broadcast kernel with custom api for sdaa.

### DIFF
--- a/paddlenlp/experimental/transformers/generation_utils.py
+++ b/paddlenlp/experimental/transformers/generation_utils.py
@@ -407,6 +407,13 @@ class GenerationInferenceModel(GenerationMixin):
 
 
 class GenerationBlockInferenceModel(GenerationMixin):
+    def __init__(self, config):
+        super().__init__(config)
+        self.rank = paddle.distributed.fleet.get_hybrid_communicate_group().get_model_parallel_rank()
+        self.nranks = paddle.distributed.fleet.get_hybrid_communicate_group().get_model_parallel_world_size()
+        self.root = 0
+        self.ring_id = paddle.distributed.fleet.get_hybrid_communicate_group().get_model_parallel_group().id
+
     @classmethod
     def get_cache_kvs_shape(cls, max_batch_size: int = None, max_length: int = None) -> list[list[int]]:
         raise NotImplementedError
@@ -735,7 +742,18 @@ class GenerationBlockInferenceModel(GenerationMixin):
                 _, next_tokens = paddle.tensor.top_p_sampling(probs, top_p)
 
             if self.config.tensor_parallel_degree > 1:
-                paddle.distributed.broadcast(next_tokens, 0)
+                if "sdaa" in paddle.device.get_device():
+                    import paddle_sdaa
+
+                    paddle_sdaa.ops.custom_broadcast(
+                        next_tokens,
+                        rank=self.rank,
+                        nranks=self.nranks,
+                        root=self.root,
+                        ring_id=self.ring_id,
+                    )
+                else:
+                    paddle.distributed.broadcast(next_tokens, 0)
 
             with paddle.base.framework._stride_in_no_check_dy2st_diff():
                 from paddlenlp_ops import update_inputs_v2


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
Due to the [issue](https://github.com/PaddlePaddle/Paddle/issues/71219) that the xccl communicator is null on custom device of broadcast kernel, the broadcast is replaced with the custom API for SDAA.
