### PR TITLE
[FIX] fix the bug for moe_gemm config searching  in sm86

### DIFF
--- a/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
+++ b/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
@@ -22,30 +22,28 @@
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <math.h>
+
 #include <optional>
 #include <sstream>
-#include "cutlass/array.h"
-#include "cutlass/numeric_conversion.h"
 
+#include "cutlass/array.h"
 #include "cutlass/gemm/device/gemm_grouped.h"
 #include "cutlass/gemm/kernel/default_gemm_grouped.h"
-
+#include "cutlass/numeric_conversion.h"
+#include "cutlass_kernels/moe_gemm/fused_moe_cutlass_kernel.h"
+#include "cutlass_kernels/moe_gemm/fused_moe_gemm_kernels.h"
 #include "paddle/common/errors.h"
 #include "paddle/phi/core/enforce.h"
-
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_extensions/compute_occupancy.h"
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_extensions/epilogue_helpers.h"
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h"
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/default_mma.h"
-#include "cutlass_kernels/moe_gemm/fused_moe_cutlass_kernel.h"
-#include "cutlass_kernels/moe_gemm/fused_moe_gemm_kernels.h"
 
 #pragma GCC diagnostic pop
 
+#include "helper.h"
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_kernels/cutlass_heuristic.h"
 #include "paddle/phi/kernels/fusion/cutlass/cutlass_kernels/gemm_config_manager.h"
-
-#include "helper.h"
 
 using namespace phi;
 // ============================= Variable batched Gemm things
@@ -207,7 +205,7 @@ void generic_moe_gemm_kernelLauncher(const T* A,
     std::string err_msg =
         "Failed to initialize cutlass variable batched gemm. Error: " +
         std::string(cutlassGetStatusString(init_status));
-    PADDLE_FATAL("[MoE Runner] " + err_msg);
+    throw std::runtime_error("[MoE Runner] " + err_msg);
   }
 
   auto run_status = gemm.run(stream);
@@ -215,7 +213,7 @@ void generic_moe_gemm_kernelLauncher(const T* A,
     std::string err_msg =
         "Failed to run cutlass variable batched gemm. Error: " +
         std::string(cutlassGetStatusString(run_status));
-    PADDLE_FATAL("[MoE Runner] " + err_msg);
+    throw std::runtime_error("[MoE Runner] " + err_msg);
   }
 }
 
