### PR TITLE
[LLM] Fix the communication group settings in the moe_layer

### DIFF
--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -176,7 +176,11 @@ class MoELayer(nn.Layer):
         except AttributeError:
             is_fleet_init = False
 
-        if is_fleet_init and dist.get_world_size() > 1 and moe_group == "data":
+        if (
+            is_fleet_init
+            and dist.fleet.get_hybrid_communicate_group().get_data_parallel_world_size() > 1
+            and moe_group == "data"
+        ):
             self.moe_group = dist.fleet.get_hybrid_communicate_group().get_data_parallel_group()
             self.moe_rank = dist.get_rank(self.moe_group)
             self.moe_rank = 0 if self.moe_rank < 0 else self.moe_rank


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Fix the communication group settings in the moe_layer.

In the following lines, `self.gate.group` will be set to `self.moe_group`. When the world_size > 1 and not in the data_group, the `self.gate.group` is not necessary. We remove the settings and avoid the warning like `xxxx/lib/python3.10/site-packages/paddle/distributed/communication/group.py:128: UserWarning: Current global rank 0 is not in group _default_pg12`

https://github.com/PaddlePaddle/PaddleNLP/blob/7d6417bc1d6a34d5037047dd038ca64eaae5a5e4/paddlenlp/transformers/moe_layer.py#L179-L209
