### PR TITLE
[PIR] Update paddle.inference infer example for Ernie-vil2.0

### DIFF
--- a/slm/examples/lexical_analysis/README.md
+++ b/slm/examples/lexical_analysis/README.md
@@ -108,6 +108,12 @@ python export_model.py --data_dir=./lexical_analysis_dataset_tiny --params_path=
 
 导出模型之后，可以用于部署，deploy/predict.py 文件提供了 python 部署预测示例。运行方式：
 
+开启 PIR（PaddlePaddle 3.0.0默认）：
+```shell
+python deploy/predict.py --model_file=infer_model/static_graph_params.json --params_file=infer_model/static_graph_params.pdiparams --data_dir lexical_analysis_dataset_tiny
+```
+
+未开启 PIR：
 ```shell
 python deploy/predict.py --model_file=infer_model/static_graph_params.pdmodel --params_file=infer_model/static_graph_params.pdiparams --data_dir lexical_analysis_dataset_tiny
 ```

--- a/slm/model_zoo/ernie-vil2.0/README.md
+++ b/slm/model_zoo/ernie-vil2.0/README.md
@@ -135,13 +135,10 @@ Tensor(shape=[1, 2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
 ```shell
 mkdir -p data/datasets
 wget https://paddlenlp.bj.bcebos.com/datasets/Flickr30k-CN.tar.gz
-tar -xzvf Flickr30k-CN.tar.gz -d data/datasets/
+tar -xzvf Flickr30k-CN.tar.gz -C data/datasets/
+mv data/datasets/Flickr30k-CN_copy data/datasets/Flickr30k-CN
 
-python preprocess/create_arrow_dataset.py \
-    --data_dir data/datasets/Flickr30k-CN \
-    --splits train,valid,test \
-    --image_dir data/datasets/Flickr30k-CN/image \
-    --t2i_type   jsonl
+python preprocess/create_arrow_dataset.py   --data_dir data/datasets/Flickr30k-CN  --image_dir data/datasets/Flickr30k-CN/image   --splits train,valid,test
 ```
 执行完后，data 目录应是如下结构：
 
@@ -337,19 +334,21 @@ python predict.py --resume output_pd/checkpoint-600/ --image_path examples/21285
 
 ```
 ......
-         -0.15448952,  0.72006893,  0.36882138, -0.84108782,  0.37967119,
-          0.12349987, -1.02212155, -0.58292383,  1.48998547, -0.46960664,
-          0.30193087, -0.56355256, -0.30767381, -0.34489608,  0.59651250,
-         -0.49545336, -0.95961350,  0.68815416,  0.47264558, -0.25057256,
-         -0.61301452,  0.09002528, -0.03568697]])
+          0.30446628, -0.40303054, -0.44902760, -0.20834517,  0.61418092,
+         -0.47503090, -0.90602577,  0.61230117,  0.31328726, -0.30551922,
+         -0.70518905,  0.02921746, -0.06500954]])
 Text features
-Tensor(shape=[2, 768], dtype=float32, place=Place(cpu), stop_gradient=True,
-       [[ 0.04250492, -0.41429815,  0.26164034, ...,  0.26221907,
-          0.34387457,  0.18779679],
-        [ 0.06672275, -0.41456315,  0.13787840, ...,  0.21791621,
-          0.36693257,  0.34208682]])
-Label probs: Tensor(shape=[1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
-       [[0.99110782, 0.00889216]])
+Tensor(shape=[2, 768], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+       [[ 0.04464678, -0.43012181,  0.25478637, ...,  0.27861869,
+          0.36597741,  0.20715161],
+        [ 0.06647702, -0.43343985,  0.12268012, ...,  0.23637798,
+          0.38784462,  0.36298674]])
+model temperature
+Parameter containing:
+Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=False,
+       [4.29992294])
+Label probs: Tensor(shape=[1, 2], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+       [[0.99257678, 0.00742322]])
 ```
 可以看到`猫的照片`的相似度更高，结果符合预期。
 
@@ -372,15 +371,11 @@ python export_model.py --model_path=output_pd/checkpoint-600/ \
 
 对于导出的模型，我们提供了 Python 的 infer 脚本，调用预测库对简单的例子进行预测。
 ```shell
-python deploy/python/infer.py --model_dir ./infer_model/
+python deploy/python/infer.py --model_dir ./infer_model/ --image_path examples/212855663-c0a54707-e14c-4450-b45d-0162ae76aeb8.jpeg --device gpu
 ```
 可以得到如下输出：
 ```
-......
-  -5.63553333e-01 -3.07674855e-01 -3.44897419e-01  5.96513569e-01
-  -4.95454431e-01 -9.59614694e-01  6.88151956e-01  4.72645760e-01
-  -2.50571519e-01 -6.13013864e-01  9.00242254e-02 -3.56860608e-02]]
-[[0.99110764 0.00889209]]
+[[0.9925795  0.00742046]]
 ```
 可以看到输出的概率值跟前面的预测结果几乎是一致的
 

--- a/slm/model_zoo/ernie-vil2.0/README.md
+++ b/slm/model_zoo/ernie-vil2.0/README.md
@@ -356,10 +356,8 @@ Label probs: Tensor(shape=[1, 2], dtype=float32, place=Place(gpu:0), stop_gradie
 
 ## 模型导出预测
 
-上一节是动态图的示例，下面提供了简单的导出静态图预测的示例，帮助用户将预训练模型导出成预测部署的参数。首先安装[FastDeploy](https://github.com/PaddlePaddle/FastDeploy):
+上一节是动态图的示例，下面提供了简单的导出静态图预测的示例，帮助用户将预训练模型导出成预测部署的参数。
 
-```
-pip install fastdeploy-gpu-python -f https://www.paddlepaddle.org.cn/whl/fastdeploy.html
 ```
 然后运行下面的命令：
 

--- a/slm/model_zoo/ernie-vil2.0/deploy/python/infer.py
+++ b/slm/model_zoo/ernie-vil2.0/deploy/python/infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.util
+import argparse
 import os
 
-import fastdeploy as fd
 import numpy as np
+import paddle.inference as paddle_infer
 from PIL import Image
+from scipy.special import softmax
 
 from paddlenlp.transformers import ErnieViLProcessor
 from paddlenlp.utils.env import (
@@ -27,161 +28,92 @@ from paddlenlp.utils.env import (
 
 
 def parse_arguments():
-    import argparse
-
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_dir", required=True, help="The directory of model.")
-    parser.add_argument(
-        "--device",
-        type=str,
-        default="gpu",
-        choices=["gpu", "cpu", "kunlunxin"],
-        help="Type of inference device, support 'cpu', 'kunlunxin' or 'gpu'.",
-    )
-    parser.add_argument(
-        "--backend",
-        type=str,
-        default="onnx_runtime",
-        choices=["onnx_runtime", "paddle", "openvino", "tensorrt", "paddle_tensorrt"],
-        help="The inference runtime backend.",
-    )
-    parser.add_argument("--batch_size", type=int, default=1, help="The batch size of data.")
-    parser.add_argument("--temperature", type=float, default=4.30022621, help="The temperature of the model.")
-    parser.add_argument("--max_length", type=int, default=128, help="The max length of sequence.")
-    parser.add_argument("--log_interval", type=int, default=10, help="The interval of logging.")
-    parser.add_argument("--use_fp16", type=distutils.util.strtobool, default=False, help="Wheter to use FP16 mode")
-    parser.add_argument(
-        "--encode_type",
-        type=str,
-        default="text",
-        choices=[
-            "image",
-            "text",
-        ],
-        help="The encoder type.",
-    )
-    parser.add_argument(
-        "--image_path",
-        default="000000039769.jpg",
-        type=str,
-        help="image_path used for prediction",
-    )
+    parser.add_argument("--model_dir", required=True, help="Directory with .json and .pdiparams")
+    parser.add_argument("--device", default="gpu", choices=["gpu", "cpu"], help="Device for inference")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--temperature", type=float, default=4.3)
+    parser.add_argument("--max_length", type=int, default=128)
+    parser.add_argument("--encode_type", choices=["text", "image"], default="text")
+    parser.add_argument("--image_path", type=str, default="data/datasets/Flickr30k-CN/image/36979.jpg")
     return parser.parse_args()
 
 
-class ErnieVil2Predictor(object):
+class PaddleErnieViLPredictor:
     def __init__(self, args):
+        self.args = args
         self.processor = ErnieViLProcessor.from_pretrained("PaddlePaddle/ernie_vil-2.0-base-zh")
-        self.runtime = self.create_fd_runtime(args)
-        self.batch_size = args.batch_size
-        self.max_length = args.max_length
-        self.encode_type = args.encode_type
+        self.predictor, self.input_names, self.output_names = self.load_predictor()
 
-    def create_fd_runtime(self, args):
-        option = fd.RuntimeOption()
-        if args.encode_type == "text":
-            model_path = os.path.join(args.model_dir, f"get_text_features{PADDLE_INFERENCE_MODEL_SUFFIX}")
-            params_path = os.path.join(args.model_dir, f"get_text_features{PADDLE_INFERENCE_WEIGHTS_SUFFIX}")
+    def load_predictor(self):
+        model_file = os.path.join(
+            self.args.model_dir, f"get_{self.args.encode_type}_features{PADDLE_INFERENCE_MODEL_SUFFIX}"
+        )
+        params_file = os.path.join(
+            self.args.model_dir, f"get_{self.args.encode_type}_features{PADDLE_INFERENCE_WEIGHTS_SUFFIX}"
+        )
+
+        config = paddle_infer.Config(model_file, params_file)
+        if self.args.device == "gpu":
+            config.enable_use_gpu(100, 0)
         else:
-            model_path = os.path.join(args.model_dir, f"get_image_features{PADDLE_INFERENCE_MODEL_SUFFIX}")
-            params_path = os.path.join(args.model_dir, f"get_image_features{PADDLE_INFERENCE_WEIGHTS_SUFFIX}")
-        option.set_model_path(model_path, params_path)
-        if args.device == "kunlunxin":
-            option.use_kunlunxin()
-            option.use_paddle_lite_backend()
-            return fd.Runtime(option)
-        if args.device == "cpu":
-            option.use_cpu()
-        else:
-            option.use_gpu()
-        if args.backend == "paddle":
-            option.use_paddle_infer_backend()
-        elif args.backend == "onnx_runtime":
-            option.use_ort_backend()
-        elif args.backend == "openvino":
-            option.use_openvino_backend()
-        else:
-            option.use_trt_backend()
-            if args.backend == "paddle_tensorrt":
-                option.enable_paddle_to_trt()
-                option.enable_paddle_trt_collect_shape()
-            trt_file = os.path.join(args.model_dir, "{}_infer.trt".format(args.encode_type))
-            if args.encode_type == "text":
-                option.set_trt_input_shape(
-                    "input_ids",
-                    min_shape=[1, args.max_length],
-                    opt_shape=[args.batch_size, args.max_length],
-                    max_shape=[args.batch_size, args.max_length],
-                )
-            else:
-                option.set_trt_input_shape(
-                    "pixel_values",
-                    min_shape=[1, 3, 224, 224],
-                    opt_shape=[args.batch_size, 3, 224, 224],
-                    max_shape=[args.batch_size, 3, 224, 224],
-                )
-            if args.use_fp16:
-                option.enable_trt_fp16()
-                trt_file = trt_file + ".fp16"
-            option.set_trt_cache_file(trt_file)
-        return fd.Runtime(option)
+            config.disable_gpu()
+        config.disable_glog_info()
+        config.switch_ir_optim(True)
+
+        predictor = paddle_infer.create_predictor(config)
+        input_names = predictor.get_input_names()
+        output_names = predictor.get_output_names()
+        return predictor, input_names, output_names
 
     def preprocess(self, inputs):
-        if self.encode_type == "text":
-            dataset = [np.array([self.processor(text=text)["input_ids"] for text in inputs], dtype="int64")]
+        if self.args.encode_type == "text":
+            input_ids = [self.processor(text=t)["input_ids"] for t in inputs]
+            input_ids = np.array(input_ids, dtype="int64")
+            return {"input_ids": input_ids}
         else:
-            dataset = [np.array([self.processor(images=image)["pixel_values"][0] for image in inputs])]
-        input_map = {}
-        for input_field_id, data in enumerate(dataset):
-            input_field = self.runtime.get_input_info(input_field_id).name
-            input_map[input_field] = data
-        return input_map
+            pixel_values = [self.processor(images=img)["pixel_values"][0] for img in inputs]
+            pixel_values = np.stack(pixel_values)
+            return {"pixel_values": pixel_values.astype("float32")}
 
-    def postprocess(self, infer_data):
-        logits = np.array(infer_data[0])
-        out_dict = {
-            "features": logits,
-        }
-        return out_dict
-
-    def infer(self, input_map):
-        results = self.runtime.infer(input_map)
-        return results
+    def infer(self, input_dict):
+        for name in self.input_names:
+            input_tensor = self.predictor.get_input_handle(name)
+            input_tensor.copy_from_cpu(input_dict[name])
+        self.predictor.run()
+        output_tensor = self.predictor.get_output_handle(self.output_names[0])
+        return output_tensor.copy_to_cpu()
 
     def predict(self, inputs):
         input_map = self.preprocess(inputs)
-        infer_result = self.infer(input_map)
-        output = self.postprocess(infer_result)
+        output = self.infer(input_map)
         return output
 
 
 def main():
     args = parse_arguments()
-    texts = [
-        "猫的照片",
-        "狗的照片",
-    ]
-    args.batch_size = 2
-    predictor = ErnieVil2Predictor(args)
-    outputs = predictor.predict(texts)
-    print(outputs)
-    text_feats = outputs["features"]
-    image = Image.open(args.image_path)
+
+    # 文本推理
+    args.encode_type = "text"
+    predictor_text = PaddleErnieViLPredictor(args)
+    texts = ["猫的照片", "狗的照片"]
+    args.batch_size = len(texts)
+    text_features = predictor_text.predict(texts)
+
+    # 图像推理
     args.encode_type = "image"
     args.batch_size = 1
-    predictor = ErnieVil2Predictor(args)
-    images = [image]
-    outputs = predictor.predict(images)
-    image_feats = outputs["features"]
-    print(image_feats)
-    from scipy.special import softmax
+    predictor_image = PaddleErnieViLPredictor(args)
+    image = Image.open(args.image_path).convert("RGB")
+    image_features = predictor_image.predict([image])
 
-    image_feats = image_feats / np.linalg.norm(image_feats, ord=2, axis=-1, keepdims=True)
-    text_feats = text_feats / np.linalg.norm(text_feats, ord=2, axis=-1, keepdims=True)
-    # Get from dygraph， refer to predict.py
-    exp_data = np.exp(args.temperature)
-    m = softmax(np.matmul(exp_data * text_feats, image_feats.T), axis=0).T
-    print(m)
+    # 特征归一化 + 相似度计算
+    image_features = image_features / np.linalg.norm(image_features, axis=-1, keepdims=True)
+    text_features = text_features / np.linalg.norm(text_features, axis=-1, keepdims=True)
+
+    sim_logits = softmax(np.exp(args.temperature) * np.matmul(text_features, image_features.T), axis=0).T
+    print("相似度矩阵（image→text）:")
+    print(sim_logits)
 
 
 if __name__ == "__main__":

--- a/slm/model_zoo/ernie-vil2.0/preprocess/create_arrow_dataset.py
+++ b/slm/model_zoo/ernie-vil2.0/preprocess/create_arrow_dataset.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-This script serializes images and image-text pair annotations into arrow files,
-which supports more convenient dataset loading and random access to samples during training
-compared with TSV and Jsonl data files.
-"""
 import argparse
-import base64
-import json
-import logging
 import os
-import random
-from collections import defaultdict
-from glob import glob
 
 import jsonlines
 import pandas as pd
@@ -34,141 +21,91 @@ import pyarrow as pa
 from tqdm import tqdm
 
 
-def id2rest(photo_id, iid2photo, iid2captions):
-    captions = iid2captions[photo_id]
-    photo_data = iid2photo[photo_id]
-    photo_data = photo_data.encode("utf-8")
-    photo_data = base64.urlsafe_b64decode(photo_data)
-    return [photo_data, captions, photo_id]
+def get_all_image_paths(image_dir):
+    valid_exts = [".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"]
+    paths = []
+    for root, _, files in os.walk(image_dir):
+        for fname in files:
+            if os.path.splitext(fname)[1] in valid_exts:
+                paths.append(os.path.join(root, fname))
+    return paths
 
 
-def path2rest(path, iid2captions, iid2photo):
-    name = path.split("/")[-1]
-    with open(path, "rb") as fp:
-        binary = fp.read()
-    text_index = iid2photo[name.split("/")[-1]]
-    bs_item = []
-    for index in text_index:
-        bs_item.append([binary, iid2captions[index], name.split("/")[-1]])
-    return bs_item
+def build_image_map(image_paths):
+    return {os.path.splitext(os.path.basename(p))[0]: p for p in image_paths}
 
 
-def valid_img(path, iid2photo):
-    name = path.split("/")[-1]
-    with open(path, "rb") as fp:
-        binary = fp.read()
-    return [binary, name.split("/")[-1]]
+def build_arrow_for_split(split_name, jsonl_path, image_map, output_dir):
+    print(f"Processing split: {split_name}")
+    all_entries = 0
+    kept_entries = 0
+    data = []
+    data_img = []
+    missing_image_ids = set()
+
+    with jsonlines.open(jsonl_path, "r") as reader:
+        for obj in tqdm(reader):
+            all_entries += 1
+            image_ids = [str(i) for i in obj.get("image_ids", [])]
+            valid_image_ids = [i for i in image_ids if i in image_map]
+
+            if not valid_image_ids:
+                missing_image_ids.update(image_ids)
+                continue
+
+            for img_id in valid_image_ids:
+                img_path = image_map[img_id]
+                with open(img_path, "rb") as img_f:
+                    img_bytes = img_f.read()
+                data.append([img_bytes, obj["text"], img_id])
+                data_img.append([img_bytes, img_id])
+                kept_entries += 1
+
+    # 保存图文对 arrow 文件
+    df = pd.DataFrame(data, columns=["image", "caption", "image_id"])
+    table = pa.Table.from_pandas(df)
+    with pa.OSFile(os.path.join(output_dir, f"{split_name}.arrow"), "wb") as sink:
+        with pa.RecordBatchFileWriter(sink, table.schema) as writer:
+            writer.write_table(table)
+
+    # 保存图像-only arrow 文件（无caption）
+    df_img = pd.DataFrame(data_img, columns=["image", "image_id"])
+    table_img = pa.Table.from_pandas(df_img)
+    with pa.OSFile(os.path.join(output_dir, f"{split_name}_img.arrow"), "wb") as sink:
+        with pa.RecordBatchFileWriter(sink, table_img.schema) as writer:
+            writer.write_table(table_img)
+
+    print(f"{split_name}: {kept_entries}/{all_entries} entries kept.")
+    if missing_image_ids:
+        miss_path = os.path.join(output_dir, f"missing_{split_name}.txt")
+        with open(miss_path, "w", encoding="utf-8") as f:
+            for mid in sorted(missing_image_ids):
+                f.write(mid + "\n")
+        print(f"⚠️ Missing image IDs written to: {miss_path}")
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--data_dir",
-    type=str,
-    required=True,
-    help="the directory which stores the image tsvfiles and the text jsonl annotations",
-)
-parser.add_argument(
-    "--splits",
-    type=str,
-    required=True,
-    help="specify the dataset splits which this script processes, concatenated by comma \ (e.g. train,valid,test)",
-)
-parser.add_argument(
-    "--data_out_dir",
-    type=str,
-    default=None,
-    help="specify the directory which stores the output arrow files. If set to None, the arrow_dir will be set to args.data_dir/arrow",
-)
-parser.add_argument("--t2i_type", type=str, default="jsonl", help="the type of text2photo filename")
-parser.add_argument(
-    "--image_dir",
-    type=str,
-    required=True,
-    help="the directory which stores the images['png','jpg','JPG']",
-)
-args = parser.parse_args()
-logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s -%(module)s:  %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S %p",
-    level=10,
-)
-# yapf: enable
+def main(args):
+    os.makedirs(args.output_dir, exist_ok=True)
+    image_paths = get_all_image_paths(args.image_dir)
+    image_map = build_image_map(image_paths)
+
+    splits = args.splits.split(",")
+    for split in splits:
+        jsonl_path = os.path.join(args.data_dir, f"{split}_texts.jsonl")
+        if not os.path.exists(jsonl_path):
+            print(f"File not found: {jsonl_path}")
+            continue
+        build_arrow_for_split(split, jsonl_path, image_map, args.output_dir)
+
+
 if __name__ == "__main__":
-    assert os.path.isdir(args.data_dir), "The data_dir does not exist! Please check the input args..."
-    specified_splits = list(set(args.splits.strip().split(",")))  # train test dev
-    specified_type = args.t2i_type
-    print("Dataset splits to be processed: {}".format(", ".join(specified_splits)))
-    for split in specified_splits:
-        datasplit_path = os.path.join(args.data_dir, split)
-        iid2captions = dict()
-        iid2photo = defaultdict(list)
-        image_dir = args.image_dir
-        assert os.path.isdir(image_dir), "The image_dir does not exist! Please check the input args..."
-        assert specified_type == "jsonl", "the type of file is not jsonl"
-        txt_path = datasplit_path + "_texts.jsonl"
-        assert os.path.exists(txt_path) is True
-        with open(txt_path, "r", encoding="utf-8") as fin_pairs:
-            for index, line in tqdm(enumerate(fin_pairs)):
-                line = line.strip()
-                obj = json.loads(line)
-                for field in ("text_id", "text", "image_ids"):
-                    assert (
-                        field in obj
-                    ), "Field {} does not exist in line {}. \
-                            Please check the integrity of the text annotation Jsonl file."
-                image_ids = obj["image_ids"]
-                if type(image_ids[0]) == str and image_ids[0].isnumeric() is True:
-                    iid2captions[index] = obj["text"]
-                    iid2photo[int(image_ids[0])].append(index)
-                else:
-                    iid2captions[index] = obj["text"]
-                    iid2photo[image_ids[0]].append(index)
-        paths = (
-            list(glob(f"{args.image_dir}/*/*jpg"))
-            + list(glob(f"{args.image_dir}/*/*.png"))
-            + list(glob(f"{args.image_dir}/*/*.JPG"))
-        )
-        random.shuffle(paths)
-        # 有效图片路径
-        if type(list(iid2photo.keys())[0]) == int:
-            caption_paths = [path for path in paths if int(path.split("/")[-1][:-4]) in iid2photo]
-        elif type(list(iid2photo.keys())[0]) == str and "." not in list(iid2photo.keys())[0]:
-            caption_paths = [path for path in paths if path.split("/")[-1][:-4] in iid2photo]
-        else:
-            caption_paths = [path for path in paths if path.split("/")[-1] in iid2photo]
-        invalid_photo = [path for path in iid2photo if path not in [i.split("/")[-1] for i in caption_paths]]
-        bs = []
-        for path in tqdm(caption_paths):
-            bs += path2rest(path, iid2captions, iid2photo)
-        dataframe = pd.DataFrame(bs, columns=["image", "caption", "image_id"])
-        table = pa.Table.from_pandas(dataframe)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_dir", required=True, help="Directory containing *_texts.jsonl files")
+    parser.add_argument("--image_dir", required=True, help="Directory containing image files")
+    parser.add_argument("--output_dir", default=None, help="Directory to save output .arrow files")
+    parser.add_argument("--splits", default="train,valid,test", help="Comma-separated list of dataset splits")
 
-        if args.data_out_dir is None:
-            data_out_dir = os.path.join(args.data_dir, "arrow")
-        else:
-            data_out_dir = args.data_out_dir
-        os.makedirs(data_out_dir, exist_ok=True)
-        with pa.OSFile(f"{data_out_dir}/{split}.arrow", "wb") as sink:
-            with pa.RecordBatchFileWriter(sink, table.schema) as writer:
-                writer.write_table(table)
-        if split in ["valid", "test"]:
-            if len(invalid_photo) > 0:
-                logging.info("The jsonl file contains invalid images")
-                data_valid = []
-                with open(txt_path, "r", encoding="utf-8") as fin_pairs:
-                    for line in fin_pairs:
-                        line = line.strip()
-                        obj = json.loads(line)
-                        obj["image_ids"] = [i for i in obj["image_ids"] if i not in invalid_photo]
-                        if len(obj["image_ids"]) == 0:
-                            continue
-                        data_valid.append(obj)
-                with jsonlines.open(datasplit_path + "_updata_texts.jsonl", mode="w") as writer:
-                    for row in data_valid:
-                        writer.write({"text_id": row["text_id"], "text": row["text"], "image_ids": row["image_ids"]})
-            bs_img = [valid_img(path, iid2captions) for path in tqdm(caption_paths)]
-            dataframe_img = pd.DataFrame(bs_img, columns=["image", "image_id"])
-            table_img = pa.Table.from_pandas(dataframe_img)
-            with pa.OSFile(f"{data_out_dir}/{split}_img.arrow", "wb") as sink:
-                with pa.RecordBatchFileWriter(sink, table_img.schema) as writer:
-                    writer.write_table(table_img)
+    args = parser.parse_args()
+    if args.output_dir is None:
+        args.output_dir = os.path.join(args.data_dir, "arrow")
+    main(args)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
1. 在文档更新lexical_analysis 进行推理时候的运行命令；
2. ernie-vil2.0原本的arrow数据生成脚本一直提示存在匹配不上的文本和图片，重新写了脚本解决这个问题；
3. ernie-vil2.0使用paddle.inference推理实现，代替原本使用fastdeploy的实现；
4. 根据代码变化和运行实际，修改文档当中的命令与输出。

##### Modified:
```slm/examples/lexical_analysis/README.md```
```slm/model_zoo/ernie-vil2.0/README.md```
```slm/model_zoo/ernie-vil2.0/deploy/python/infer.py```
```slm/model_zoo/ernie-vil2.0/preprocess/create_arrow_dataset.py```

Issue: https://github.com/PaddlePaddle/PaddleNLP/issues/9763
@DrownFish19