@@ -670,55 +668,65 @@ void MoeGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(
     int profile_total_rows =
         std::min(gemmConfigManager.nextPowerOfTwo(total_rows),
                  gemmConfigManager.getMaxProfileM());
-
+    bool find_one = false;
     for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {
-      for (int i = 0; i < warm_time; i++) {
-        dispatch_to_arch<EpilogueTag>(A,
-                                      B,
-                                      weight_scales,
-                                      biases,
-                                      C,
-                                      total_rows_before_expert,
-                                      total_rows,
-                                      gemm_n,
-                                      gemm_k,
-                                      num_experts,
-                                      candidate_configs[ii],
-                                      stream);
-      }
-      cudaEvent_t start;
-      cudaEvent_t stop;
-      check_cuda_error(cudaEventCreate(&start));
-      check_cuda_error(cudaEventCreate(&stop));
-      check_cuda_error(cudaStreamSynchronize(stream));
-      check_cuda_error(cudaEventRecord(start, stream));
-      for (int i = 0; i < test_time; i++) {
-        dispatch_to_arch<EpilogueTag>(A,
-                                      B,
-                                      weight_scales,
-                                      biases,
-                                      C,
-                                      total_rows_before_expert,
-                                      total_rows,
-                                      gemm_n,
-                                      gemm_k,
-                                      num_experts,
-                                      candidate_configs[ii],
-                                      stream);
-      }
-      check_cuda_error(cudaEventRecord(stop, stream));
-      check_cuda_error(cudaEventSynchronize(stop));
-      float elapsed;
-      check_cuda_error(cudaEventElapsedTime(&elapsed, start, stop));
-      check_cuda_error(cudaEventDestroy(start));
-      check_cuda_error(cudaEventDestroy(stop));
-      if (elapsed < best_time) {
-        best_time = elapsed;
-        best_config = candidate_configs[ii];
+      try {
+        for (int i = 0; i < warm_time; i++) {
+          dispatch_to_arch<EpilogueTag>(A,
+                                        B,
+                                        weight_scales,
+                                        biases,
+                                        C,
+                                        total_rows_before_expert,
+                                        total_rows,
+                                        gemm_n,
+                                        gemm_k,
+                                        num_experts,
+                                        candidate_configs[ii],
+                                        stream);
+        }
+        cudaEvent_t start;
+        cudaEvent_t stop;
+        check_cuda_error(cudaEventCreate(&start));
+        check_cuda_error(cudaEventCreate(&stop));
+        check_cuda_error(cudaStreamSynchronize(stream));
+        check_cuda_error(cudaEventRecord(start, stream));
+        for (int i = 0; i < test_time; i++) {
+          dispatch_to_arch<EpilogueTag>(A,
+                                        B,
+                                        weight_scales,
+                                        biases,
+                                        C,
+                                        total_rows_before_expert,
+                                        total_rows,
+                                        gemm_n,
+                                        gemm_k,
+                                        num_experts,
+                                        candidate_configs[ii],
+                                        stream);
+        }
+        check_cuda_error(cudaEventRecord(stop, stream));
+        check_cuda_error(cudaEventSynchronize(stop));
+        float elapsed;
+        check_cuda_error(cudaEventElapsedTime(&elapsed, start, stop));
+        check_cuda_error(cudaEventDestroy(start));
+        check_cuda_error(cudaEventDestroy(stop));
+        if (elapsed < best_time) {
+          best_time = elapsed;
+          best_config = candidate_configs[ii];
+        }
+        find_one = true;
+      } catch (const std::exception& e) {
+        std::cerr << "MOE config[" << ii << "]  Caught exception: " << e.what()
+                  << std::endl;
       }
     }
-    gemmConfigManager.addBestConfig(gemmId, profile_total_rows, best_config);
-    chosen_config = best_config;
+    if (find_one) {
+      gemmConfigManager.addBestConfig(gemmId, profile_total_rows, best_config);
+      chosen_config = best_config;
+    } else {
+      PADDLE_FATAL("[MoE Configure Search] find no one avaliable config.");
+    }
   }
 
   dispatch_to_arch<EpilogueTag>(A,

--- a/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
+++ b/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
@@ -728,7 +728,6 @@ void MoeGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(
       PADDLE_FATAL("[MoE Configure Search] find no one avaliable config.");
     }
   }
-
   dispatch_to_arch<EpilogueTag>(A,
                                 B,
                                 weight_scales,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

在RTX A6000显卡(sm=86)上执行MOE GEMM配置搜索时，由于A6000的sm上最大动态共享内存小于A100(sm=80)的最大动态共享内存，导致在部分使用共享内存比较大的配置中执行失败，使得模型推理失败。具体报错如下

```shell
([MoE Runner] Failed to run cutlass variable batched gemm. ) Error Internal (at ./gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h:218)
```

本PR给搜索过程添加了异常捕获，在执行到不可用的配置时并不直接退出，最后使用可用且合适的配置执行模型推理。

```python
python ./predict/predictor.py --model_name_or_path deepseek-ai/DeepSeek-V2-Lite-Chat --dtype bfloat16 --mode dynamic --decode_strategy greedy_search --inference_model 1 --block_attn 1 --append_attn 1 --mla_use_matrix_absorption 1 --batch_size 2 --quant_type weight_only_int4 --weightonly_group_size 64
```

结果如下：
```shell
[2025-04-01 12:47:20,760] [    INFO] - Start read result message
[2025-04-01 12:47:20,761] [    INFO] - Current path is /workspace/PaddleNLP/llm
MOE config[15]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[19]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[20]  Caught exception: [MoE Runner] Failed to run cutlass variable batched gemm. Error: Error Internal
MOE config[15]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[19]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[20]  Caught exception: [MoE Runner] Failed to run cutlass variable batched gemm. Error: Error Internal
MOE config[15]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[19]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[20]  Caught exception: [MoE Runner] Failed to run cutlass variable batched gemm. Error: Error Internal
MOE config[15]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[19]  Caught exception: [MoE Runner] Failed to initialize cutlass variable batched gemm. Error: Error Internal
MOE config[20]  Caught exception: [MoE Runner] Failed to run cutlass variable batched gemm. Error: Error Internal
[2025-04-01 12:47:34,829] [    INFO] - running spend 14.069046020507812
[2025-04-01 12:47:34,835] [    INFO] - Finish read result message
[2025-04-01 12:47:34,865] [    INFO] - End predict
***********Source**********
2014年3月，大范围雾霾天气长时间影响我国东部地区，严重危害人体健康。造成雾霾天气的人为原因有____
①工业生产中使用矿物作为燃料，大量排放污染物     ②汽车尾气的大量排放     
③风力小，空气流动不畅     ④冬季取暖排放粉尘
A. ①②③
B. ②③④
C. ①③④
D. ①②④
***********Target**********

***********Output**********
 这道题目是关于雾霾天气的人为原因的选择题。雾霾天气主要是由于空气中的悬浮颗粒物（PM2.5和PM1 Moore）超标引起的。这些颗粒物主要来源于人类活动，包括工业生产、汽车尾气排放、冬季取暖等。

选项①"工业生产中使用矿物作为燃料，大量排放污染物"，这是人为原因之一。因为矿物燃料燃烧会产生大量的二氧化硫、氮氧化物等污染物，这些污染物是形成雾霾的主要成分。

选项②"汽车尾气的大量排放"，这也是人为原因之一。汽车尾气中含有大量的氮氧化物、一氧化碳等污染物，这些污染物也是形成雾霾的主要成分。

选项③"风力小，空气流动不畅"，这是自然因素，与人为活动无关。风力小，空气流动不畅，会导致污染物在地面附近积聚，形成雾霾。

选项④"冬季取暖排放粉尘"，这也是人为原因之一。冬季取暖，尤其是燃煤取暖，会产生大量的粉尘，这些粉尘也是形成雾霾的主要成分。

所以，造成雾霾天气的人为原因有①工业生产中使用矿物作为燃料，大量排放污染物和②汽车尾气的大量排放和④冬季取暖排放粉尘，答案是D. ①②④。
***********Source**********
2014年3月，大范围雾霾天气长时间影响我国东部地区，严重危害人体健康。造成雾霾天气的人为原因有____
①工业生产中使用矿物作为燃料，大量排放污染物     ②汽车尾气的大量排放     
③风力小，空气流动不畅     ④冬季取暖排放粉尘
A. ①②③
B. ②③④
C. ①③④
D. ①②④
***********Target**********

***********Output**********
 这道题目是关于雾霾天气的人为原因的选择题。雾霾天气主要是由于空气中的悬浮颗粒物（PM2.5和PM1 Moore）超标引起的。这些颗粒物主要来源于人类活动，包括工业生产、汽车尾气排放、冬季取暖等。

选项①"工业生产中使用矿物作为燃料，大量排放污染物"，这是人为原因之一。因为矿物燃料燃烧会产生大量的二氧化硫、氮氧化物等污染物，这些污染物是形成雾霾的主要成分。

选项②"汽车尾气的大量排放"，这也是人为原因之一。汽车尾气中含有大量的氮氧化物、一氧化碳等污染物，这些污染物也是形成雾霾的主要成分。

选项③"风力小，空气流动不畅"，这是自然因素，与人为活动无关。风力小，空气流动不畅，会导致污染物在地面附近积聚，形成雾霾。

选项④"冬季取暖排放粉尘"，这也是人为原因之一。冬季取暖，尤其是燃煤取暖，会产生大量的粉尘，这些粉尘也是形成雾霾的主要成分。

所以，造成雾霾天气的人为原因有①工业生产中使用矿物作为燃料，大量排放污染物和②汽车尾气的大量排放和④冬季取暖排放粉尘，答案是D. ①②④。
```

