### PR TITLE
[CI] Revert `fused_rms_norm` for auto_parallel

### DIFF
--- a/paddlenlp/transformers/llama/fusion_ops.py
+++ b/paddlenlp/transformers/llama/fusion_ops.py
@@ -136,14 +136,8 @@ def rms_norm_fused(x_in, w, eps, use_fast_ln=False):
         fast_ln = try_import("fast_ln")
         return fast_ln.fast_rms_norm(x_in, w, eps)[0]
     else:
-        try:
-            from paddle.incubate.nn.functional import fused_rms_norm
-
-            return fused_rms_norm(x=x_in, norm_weight=w, norm_bias=None, epsilon=eps, begin_norm_axis=2)[0]
-        except ImportError:
-            fused_ln = try_import("fused_ln")
-
-            return fused_ln.fused_rms_norm(x_in, w, eps)[0]
+        fused_ln = try_import("fused_ln")
+        return fused_ln.fused_rms_norm(x_in, w, eps)[0]
 
 
 def fusion_rms_norm(hidden_states, weight, variance_epsilon, use_fast_ln=False):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Revert `fused_rms_norm` for auto_parallel.