### PR TITLE
[Inference] fix the bug for dynamic/static inference and dy2st for deepseekv2 in weight only int4/int8

### DIFF
--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -2687,7 +2687,7 @@ class FusedMultiTransformerA8W8(FusedMultiTransformerBase):
 
         return ln_out
 
-    def compute_qkv_linear(self, ln_out, i):
+    def compute_qkv_linear(self, ln_out, i, **kwargs):
         if self.config.mla_config.use_mla():
             raise NotImplementedError("Not support MLA yet.")
         else:
@@ -5138,7 +5138,7 @@ class FusedBlockMultiTransformerFP8(FusedBlockMultiTransformer):
 
         return ln_out
 
-    def compute_qkv_linear(self, ln_out, i):
+    def compute_qkv_linear(self, ln_out, i, **kwargs):
         if self.config.mla_config.use_mla():
             raise NotImplementedError("Not support MLA yet.")
         else:

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -2055,10 +2055,7 @@ class FusedMultiTransformerWeightOnly(FusedMultiTransformerBase):
                 epsilon=self._epsilon,
                 begin_norm_axis=1,
             )[0]
-            idx = kwargs.get("seq_lens_encoder", None).sum()
-            query_pe, key_pe = self.config.rotary_emb(
-                self.position_ids[0:idx] if idx > 0 else self.position_ids, query_pe, key_pe
-            )
+            query_pe, key_pe = self.config.rotary_emb(self.position_ids, query_pe, key_pe)
 
             if self.config.mla_config.use_absorb():
                 from paddlenlp_ops import prefill_mla_write_cache

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -1131,13 +1131,13 @@ class FusedMultiTransformerBase(Layer):
                 qkv_out = paddle.add(qkv_out, self.qkv_biases[i])
             return qkv_out
 
-    def compute_qkv(self, src, residual_input, i):
+    def compute_qkv(self, src, residual_input, i, **kwargs):
         ln_out = self.compute_layernorm_before_qkv(src, i)
 
         if self.config.mla_config.use_absorb():
             qkv_out = ln_out
         else:
-            qkv_out = self.compute_qkv_linear(ln_out, i)
+            qkv_out = self.compute_qkv_linear(ln_out, i, **kwargs)
 
         return qkv_out, residual_input
 
@@ -1523,7 +1523,7 @@ class FusedMultiTransformerBase(Layer):
 
         residual_input = src
         for i in range(self.num_layers):
-            qkv_out, residual_input = self.compute_qkv(src, residual_input, i)
+            qkv_out, residual_input = self.compute_qkv(src, residual_input, i, **kwargs)
             fmha_out = self.compute_attn(
                 time_step,
                 qkv_out,

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -2055,8 +2055,9 @@ class FusedMultiTransformerWeightOnly(FusedMultiTransformerBase):
                 epsilon=self._epsilon,
                 begin_norm_axis=1,
             )[0]
+            idx = kwargs.get("seq_lens_encoder", None).sum()
             query_pe, key_pe = self.config.rotary_emb(
-                self.position_ids[0 : kwargs.get("seq_lens_encoder", None).sum()], query_pe, key_pe
+                self.position_ids[0:idx] if idx > 0 else self.position_ids, query_pe, key_pe
             )
 
             if self.config.mla_config.use_absorb():

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -1596,7 +1596,7 @@ class FusedMultiTransformerPostLayernorm(FusedMultiTransformerBase):
     def __init__(self, config: FusedMultiTransformerConfig):
         super().__init__(config)
 
-    def compute_qkv(self, src, residual_input, i):
+    def compute_qkv(self, src, residual_input, i, **kwargs):
         qkv_out = self.compute_qkv_linear(src, i)
         return qkv_out, src
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

修复deepseekv2，使用weight only int4/int8时，在动态图/静态图推理以及动转静导出模型时的bug。

指令
```shell
cd llm

# dynamic

python ./predict/predictor.py --model_name_or_path deepseek-ai/DeepSeek-V2-Lite-Chat --dtype bfloat16 --quant_type weight_only_int8 --mode dynamic --inference_model 1 --append_attn 1

python ./predict/predictor.py --model_name_or_path deepseek-ai/DeepSeek-V2-Lite-Chat --dtype bfloat16 --quant_type weight_only_int4 --mode dynamic --inference_model 1 --append_attn 1 --mla_use_matrix_absorption 1 --weightonly_group_size 64

# export

python predict/export_model.py --model_name_or_path deepseek-ai/DeepSeek-V2-Lite-Chat --output_path ./DeepSeek-V2-Lite-Chat --dtype bfloat16 --quant_type weight_only_int8 --inference_model 1 --append_attn 1

python predict/export_model.py --model_name_or_path deepseek-ai/DeepSeek-V2-Lite-Chat --output_path ./DeepSeek-V2-Lite-Chat --dtype bfloat16 --quant_type weight_only_int4 --mode dynamic --inference_model 1 --append_attn 1 --mla_use_matrix_absorption 1 --weightonly_group_size 64

# static

python predict/predictor.py --model_name_or_path ./DeepSeek-V2-Lite-Chat --dtype bfloat16 --mode static

python predict/predictor.py --model_name_or_path ./DeepSeek-V2-Lite-Chat --dtype bfloat16 --mode static --quant_type weight_only_int4 --inference_model 1 --append_attn 1 --mla_use_matrix_absorption 1 --weightonly_group_size 64
```