### PR TITLE
fix rng_state checkpoint error when tp8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   Pipelines-Test:
     name: Pipelines-Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   Release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     permissions:
       issues: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       contents: read

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -5,7 +5,7 @@
 # Required
 version: 2
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.10"
 

--- a/paddlenlp/trainer/trainer_utils.py
+++ b/paddlenlp/trainer/trainer_utils.py
@@ -130,6 +130,8 @@ def _get_distributed_seeds(seed: int = 1234, topo: Topology = None):
         pp_rank, pp_size = 0, 1
         dp_rank, dp_size = 0, 1
         sharding_rank, _ = 0, 1
+    # when tp=8,tp_rank=7 , fleet model_parallel_random_seed would gen local_seed seed+1+mp_rank(seed+1+7),it is conflict with global_seed = seed+sharding_rank*mp_size(seed+1*8)
+    seed_offset = seed + paddle.distributed.get_world_size()
 
     seed_offset = seed
     global_seed = (

--- a/paddlenlp/trainer/trainer_utils.py
+++ b/paddlenlp/trainer/trainer_utils.py
@@ -130,10 +130,9 @@ def _get_distributed_seeds(seed: int = 1234, topo: Topology = None):
         pp_rank, pp_size = 0, 1
         dp_rank, dp_size = 0, 1
         sharding_rank, _ = 0, 1
-    # when tp=8,tp_rank=7 , fleet model_parallel_random_seed would gen local_seed seed+1+mp_rank(seed+1+7),it is conflict with global_seed = seed+sharding_rank*mp_size(seed+1*8)
-    seed_offset = seed + paddle.distributed.get_world_size()
+    # in mpu/random.py , local_seed = seed + 1 + mp_rank * pp_size + pp_rank , so here add a offset to avoid same with local_seed
+    seed_offset = seed + 2 + mp_size * pp_size + pp_size
 
-    seed_offset = seed
     global_seed = (
         seed_offset
         + sep_rank * (mp_size)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
sharding+tp时，sharing_rank 1 ,tp_rank 7的global_seed和local_seed一致，rng tracker丢失global seed信息
![ab6da626543a70f91a14293677d3d67c](https://github.com/user-attachments/assets/0954d7e2-abb4-4f11-9606-b83ed7e46620)
