### PR TITLE
【PaddleNLP No.6】Fix text_classification PIR

### DIFF
--- a/slm/applications/text_classification/hierarchical/retrieval_based/deploy/python/predict.py
+++ b/slm/applications/text_classification/hierarchical/retrieval_based/deploy/python/predict.py
@@ -22,6 +22,10 @@ from scipy import spatial
 
 from paddlenlp.data import Pad, Tuple
 from paddlenlp.transformers import AutoTokenizer
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 sys.path.append(".")
 
@@ -114,8 +118,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):

--- a/slm/applications/text_classification/hierarchical/retrieval_based/utils/feature_extract.py
+++ b/slm/applications/text_classification/hierarchical/retrieval_based/utils/feature_extract.py
@@ -22,6 +22,10 @@ from tqdm import tqdm
 
 import paddlenlp as ppnlp
 from paddlenlp.data import Pad, Tuple
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 # fmt: off
 parser = argparse.ArgumentParser()
@@ -82,8 +86,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):

--- a/slm/applications/text_classification/multi_class/retrieval_based/deploy/python/predict.py
+++ b/slm/applications/text_classification/multi_class/retrieval_based/deploy/python/predict.py
@@ -22,6 +22,10 @@ from scipy import spatial
 
 from paddlenlp.data import Pad, Tuple
 from paddlenlp.transformers import AutoTokenizer
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 sys.path.append(".")
 
@@ -114,8 +118,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):

--- a/slm/applications/text_classification/multi_class/retrieval_based/utils/feature_extract.py
+++ b/slm/applications/text_classification/multi_class/retrieval_based/utils/feature_extract.py
@@ -22,6 +22,10 @@ from tqdm import tqdm
 
 import paddlenlp as ppnlp
 from paddlenlp.data import Pad, Tuple
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 # fmt: off
 parser = argparse.ArgumentParser()
@@ -83,8 +87,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):

--- a/slm/applications/text_classification/multi_label/README.md
+++ b/slm/applications/text_classification/multi_label/README.md
@@ -355,7 +355,7 @@ python export_model.py --params_path ./checkpoint/ --output_path ./export --mult
 export/
 ├── float32.pdiparams
 ├── float32.pdiparams.info
-└── float32.pdmodel
+└── float32.json(PIR enabled)/float32.pdmodel(PIR disabled)
 ```
  导出模型之后用于部署，项目提供了基于 ONNXRuntime 的 [离线部署方案](./deploy/predictor/README.md) 和基于 Paddle Serving 的 [在线服务化部署方案](./deploy/predictor/README.md)。
 

--- a/slm/applications/text_classification/multi_label/retrieval_based/deploy/python/predict.py
+++ b/slm/applications/text_classification/multi_label/retrieval_based/deploy/python/predict.py
@@ -22,6 +22,10 @@ from scipy import spatial
 
 from paddlenlp.data import Pad, Tuple
 from paddlenlp.transformers import AutoTokenizer
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 sys.path.append(".")
 
@@ -114,8 +118,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):

--- a/slm/applications/text_classification/multi_label/retrieval_based/utils/feature_extract.py
+++ b/slm/applications/text_classification/multi_label/retrieval_based/utils/feature_extract.py
@@ -22,6 +22,10 @@ from tqdm import tqdm
 
 import paddlenlp as ppnlp
 from paddlenlp.data import Pad, Tuple
+from paddlenlp.utils.env import (
+    PADDLE_INFERENCE_MODEL_SUFFIX,
+    PADDLE_INFERENCE_WEIGHTS_SUFFIX,
+)
 
 # fmt: off
 parser = argparse.ArgumentParser()
@@ -84,8 +88,8 @@ class Predictor(object):
         self.max_seq_length = max_seq_length
         self.batch_size = batch_size
 
-        model_file = model_dir + "/inference.get_pooled_embedding.pdmodel"
-        params_file = model_dir + "/inference.get_pooled_embedding.pdiparams"
+        model_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        params_file = model_dir + f"/inference.get_pooled_embedding{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
         if not os.path.exists(model_file):
             raise ValueError("not find model file path {}".format(model_file))
         if not os.path.exists(params_file):


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
1. 添加text_classification中rretrieval_based的hierarchical/multi_class/multi_label模型基于paddle.inference推理对PIR的适配；
2. 修改设计到导出模型的文档。
修改部分可以成功运行推理。
```
I0425 05:49:54.312034 17340 pir_interpreter.cc:1640] pir interpreter is running by trace mode ...
(1, 768)
......
   5.13511896e-02  1.27085205e-02 -1.99236199e-02 -3.18305828e-02
  -6.04303088e-03 -2.46610641e-02 -1.73023611e-03 -6.33593462e-03
  -1.72202699e-02  1.04825031e-02 -5.76227345e-03 -2.10440122e-02
   4.56353836e-02 -1.11948913e-02  3.09750624e-02  4.88217883e-02
   6.00924827e-02 -1.12980399e-02  2.02461407e-02  4.56624702e-02
  -2.55786590e-02  3.89200114e-02 -9.09841619e-03  4.24942374e-02
  -6.72577918e-02  7.34342411e-02  2.94713527e-02 -5.68274520e-02
   5.37596755e-02 -2.73752045e-02  2.10331194e-02  4.71913368e-02]]
[0.6664873361587524, 0.4887930154800415]
```

Modified:
1. ```slm/applications/text_classification/hierarchical/retrieval_based/deploy/python/predict.py```
2. ```slm/applications/text_classification/hierarchical/retrieval_based/utils/feature_extract.py```
3. ```slm/applications/text_classification/multi_class/retrieval_based/deploy/python/predict.py```
4. ```slm/applications/text_classification/multi_class/retrieval_based/utils/feature_extract.py```
5. ```slm/applications/text_classification/multi_label/README.md```
6. ```slm/applications/text_classification/multi_label/retrieval_based/deploy/python/predict.py```
7. ```slm/applications/text_classification/multi_label/retrieval_based/utils/feature_extract.py```

### 其他问题
1. 本次修改验证了三个模型的训练、导出及paddle.inference推理。没有修改paddle_serving, simple_serving, triton_serving及onnx部署的内容，因为其已经无法与paddle3.0.0适配，如onnx部署：
```
[2025-04-24 11:21:34,047] [    INFO] - >>> [InferBackend] Creating Engine ...
Traceback (most recent call last):
  File "infer.py", line 69, in <module>
    predictor = Predictor(args, label_list)
  File "/home/aistudio/PaddleNLP/slm/applications/text_classification/hierarchical/deploy/predictor/predictor.py", line 121, in __init__
    self.inference_backend = InferBackend(
  File "/home/aistudio/PaddleNLP/slm/applications/text_classification/hierarchical/deploy/predictor/predictor.py", line 35, in __init__
    onnx_model = paddle2onnx.export(
TypeError: export() got an unexpected keyword argument 'model_file'
```
2. 没有修改few-shot的部分，根据[文档](https://github.com/PaddlePaddle/PaddleNLP/blob/develop/slm/applications/text_classification/multi_class/few-shot/README.md)该部分将在未来删除，并推荐使用其他zero-shot模型。

Issue: https://github.com/PaddlePaddle/PaddleNLP/issues/9763
@DrownFish19
