### PR TITLE
Add tokens_zip op to perform zip operation more efficiently, substituing unpermute

### DIFF
--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_unzip_and_zip.cu
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_unzip_and_zip.cu
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -241,6 +241,111 @@ __global__ void tokens_weighted_zip_kernel(
   }
 }
 
+
+template <int num_experts, bool MP = true>
+__global__ void tokens_zip_kernel(
+    const phi::bfloat16 *__restrict__ unzipped_tokens_in,
+    const int *__restrict__ zipped_expertwise_rowmap,
+    phi::bfloat16 *__restrict__ zipped_tokens_out,
+    const int total_zipped_tokens_num,
+    const int token_length) {
+  const int this_row = blockIdx.x;
+  if (this_row >= total_zipped_tokens_num) return;
+
+  const __nv_bfloat16 *unzipped_tokens =
+      reinterpret_cast<const __nv_bfloat16 *>(unzipped_tokens_in);
+  __nv_bfloat16 *zipped_tokens =
+      reinterpret_cast<__nv_bfloat16 *>(zipped_tokens_out);
+
+  int local_row_fetchlist[num_experts];
+
+// -------------------------初始化任务表 ------------------------
+#pragma unroll
+  for (int expert = 0; expert < num_experts; ++expert) {
+    const int fetch_row =
+        zipped_expertwise_rowmap[this_row * num_experts + expert];
+    local_row_fetchlist[expert] = fetch_row;
+  }
+
+  constexpr int vecSize = 2;  // __nv_bfloat162 = 2 x bfloat16
+  const int num_full_vec = token_length / vecSize;
+  const int remaining_elems = token_length % vecSize;
+  const int thread_stride = blockDim.x * vecSize;
+
+  if constexpr (MP) {
+    // ------------------------ 手动混合精度 ---------------------------------
+    // 齐整区域向量化搬移
+    for (int x_offset = threadIdx.x * vecSize;
+         x_offset < num_full_vec * vecSize;
+         x_offset += thread_stride) {
+      float2 sum = {0.0f, 0.0f};
+      __nv_bfloat162 *out_ptr = reinterpret_cast<__nv_bfloat162 *>(
+          &zipped_tokens[this_row * token_length + x_offset]);
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        const int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        // 手动类型提升
+        float2 token_vec =
+            __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162 *>(
+                &unzipped_tokens[fetch_row * token_length + x_offset]));
+        sum.x = __fadd_rn(token_vec.x, sum.x);
+        sum.y = __fadd_rn(token_vec.y, sum.y);
+      }
+      // 类型下降为原有精度
+      *out_ptr = __float22bfloat162_rn(sum);
+    }
+
+    // 剩余元素处理
+    for (int i = num_full_vec * vecSize + threadIdx.x; i < token_length;
+         i += blockDim.x) {
+      float sum = 0.0f;
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        float token_val =
+            __bfloat162float(unzipped_tokens[fetch_row * token_length + i]);
+        sum = __fadd_rn(token_val, sum);
+      }
+      zipped_tokens[this_row * token_length + i] = __float2bfloat16_rn(sum);
+    }
+  } else {
+    // ------------------------ BF16 intrinsics 加权累加 -----------------------
+    // 齐整区域向量化搬移
+    for (int x_offset = threadIdx.x * vecSize;
+         x_offset < num_full_vec * vecSize;
+         x_offset += thread_stride) {
+      __nv_bfloat162 sum = {0, 0};
+      __nv_bfloat162 *out_ptr = reinterpret_cast<__nv_bfloat162 *>(
+          &zipped_tokens[this_row * token_length + x_offset]);
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        const int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        __nv_bfloat162 token_vec = *reinterpret_cast<const __nv_bfloat162 *>(
+            &unzipped_tokens[fetch_row * token_length + x_offset]);
+        sum = __hadd2(sum, token_vec);
+      }
+      *out_ptr = sum;
+    }
+
+    // 剩余元素处理
+    for (int i = num_full_vec * vecSize + threadIdx.x; i < token_length;
+         i += blockDim.x) {
+      __nv_bfloat16 sum = (__nv_bfloat16)0;
+#pragma unroll
+      for (int expert = 0; expert < num_experts; ++expert) {
+        int fetch_row = local_row_fetchlist[expert];
+        if (fetch_row < 0) continue;
+        __nv_bfloat16 token_val = unzipped_tokens[fetch_row * token_length + i];
+        sum = __hadd(sum, token_val);
+      }
+      zipped_tokens[this_row * token_length + i] = sum;
+    }
+  }
+}
+
 // ---------------------------- Dispatch ---------------------------------
 void dispatch_tokens_unzip(const paddle::Tensor &X,
                            const paddle::Tensor &expert_routemap_topk,
@@ -317,6 +422,27 @@ void dispatch_tokens_unzip(const paddle::Tensor &X,
 #undef HANDLE_PROB_TYPE
 }
 
+void dispatch_tokens_zip(const paddle::Tensor &unzipped_tokens,
+                         const paddle::Tensor &zipped_expertwise_rowmap,
+                         paddle::Tensor &zipped_tokens,
+                         const int total_zipped_tokens_num,
+                         const int num_experts,
+                         const int token_length) {
+  dim3 grid, block;
+  grid.x = total_zipped_tokens_num;
+  block.x = 256;
+
+  // Map data types to C++ types
+  if (num_experts == 4) {
+    tokens_zip_kernel<4><<<grid, block, 0, unzipped_tokens.stream()>>>(
+        unzipped_tokens.data<phi::bfloat16>(),
+        zipped_expertwise_rowmap.data<int>(),
+        zipped_tokens.data<phi::bfloat16>(),
+        total_zipped_tokens_num,
+        token_length);
+  }
+}
+
 void dispatch_tokens_weighted_zip(
     const paddle::Tensor &unzipped_tokens,
     const paddle::Tensor &unzipped_token_probs,
@@ -365,6 +491,29 @@ std::vector<paddle::Tensor> tokens_weighted_zip(
                                num_experts,
                                cols);
   return {weighted_zipped_tokens};
+}
+
+std::vector<paddle::Tensor> tokens_zip(
+    const paddle::Tensor &unzipped_tokens,
+    const paddle::Tensor &zipped_expertwise_rowmap,
+    const int &total_zipped_tokens_num,
+    const int &num_experts) {
+  PD_CHECK(unzipped_tokens.dtype() == paddle::DataType::BFLOAT16);
+  int rows = unzipped_tokens.shape()[0];  // seqlen
+  int cols = unzipped_tokens.shape()[1];  // 一般为7168
+
+  //------------------------ 输出1张量 ------------------------
+  auto zipped_tokens = paddle::empty({total_zipped_tokens_num, cols},
+                                     unzipped_tokens.dtype(),
+                                     unzipped_tokens.place());
+
+  dispatch_tokens_zip(unzipped_tokens,
+                      zipped_expertwise_rowmap,
+                      zipped_tokens,
+                      total_zipped_tokens_num,
+                      num_experts,
+                      cols);
+  return {zipped_tokens};
 }
 
 std::vector<paddle::Tensor> tokens_unzip(
@@ -436,6 +585,12 @@ PD_BUILD_OP(tokens_unzip)
               "expert_idx_unzipped"})
     .Attrs({"total_unzipped_tokens_num: int", "topk: int", "num_experts: int"})
     .SetKernelFn(PD_KERNEL(tokens_unzip));
