### PR TITLE
Undo old cupti patch to improve fp8 gemm performance

### DIFF
--- a/ops/csrc/fp8/deep_gemm/include/deep_gemm/tma_utils.cuh
+++ b/ops/csrc/fp8/deep_gemm/include/deep_gemm/tma_utils.cuh
@@ -63,15 +63,13 @@ PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled() {
     cudaDriverEntryPointQueryResult driver_status;
     void* cuTensorMapEncodeTiled_ptr = nullptr;
 
-/*
 #if CUDA_VERSION >= 12050
     cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &cuTensorMapEncodeTiled_ptr, 12000,
                                      cudaEnableDefault, &driver_status);
 #else
-*/
     cudaGetDriverEntryPoint("cuTensorMapEncodeTiled", &cuTensorMapEncodeTiled_ptr,
                             cudaEnableDefault, &driver_status);
-//#endif
+#endif
 
     if (driver_status != cudaDriverEntryPointSuccess)
         throw std::runtime_error("driver_status != cudaDriverEntryPointSuccess");


### PR DESCRIPTION

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
Undo old cupti patch to improve fp8 gemm performance
