### PR TITLE
【PaddleNLP No.5】Update simcse to apply PIR

### DIFF
--- a/slm/applications/neural_search/recall/simcse/README.md
+++ b/slm/applications/neural_search/recall/simcse/README.md
@@ -149,6 +149,12 @@ simcse/
 
 <a name="模型训练"></a>
 
+下载数据集并解压到当前目录：
+```shell
+wget https://bj.bcebos.com/v1/paddlenlp/data/literature_search_data.zip
+unzip literature_search_data.zip
+```
+
 ## 5. 模型训练
 
 **语义索引预训练模型下载链接：**

--- a/slm/applications/neural_search/recall/simcse/deploy/python/deploy.sh
+++ b/slm/applications/neural_search/recall/simcse/deploy/python/deploy.sh
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-python predict.py --model_dir=../../output
+python deploy/python/predict.py --model_dir=./output

--- a/slm/applications/neural_search/recall/simcse/deploy/python/predict.py
+++ b/slm/applications/neural_search/recall/simcse/deploy/python/predict.py
@@ -16,12 +16,17 @@ import argparse
 import os
 import sys
 
+import numpy as np
 import paddle
 from paddle import inference
 from scipy import spatial
 
 from paddlenlp.data import Pad, Tuple
 from paddlenlp.transformers import AutoTokenizer
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 from paddlenlp.utils.log import logger
 
 sys.path.append(".")
@@ -90,8 +95,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):
@@ -238,6 +243,9 @@ class Predictor(object):
 
         if args.benchmark:
             self.autolog.times.end(stamp=True)
+
+        query_logits = np.atleast_2d(query_logits)
+        title_logits = np.atleast_2d(title_logits)
         result = [float(1 - spatial.distance.cosine(arr1, arr2)) for arr1, arr2 in zip(query_logits, title_logits)]
         return result
 


### PR DESCRIPTION
### PR types
 Function optimization

### PR changes
Models

### Description
Updated ```slm/applications/neural_search/recall/simcse/README.md``` to include instructions for downloading and unzipping the required data.
Modified ```deploy.sh``` to ensure it can be executed directly from ```slm/applications/neural_search/recall/simcse/```, aligning with the structure of other scripts.
Updated ```slm/applications/neural_search/recall/simcse/deploy/python/predict.py``` to support PIR.

issue: https://github.com/PaddlePaddle/PaddleNLP/issues/9763
@DrownFish19

### 其他问题
发现在paddle3.0.0下simcse模型无法成功转换为静态模型，执行导出脚本输出如下：
```
aistudio@jupyter-227232-8957468:~/PaddleNLP/slm/applications/neural_search/recall/simcse$ python export_model.py --params_path checkpoints/model_7000/model_state.pdparams                        --model_name_or_path rocketqa-zh-base-query-encoder                        --output_path=./output
/home/aistudio/.local/lib/python3.8/site-packages/paddle/jit/dy2static/program_translator.py:768: UserWarning: full_graph=False don't support input_spec arguments. It will not produce any effect.
You can set full_graph=True, then you can assign input spec.

  warnings.warn(
/home/aistudio/.local/lib/python3.8/site-packages/_distutils_hack/__init__.py:26: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
[2025-04-11 12:00:06,888] [    INFO] - We are using <class 'paddlenlp.transformers.ernie.modeling.ErnieModel'> to load 'rocketqa-zh-base-query-encoder'.
[2025-04-11 12:00:06,890] [    INFO] - Loading weights file from cache at /home/aistudio/.paddlenlp/models/rocketqa-zh-base-query-encoder/model_state.pdparams
[2025-04-11 12:00:07,779] [    INFO] - Loaded weights file from disk, setting weights to model.
W0411 12:00:10.467890 54098 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.0, Runtime API Version: 12.6
W0411 12:00:10.472265 54098 gpu_resources.cc:164] device: 0, cuDNN Version: 9.5.
W0411 12:00:10.472301 54098 gpu_resources.cc:196] WARNING: device: 0. The installed Paddle is compiled with CUDA 12.6, but CUDA runtime version in your machine is 12.0, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDA version.
[2025-04-11 12:00:11,455] [ WARNING] - Some weights of the model checkpoint at rocketqa-zh-base-query-encoder were not used when initializing ErnieModel: ['classifier.bias', 'classifier.weight']
- This IS expected if you are initializing ErnieModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing ErnieModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
[2025-04-11 12:00:11,455] [    INFO] - All the weights of ErnieModel were initialized from the model checkpoint at rocketqa-zh-base-query-encoder.
If your task is similar to the task the model of the checkpoint was trained on, you can already use ErnieModel for predictions without further training.
[2025-04-11 12:00:11,479] [    INFO] - We are using <class 'paddlenlp.transformers.ernie.tokenizer.ErnieTokenizer'> to load 'rocketqa-zh-base-query-encoder'.
[2025-04-11 12:00:11,502] [    INFO] - tokenizer config file saved in /home/aistudio/.paddlenlp/models/rocketqa-zh-base-query-encoder/tokenizer_config.json
[2025-04-11 12:00:11,502] [    INFO] - Special tokens file saved in /home/aistudio/.paddlenlp/models/rocketqa-zh-base-query-encoder/special_tokens_map.json
Loaded parameters from checkpoints/model_7000/model_state.pdparams
/home/aistudio/.local/lib/python3.8/site-packages/paddle/jit/dy2static/program_translator.py:768: UserWarning: full_graph=False don't support input_spec arguments. It will not produce any effect.
You can set full_graph=True, then you can assign input spec.

  warnings.warn(
```
导致转换后的模型在```deploy/python/predict.py```中运行结果为空，尝试在```export_model.py```中显示```full_graph=True```但并没什么效果，参考https://github.com/PaddlePaddle/Paddle/issues/69119 ，应该是默认开启的。尝试不传```input_spec```依旧报错：
```
[2025-04-11 12:13:07,143] [    INFO] - Special tokens file saved in /home/aistudio/.paddlenlp/models/rocketqa-zh-base-query-encoder/special_tokens_map.json
Loaded parameters from checkpoints/model_7000/model_state.pdparams
Traceback (most recent call last):
  File "export_model.py", line 58, in <module>
    paddle.jit.save(model, save_path)
  File "/usr/local/lib/python3.8/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/wrapped_decorator.py", line 40, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/jit/api.py", line 901, in wrapper
    func(layer, path, input_spec, **configs)
  File "/usr/local/lib/python3.8/dist-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/wrapped_decorator.py", line 40, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/base/dygraph/base.py", line 101, in __impl__
    return func(*args, **kwargs)
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/jit/api.py", line 1215, in save
    static_func.concrete_program_specify_input_spec(
  File "/home/aistudio/.local/lib/python3.8/site-packages/paddle/jit/dy2static/program_translator.py", line 1079, in concrete_program_specify_input_spec
    raise ValueError(
ValueError: No valid transformed program for function: forward(query_input_ids,title_input_ids,query_token_type_ids,query_position_ids,query_attention_mask,title_token_type_ids,title_position_ids,title_attention_mask), input_spec: None.
            Please specific `input_spec` in `@paddle.jit.to_static` or feed input tensor to call the decorated function at once.
```