+
+PD_BUILD_OP(tokens_zip)
+    .Inputs({"unzipped_tokens", "zipped_expertwise_rowmap"})
+    .Outputs({"zipped_tokens"})
+    .Attrs({"total_zipped_tokens: int", "num_experts: int"})
+    .SetKernelFn(PD_KERNEL(tokens_zip));
 
 PD_BUILD_OP(tokens_weighted_zip)
     .Inputs({"unzipped_tokens",

--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/utils.h
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/utils.h
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/ops/test_tokens_zip.py
+++ b/tests/ops/test_tokens_zip.py
@@ -1,0 +1,143 @@
+import numpy as np
+import paddle
+import paddle.incubate.nn.functional as F
+import TokenDispatcherUtils as TDU
+
+def compare_tensors(a, b):
+    # 形状一致性检查
+    assert a.shape == b.shape, "输入张量形状不一致"
+    
+    # 计算绝对差距
+    abs_diff = np.abs(a - b)
+    max_abs_val = np.max(abs_diff)
+    max_abs_flat_idx = np.argmax(abs_diff)
+    max_abs_idx = np.unravel_index(max_abs_flat_idx, a.shape)
+    
+    # 计算相对差距（防止除以零）
+    denominator = np.maximum(np.abs(a), np.abs(b))
+    rel_diff = np.divide(
+        abs_diff, 
+        denominator, 
+        out=np.zeros_like(abs_diff),
+        where=(denominator != 0)
+    )
+    max_rel_val = np.max(rel_diff)
+    max_rel_flat_idx = np.argmax(rel_diff)
+    max_rel_idx = np.unravel_index(max_rel_flat_idx, a.shape)
+    
+
+    # 打印结果
+    print("\n[最大绝对差距]" f"位置: {max_abs_idx}")
+    print(f"a[{max_abs_idx}] = {a[max_abs_idx]:.6g}" + f"\t b[{max_abs_idx}] = {b[max_abs_idx]:.6g}" + f"\t 绝对差值: {max_abs_val:.6g}\n")
+    
+    print("[最大相对差距]" f"位置: {max_rel_idx}")
+    print(f"a[{max_rel_idx}] = {a[max_rel_idx]:.6g}" + f"\t b[{max_rel_idx}] = {b[max_rel_idx]:.6g}" + f"\t 相对差值: {max_rel_val:.6g}\n")
+    print("周围元素比较-a:")
+    print(f"{a[max_rel_idx[0], (max_rel_idx[1] - 10):(max_rel_idx[1] + 10)]} ")
+    print("周围元素比较-b:")
+    print(f"{b[max_rel_idx[0], (max_rel_idx[1] - 10):(max_rel_idx[1] + 10)]} ")
+    
+    # 返回结构化结果
+    return {
+        'max_absolute': {
+            'index': max_abs_idx,
+            'a_value': a[max_abs_idx],
+            'b_value': b[max_abs_idx],
+            'difference': max_abs_val
+        },
+        'max_relative': {
+            'index': max_rel_idx,
+            'a_value': a[max_rel_idx],
+            'b_value': b[max_rel_idx],
+            'difference': max_rel_val
+        }
+    }
+
+def verify_tokens_unzip():
+    expert_num = 4
+    topk = 8
+    seqlen = 3
+    token_len = 8
+    tokens_zipped = [
+        [1,1,1,1,1,1,1,1],
+        [2,2,2,2,2,2,2,2],
+        [3,3,3,3,3,3,3,3]
+    ]
+    routemap_topk = [ 
+        [-1,-1,0,1,-1,-1,-1,-1],
+        [1,-1,-1,-1,-1,-1,-1,-1],
+        [-1,0,-1,-1,-1,-1,-1,-1],
+    ]
+    probs_topk = [ 
+        [0,0,0.5,0.5,0,0,0,0],
+        [1,0,0,0,0,0,0,0],
+        [0,1,0,0,0,0,0,0],
+    ]
+    total_unzipped_tokens_num = 4
+    expected_unzipped_tokens= [
+        [1,1,1,1,1,1,1,1],
+        [2,2,2,2,2,2,2,2],
+        [3,3,3,3,3,3,3,3],
+        [1,1,1,1,1,1,1,1],
+    ]
+    expected_unzipped_probs= [
+        0.5,
+        1,
+        1,
+        0.5
+    ]
+    expected_zipped_expertwise_rowmap= [
+        [0,3,-1,-1],
+        [-1,1,-1,-1],
+        [2,-1,-1,-1],
+    ]
+    expected_unzipped_expert_idx = [
+        0,
+        1,
+        0,
+        1 
+    ]
+    tokens_simple_zipped = [
+        [2,2,2,2,2,2,2,2],
+        [2,2,2,2,2,2,2,2],
+        [3,3,3,3,3,3,3,3]
+    ]
+    tokens_zipped = paddle.to_tensor(tokens_zipped, dtype='bfloat16')
+    routemap_topk = paddle.to_tensor(routemap_topk, dtype='int32')
+    probs_topk = paddle.to_tensor(probs_topk, dtype='bfloat16')
+    expected_unzipped_probs = paddle.to_tensor(expected_unzipped_probs, dtype='bfloat16')
+    expected_zipped_expertwise_rowmap = paddle.to_tensor(expected_zipped_expertwise_rowmap, dtype='int32')
+    expected_unzipped_tokens = paddle.to_tensor(expected_unzipped_tokens, dtype='bfloat16')
+    expected_unzipped_expert_idx = paddle.to_tensor(expected_unzipped_expert_idx, dtype='int32')
+
+    unzipped_tokens, zipped_expertwise_rowmap, unzipped_probs, unzipped_expert_idx = TDU.tokens_unzip(tokens_zipped,routemap_topk, probs_topk,total_unzipped_tokens_num=total_unzipped_tokens_num, topk=topk, num_experts=expert_num)
+
+    zipped_tokens = TDU.tokens_zip(unzipped_tokens, zipped_expertwise_rowmap, total_zipped_tokens=seqlen, num_experts=expert_num)
+    # ------------------------- 前向验证 ------------------------
+    print("-------- Tokens unzipped by customed op: ------------")
+    print(unzipped_tokens)
+    print("-------- Tokens expected : ------------")
+    print(expected_unzipped_tokens)
+    print("-------- Probs unzipped by customed op: ------------")
+    print(unzipped_probs)
+    print("-------- Probs expected: ------------")
+    print(expected_unzipped_probs)
+    print("-------- zipped expertwize rowmap by customed op: ------------")
+    print(zipped_expertwise_rowmap)
+    print("-------- rowmap expected: ------------")
+    print(expected_zipped_expertwise_rowmap)
+    print("-------- expert_idx unzipped by customed op: ------------")
+    print(unzipped_expert_idx)
+    print("-------- expert_idx expected: ------------")
+    print(expected_unzipped_expert_idx)
+    print("-------- zipped by customed op: ------------")
+    print(zipped_tokens)
+    print("-------- zipped expected: ------------")
+    print(tokens_simple_zipped)
+
+    
+def run():
+    verify_tokens_unzip()
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION


### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
Add tokens_zip op to perform zip operation more efficiently, substituing unpermute, optest is in  PaddleNLP/tests/ops/test_tokens_zip.py