### PR TITLE
Add pid and start timestamp to metrics dump (#10142)

### DIFF
--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -19,6 +19,7 @@ import functools
 import json
 import logging
 import multiprocessing
+import os
 import signal
 import threading
 import time

--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -148,6 +148,9 @@ class MetricsDumper(object):
         self.process = multiprocessing.Process(target=self._write_json, args=(self.queue,))
         self.process.start()
 
+        # process pid and the start time
+        self.pid = os.getpid()
+
         # Ensure subprocess exits when main process is interrupted
         signal.signal(signal.SIGINT, self._signal_handler)
         signal.signal(signal.SIGTERM, self._signal_handler)
@@ -160,6 +163,7 @@ class MetricsDumper(object):
 
         :param data: The JSON object to append.
         """
+        data.update({"metrics_dumper_pid": self.pid, "metrics_dumper_timestamp": int(time.time() * 1000)})
         self.queue.put(data)
 
     def _write_json(self, queue):


### PR DESCRIPTION
* Add pid and start timestamp to metrics dump

* update start timestamp

<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Add pid and start timestamp to metrics dump