### PR TITLE
【Inference Fix Bug】 fix moe_expert_reduce op output shape

### DIFF
--- a/csrc/gpu/moe/fused_moe/moe_reduce.cu
+++ b/csrc/gpu/moe/fused_moe/moe_reduce.cu
@@ -117,9 +117,8 @@ std::vector<std::vector<int64_t>> MoeExpertReduceInferShape(
     const std::vector<int64_t>& top_k_indices_shape,
     const paddle::optional<std::vector<int64_t>>& ffn2_bias_shape) {
   const int topk = top_k_indices_shape[1];
-  const int num_rows = ffn_out_shape[0] / topk;
-  const int hidden_size = ffn_out_shape[1];
-  std::vector<int64_t> fused_moe_out_shape = {num_rows, hidden_size};
+  std::vector<int64_t> fused_moe_out_shape = {ffn_out_shape[0] / topk,
+                                              ffn_out_shape[1]};
 
   return {fused_moe_out_shape};
 }

--- a/csrc/gpu/moe/fused_moe/moe_reduce.cu
+++ b/csrc/gpu/moe/fused_moe/moe_reduce.cu
@@ -74,8 +74,7 @@ std::vector<paddle::Tensor> MoeExpertReduce(
   auto output = GetEmptyTensor({num_rows, hidden_size}, input_type, place);
 
   // Avoids ‘invalid configuration argument’ when we launch the kernel.
-  if(ffn_out.dims()[0] == 0 )
-    return {output};
+  if (ffn_out.dims()[0] == 0) return {output};
 
   switch (input_type) {
     case paddle::DataType::BFLOAT16:
@@ -117,7 +116,12 @@ std::vector<std::vector<int64_t>> MoeExpertReduceInferShape(
     const std::vector<int64_t>& permute_indices_per_token_shape,
     const std::vector<int64_t>& top_k_indices_shape,
     const paddle::optional<std::vector<int64_t>>& ffn2_bias_shape) {
-  return {ffn_out_shape};
+  const int topk = top_k_indices_shape[1];
+  const int num_rows = ffn_out_shape[0] / topk;
+  const int hidden_size = ffn_out_shape[1];
+  std::vector<int64_t> fused_moe_out_shape = {num_rows, hidden_size};
+
+  return {fused_moe_out_shape};
 }
 
 std::vector<paddle::DataType> MoeExpertReduceInferDtype(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
*Fixed the problem of wrong output shape of moe_export_reduce
