### PR TITLE
Fix fused_act_dequant op with memset output to 0

### DIFF
--- a/slm/model_zoo/gpt-3/external_ops/fused_quanted_ops/fused_act_dequant.cu
+++ b/slm/model_zoo/gpt-3/external_ops/fused_quanted_ops/fused_act_dequant.cu
@@ -106,7 +106,7 @@ std::vector<paddle::Tensor> fused_act_dequant(
     reinterpret_cast<void *>(out.data<phi::bfloat16>());
   cudaMemsetAsync(out_ptr,
                   0,
-                  sizeof(phi::bfloat16) * row * cols,
+                  sizeof(phi::bfloat16) * rows * cols,
                   out.stream());
   dispatch_fused_act_dequant(
       X,

--- a/slm/model_zoo/gpt-3/external_ops/fused_quanted_ops/fused_act_dequant.cu
+++ b/slm/model_zoo/gpt-3/external_ops/fused_quanted_ops/fused_act_dequant.cu
@@ -100,7 +100,14 @@ std::vector<paddle::Tensor> fused_act_dequant(
   rows = X.shape()[0];
   cols = X.shape()[1];
   paddle::Tensor out;
+  
   out = paddle::empty({rows, cols}, paddle::DataType::BFLOAT16, X.place());
+  auto out_ptr =
+    reinterpret_cast<void *>(out.data<phi::bfloat16>());
+  cudaMemsetAsync(out_ptr,
+                  0,
+                  sizeof(phi::bfloat16) * row * cols,
+                  out.stream());
   dispatch_fused_act_dequant(
       X,
       Xscale,


### PR DESCRIPTION


### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
Fix fused_act_dequant op with memset output to 0
