### PR TITLE
[RL] 加速推理模型qwen2的set state dict的性能

### DIFF
--- a/paddlenlp/experimental/transformers/qwen2/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen2/modeling.py
@@ -577,7 +577,7 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             if isinstance(tensor_list[0], paddle.Tensor):
                 return paddle.concat(tensor_list, axis=axis)
             elif isinstance(tensor_list[0], np.ndarray):
-                return np.concatenate(tensor_list, dim=axis)
+                return np.concatenate(tensor_list, axis=axis)
             else:
                 raise ValueError(f"Unsupported type of tensor list: {type(tensor_list[0])}")
 

--- a/paddlenlp/experimental/transformers/qwen2/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen2/modeling.py
@@ -412,9 +412,9 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                 )
 
                 for weight_name in weight_scales.scale:
-                    weight_scales.scale[weight_name] = weight_scales.scale[weight_name].astype(np.float32)
+                    weight_scales.scale[weight_name] = weight_scales.scale[weight_name].astype("float32")
                 for act_name in act_scales.scale:
-                    act_scales.scale[act_name] = act_scales.scale[act_name].astype(np.float32)
+                    act_scales.scale[act_name] = act_scales.scale[act_name].astype("float32")
                 self.transformer_block.weight_scales = weight_scales.scale
                 self.transformer_block.act_scales = act_scales.scale
         elif "a8w8" in self.quant_type:
@@ -482,14 +482,14 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                                     ]
                                     .reshape([-1])
                                 )
-                            self.transformer_block.qkv_out_scales[i_layer].set_value(tmp)
+                            self.transformer_block.qkv_out_scales[i_layer].copy_(tmp, False)
                 elif "out_linear_" in k:
                     for i_layer, weight_scale in enumerate(v):
                         if not np.all(weight_scale == -1):
                             tmp = paddle.to_tensor(
                                 weight_scale / (127.0 * 127.0 * act_scale_loader.scale["out_linear_in_scale"][i_layer])
                             )
-                            self.transformer_block.linear_out_scales[i_layer].set_value(tmp)
+                            self.transformer_block.linear_out_scales[i_layer].copy_(tmp, False)
                 elif "ffn1_weight_scale" in k:
                     for i_layer, weight_scale in enumerate(v):
                         if not np.all(weight_scale == -1):
@@ -505,14 +505,15 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                                     ],
                                     axis=0,
                                 )
-                            self.transformer_block.ffn1_out_scales[i_layer].set_value(tmp)
+                            self.transformer_block.ffn1_out_scales[i_layer].copy_(tmp, False)
                 elif "ffn2" in k:
                     for i_layer, weight_scale in enumerate(v):
                         if not np.all(weight_scale == -1):
-                            self.transformer_block.ffn2_out_scales[i_layer].set_value(
+                            self.transformer_block.ffn2_out_scales[i_layer].copy_(
                                 paddle.to_tensor(
                                     weight_scale / (127.0 * 127.0 * act_scale_loader.scale["ffn2_in_scale"][i_layer])
-                                )
+                                ),
+                                False,
                             )
 
         if self.config.cachekv_int8_type == "static":
@@ -547,13 +548,13 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                     else:
                         weight_scale = weight_scale.astype("float32")
                     if k == "cache_k_scale":
-                        self.transformer_block.cache_k_scales[i_layer].set_value(weight_scale)
+                        self.transformer_block.cache_k_scales[i_layer].copy_(weight_scale, False)
                     elif k == "cache_v_scale":
-                        self.transformer_block.cache_v_scales[i_layer].set_value(weight_scale)
+                        self.transformer_block.cache_v_scales[i_layer].copy_(weight_scale, False)
                     elif k == "cache_k_out_scale":
-                        self.transformer_block.cache_k_out_scales[i_layer].set_value(weight_scale)
+                        self.transformer_block.cache_k_out_scales[i_layer].copy_(weight_scale, False)
                     else:
-                        self.transformer_block.cache_v_out_scales[i_layer].set_value(weight_scale)
+                        self.transformer_block.cache_v_out_scales[i_layer].copy_(weight_scale, False)
 
     @paddle.no_grad()
     def set_state_dict(self, state_dict):
@@ -562,14 +563,23 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             self.transformer_block.init_weight()
             self._weights_initialized = True
         split_fn = split_param_func()
-        self.embed_tokens.weight.set_value(
+        self.embed_tokens.weight.copy_(
             paddle.to_tensor(state_dict[f"{self.base_model_prefix}.embed_tokens.weight"]).cast(
                 self.embed_tokens.weight.dtype
-            )
+            ),
+            False,
         )
-        self.norm.weight.set_value(
-            paddle.to_tensor(state_dict[f"{self.base_model_prefix}.norm.weight"]).cast(self.norm.weight.dtype)
+        self.norm.weight.copy_(
+            paddle.to_tensor(state_dict[f"{self.base_model_prefix}.norm.weight"]).cast(self.norm.weight.dtype), False
         )
+
+        def concat(tensor_list, axis=-1):
+            if isinstance(tensor_list[0], paddle.Tensor):
+                return paddle.concat(tensor_list, axis=axis)
+            elif isinstance(tensor_list[0], np.ndarray):
+                return np.concatenate(tensor_list, dim=axis)
+            else:
+                raise ValueError(f"Unsupported type of tensor list: {type(tensor_list[0])}")
 
         for idx in range(self.num_layers):
             model_prefix = self.base_model_prefix + f".layers.{idx}"
@@ -578,11 +588,11 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             ln_scale = paddle.to_tensor(state_dict[f"{model_prefix}.input_layernorm.weight"]).cast(
                 self.transformer_block.ln_scales[idx].dtype
             )
-            self.transformer_block.ln_scales[idx].set_value(ln_scale)
+            self.transformer_block.ln_scales[idx].copy_(ln_scale, False)
 
             if f"{model_prefix}.self_attn.qkv_proj.weight" in state_dict.keys():
                 concated_qkv_weight = paddle.to_tensor(
-                    np.concatenate(
+                    concat(
                         split_fn(
                             state_dict[f"{model_prefix}.self_attn.qkv_proj.weight"],
                             is_qkv=True,
@@ -590,7 +600,7 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                             num_key_value_heads=self.num_key_value_heads // self.config.tensor_parallel_degree,
                         ),
                         axis=-1,
-                    ).transpose(1, 0)
+                    ).transpose([1, 0])
                 )
             else:
                 unfused_state_dict = {}
@@ -664,20 +674,20 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             if self.use_weight_only:
                 qkv_weight = paddle.transpose(qkv_weight, perm=[1, 0])
                 qkv_quanted_weight, qkv_weight_scale = weight_quantize(qkv_weight, algo=self.quant_algo)
-                self.transformer_block.qkv_weights[idx].set_value(qkv_quanted_weight)
-                self.transformer_block.qkv_weights_scale[idx].set_value(qkv_weight_scale)
+                self.transformer_block.qkv_weights[idx].copy_(qkv_quanted_weight, False)
+                self.transformer_block.qkv_weights_scale[idx].copy_(qkv_weight_scale, False)
             elif "fp8" in self.quant_type:
                 self.transformer_block.qkv_weights[idx].copy_(paddle.cast(concated_qkv_weight, "float8_e4m3fn"), False)
             elif "a8w8" in self.quant_type and not self.transformer_block.skip_quant("qkv_weight_scale", idx):
-                self.transformer_block.qkv_weights[idx].set_value(
-                    paddle.cast(paddle.to_tensor(concated_qkv_weight), "int8")
+                self.transformer_block.qkv_weights[idx].copy_(
+                    paddle.cast(paddle.to_tensor(concated_qkv_weight), "int8"), False
                 )
             else:
-                self.transformer_block.qkv_weights[idx].set_value(qkv_weight)
+                self.transformer_block.qkv_weights[idx].copy_(qkv_weight, False)
 
             if f"{model_prefix}.self_attn.qkv_proj.bias" in state_dict.keys():
                 qkv_bias = paddle.to_tensor(
-                    np.concatenate(
+                    concat(
                         split_fn(
                             state_dict[f"{model_prefix}.self_attn.qkv_proj.bias"],
                             is_qkv=True,
@@ -691,10 +701,10 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                 q_bias = state_dict[f"{model_prefix}.self_attn.q_proj.bias"]
                 k_bias = state_dict[f"{model_prefix}.self_attn.k_proj.bias"]
                 v_bias = state_dict[f"{model_prefix}.self_attn.v_proj.bias"]
-                concated_qkv_biases = np.concatenate([q_bias, k_bias, v_bias], axis=-1)
+                concated_qkv_biases = concat([q_bias, k_bias, v_bias], axis=-1)
                 qkv_bias = paddle.to_tensor(concated_qkv_biases)
-            self.transformer_block.qkv_biases[idx].set_value(
-                qkv_bias.cast(self.transformer_block.qkv_biases[idx].dtype)
+            self.transformer_block.qkv_biases[idx].copy_(
+                qkv_bias.cast(self.transformer_block.qkv_biases[idx].dtype), False
             )
 
             linear_weight = paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.weight"]).cast(
@@ -702,8 +712,8 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             )
             if self.use_weight_only:
                 linear_quanted_weight, linear_weight_scale = weight_quantize(linear_weight, algo=self.quant_algo)
-                self.transformer_block.linear_weights[idx].set_value(linear_quanted_weight)
-                self.transformer_block.linear_weights_scale[idx].set_value(linear_weight_scale)
+                self.transformer_block.linear_weights[idx].copy_(linear_quanted_weight, False)
+                self.transformer_block.linear_weights_scale[idx].copy_(linear_weight_scale, False)
             elif "fp8" in self.quant_type:
                 self.transformer_block.linear_weights[idx].copy_(
                     paddle.cast(
@@ -719,48 +729,50 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                     else "int8"
                 )
                 if paddle.is_compiled_with_rocm():
-                    self.transformer_block.linear_weights[idx].set_value(
+                    self.transformer_block.linear_weights[idx].copy_(
                         paddle.cast(
                             paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.weight"]),
                             w_dtype,
-                        )
+                        ),
+                        False,
                     )
                 else:
-                    self.transformer_block.linear_weights[idx].set_value(
+                    self.transformer_block.linear_weights[idx].copy_(
                         paddle.cast(
                             paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.weight"]).transpose((1, 0)),
                             w_dtype,
-                        )
+                        ),
+                        False,
                     )
             else:
-                self.transformer_block.linear_weights[idx].set_value(
-                    linear_weight.cast(self.transformer_block.linear_weights[idx].dtype)
+                self.transformer_block.linear_weights[idx].copy_(
+                    linear_weight.cast(self.transformer_block.linear_weights[idx].dtype), False
                 )
 
             ffn_ln_scale = paddle.to_tensor(
                 state_dict[f"{model_prefix}.post_attention_layernorm.weight"],
             )
 
-            self.transformer_block.ffn_ln_scales[idx].set_value(
-                ffn_ln_scale.cast(self.transformer_block.ffn_ln_scales[idx].dtype)
+            self.transformer_block.ffn_ln_scales[idx].copy_(
+                ffn_ln_scale.cast(self.transformer_block.ffn_ln_scales[idx].dtype), False
             )
 
             if f"{model_prefix}.mlp.gate_up_fused_proj.weight" in state_dict.keys():
-                concated_ffn1_weight = np.concatenate(
+                concated_ffn1_weight = concat(
                     split_fn(state_dict[f"{model_prefix}.mlp.gate_up_fused_proj.weight"]), axis=-1
                 )
             else:
                 unfused_state_dict["mlp.gate_proj.weight"] = state_dict[f"{model_prefix}.mlp.gate_proj.weight"]
                 unfused_state_dict["mlp.up_proj.weight"] = state_dict[f"{model_prefix}.mlp.up_proj.weight"]
-                concated_ffn1_weight = np.concatenate(
+                concated_ffn1_weight = concat(
                     [unfused_state_dict["mlp.gate_proj.weight"], unfused_state_dict["mlp.up_proj.weight"]], axis=-1
                 )
             ffn1_weight = paddle.to_tensor(concated_ffn1_weight).cast(paddle.get_default_dtype())
 
             if self.use_weight_only:
                 ffn1_quanted_weight, ffn1_weight_scale = weight_quantize(ffn1_weight, algo=self.quant_algo)
-                self.transformer_block.ffn1_weights[idx].set_value(ffn1_quanted_weight)
-                self.transformer_block.ffn1_weights_scale[idx].set_value(ffn1_weight_scale)
+                self.transformer_block.ffn1_weights[idx].copy_(ffn1_quanted_weight, False)
+                self.transformer_block.ffn1_weights_scale[idx].copy_(ffn1_weight_scale, False)
             elif "fp8" in self.quant_type:
                 self.transformer_block.ffn1_0_weights[idx].copy_(
                     paddle.to_tensor(unfused_state_dict["mlp.gate_proj.weight"])
@@ -779,16 +791,16 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                     else "int8"
                 )
                 if paddle.is_compiled_with_rocm():
-                    self.transformer_block.ffn1_weights[idx].set_value(
-                        paddle.cast(paddle.to_tensor(ffn1_weight), w_dtype)
+                    self.transformer_block.ffn1_weights[idx].copy_(
+                        paddle.cast(paddle.to_tensor(ffn1_weight), w_dtype), False
                     )
                 else:
-                    self.transformer_block.ffn1_weights[idx].set_value(
-                        paddle.cast(paddle.to_tensor(ffn1_weight).transpose((1, 0)), w_dtype)
+                    self.transformer_block.ffn1_weights[idx].copy_(
+                        paddle.cast(paddle.to_tensor(ffn1_weight).transpose((1, 0)), w_dtype), False
                     )
             else:
-                self.transformer_block.ffn1_weights[idx].set_value(
-                    ffn1_weight.cast(self.transformer_block.ffn1_weights[idx].dtype)
+                self.transformer_block.ffn1_weights[idx].copy_(
+                    ffn1_weight.cast(self.transformer_block.ffn1_weights[idx].dtype), False
                 )
 
             ffn2_weight = paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.weight"]).cast(
@@ -796,8 +808,8 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             )
             if self.use_weight_only:
                 ffn2_quanted_weight, ffn2_weight_scale = weight_quantize(ffn2_weight, algo=self.quant_algo)
-                self.transformer_block.ffn2_weights[idx].set_value(ffn2_quanted_weight)
-                self.transformer_block.ffn2_weights_scale[idx].set_value(ffn2_weight_scale)
+                self.transformer_block.ffn2_weights[idx].copy_(ffn2_quanted_weight, False)
+                self.transformer_block.ffn2_weights_scale[idx].copy_(ffn2_weight_scale, False)
             elif "fp8" in self.quant_type:
                 self.transformer_block.ffn2_weights[idx].copy_(
                     paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.weight"])
@@ -812,12 +824,12 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                     else "int8"
                 )
                 if paddle.is_compiled_with_rocm():
-                    self.transformer_block.ffn2_weights[idx].set_value(ffn2_weight.cast(w_dtype))
+                    self.transformer_block.ffn2_weights[idx].copy_(ffn2_weight.cast(w_dtype), False)
                 else:
-                    self.transformer_block.ffn2_weights[idx].set_value(ffn2_weight.transpose([1, 0]).cast(w_dtype))
+                    self.transformer_block.ffn2_weights[idx].copy_(ffn2_weight.transpose([1, 0]).cast(w_dtype), False)
             else:
-                self.transformer_block.ffn2_weights[idx].set_value(
-                    ffn2_weight.cast(self.transformer_block.ffn2_weights[idx].dtype)
+                self.transformer_block.ffn2_weights[idx].copy_(
+                    ffn2_weight.cast(self.transformer_block.ffn2_weights[idx].dtype), False
                 )
 
             if "fp8" not in self.quant_type and "a8w8" in self.quant_type:
@@ -846,25 +858,29 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                                 shape=[self.intermediate_size // self.config.tensor_parallel_degree],
                                 dtype=paddle.get_default_dtype(),
                             )
-                    self.transformer_block.linear_shifts[idx].set_value(
+                    self.transformer_block.linear_shifts[idx].copy_(
                         paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.shift_bias"]).astype(
                             paddle.get_default_dtype()
-                        )
+                        ),
+                        False,
                     )
-                    self.transformer_block.linear_smooths[idx].set_value(
+                    self.transformer_block.linear_smooths[idx].copy_(
                         paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.smooth_weight"]).astype(
                             paddle.get_default_dtype()
-                        )
+                        ),
+                        False,
                     )
-                    self.transformer_block.ffn2_shifts[idx].set_value(
+                    self.transformer_block.ffn2_shifts[idx].copy_(
                         paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.shift_bias"]).astype(
                             paddle.get_default_dtype()
-                        )
+                        ),
+                        False,
                     )
-                    self.transformer_block.ffn2_smooths[idx].set_value(
+                    self.transformer_block.ffn2_smooths[idx].copy_(
                         paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.smooth_weight"]).astype(
                             paddle.get_default_dtype()
-                        )
+                        ),
+                        False,
                     )
 
                 if self.shift:
@@ -907,13 +923,13 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                         unfused_state_dict["mlp.gate_proj.bias"] = state_dict[f"{model_prefix}.mlp.gate_proj.bias"]
                         unfused_state_dict["mlp.up_proj.bias"] = state_dict[f"{model_prefix}.mlp.up_proj.bias"]
 
-                    self.transformer_block.ln_biases[idx].set_value(
-                        paddle.to_tensor(state_dict[f"{model_prefix}.input_layernorm.bias"])
+                    self.transformer_block.ln_biases[idx].copy_(
+                        paddle.to_tensor(state_dict[f"{model_prefix}.input_layernorm.bias"]), False
                     )
-                    self.transformer_block.ffn_ln_biases[idx].set_value(
-                        paddle.to_tensor(state_dict[f"{model_prefix}.post_attention_layernorm.bias"])
+                    self.transformer_block.ffn_ln_biases[idx].copy_(
+                        paddle.to_tensor(state_dict[f"{model_prefix}.post_attention_layernorm.bias"]), False
                     )
-                    concated_qkv_biases = np.concatenate(
+                    concated_qkv_biases = concat(
                         [
                             unfused_state_dict["self_attn.q_proj.bias"],
                             unfused_state_dict["self_attn.k_proj.bias"],
@@ -922,11 +938,11 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                         axis=-1,
                     )
 
-                    self.transformer_block.qkv_biases[idx].set_value(paddle.to_tensor(concated_qkv_biases))
-                    concated_ffn1_bias = np.concatenate(
+                    self.transformer_block.qkv_biases[idx].copy_(paddle.to_tensor(concated_qkv_biases), False)
+                    concated_ffn1_bias = concat(
                         [unfused_state_dict["mlp.gate_proj.bias"], unfused_state_dict["mlp.up_proj.bias"]], axis=-1
                     )
-                    self.transformer_block.ffn1_biases[idx].set_value(paddle.to_tensor(concated_ffn1_bias))
+                    self.transformer_block.ffn1_biases[idx].copy_(paddle.to_tensor(concated_ffn1_bias), False)
 
                     if self.shift_smooth_all_linears:
                         if self.use_fake_parameter:
@@ -937,11 +953,11 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
                                 state_dict[f"{model_prefix}.mlp.down_proj.layer.bias"] = paddle.zeros(
                                     [self.hidden_size], dtype=paddle.get_default_dtype()
                                 )
-                        self.transformer_block.linear_biases[idx].set_value(
-                            paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.bias"])
+                        self.transformer_block.linear_biases[idx].copy_(
+                            paddle.to_tensor(state_dict[f"{model_prefix}.self_attn.o_proj.bias"]), False
                         )
-                        self.transformer_block.ffn2_biases[idx].set_value(
-                            paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.layer.bias"])
+                        self.transformer_block.ffn2_biases[idx].copy_(
+                            paddle.to_tensor(state_dict[f"{model_prefix}.mlp.down_proj.layer.bias"]), False
                         )
 
     def remove_padding(self, input_ids, seq_lens_this_time):
@@ -1236,7 +1252,7 @@ class Qwen2ForCausalLMInferenceModel(GenerationInferenceModel, Qwen2PretrainedMo
     def set_state_dict(self, state_dict):
         if "lm_head.weight" in state_dict:
             lm_head_weight = paddle.to_tensor(state_dict["lm_head.weight"]).cast(self.lm_head.weight.dtype)
-            self.lm_head.weight.set_value(lm_head_weight)
+            self.lm_head.weight.copy_(lm_head_weight, False)
         self.qwen2.set_state_dict({k: state_dict[k] for k in state_dict.keys()})
 
 
@@ -1570,8 +1586,8 @@ class Qwen2ForCausalLMBlockInferenceModel(GenerationBlockInferenceModel, Qwen2Pr
     @paddle.no_grad()
     def set_state_dict(self, state_dict):
         if "lm_head.weight" in state_dict:
-            self.lm_head.weight.set_value(
-                paddle.to_tensor(state_dict["lm_head.weight"]).cast(self.lm_head.weight.dtype)
+            self.lm_head.weight.copy_(
+                paddle.to_tensor(state_dict["lm_head.weight"]).cast(self.lm_head.weight.dtype), False
             )
         self.qwen2.set_state_dict({k: state_dict[k] for k in state_dict.keys()})
 

--- a/paddlenlp/rl/trainer/rl_trainer.py
+++ b/paddlenlp/rl/trainer/rl_trainer.py
@@ -49,9 +49,7 @@ from ...transformers import PretrainedModel, PretrainedTokenizer
 from ...utils.env import TRAINER_STATE_NAME
 from ..models.ppo_model_utils import create_loss
 from ..utils.comm_utils import create_data_trans_group
-from ..utils.infer_utils import InferEvalModel
 from ..utils.reshard_utils import init_rollout_env
-from .trainer_utils import PipeEvalModel
 
 # ########## patches for Trianer ##########
 
@@ -641,10 +639,14 @@ class RLTrainer(Trainer):
         if (self.args.pipeline_parallel_degree > 1 and inner_eval_model is None) or isinstance(
             inner_eval_model, fleet.model.PipelineParallel
         ):
+            from .trainer_utils import PipeEvalModel
+
             # Only accept wrapped model for pipeline_parallel mode
             model = PipeEvalModel(self)
             self._eval_model = model
         else:
+            from ..utils.infer_utils import InferEvalModel
+
             model = InferEvalModel(self)
             self._eval_model = model
         return model

--- a/paddlenlp/rl/utils/infer_utils.py
+++ b/paddlenlp/rl/utils/infer_utils.py
@@ -268,6 +268,11 @@ def infer_guard(trainer, offload_model=True):
     policy_predictor.disable(model, onload_model=offload_model)
 
 
+def get_policy_predictor():
+    global policy_predictor
+    return policy_predictor
+
+
 class InferEvalModel:
     """For faster generation, not support PipelineParallel yet."""
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
1. 加速推理模型qwen2的set state dict的性能（加速点：使用copy_替换set_value，避免使用np将处于gpu的tensor切换为cpu ）
3. 挪动InferEvalModel的导入，防止出现circle import的报错
4. 新增get_policy_predictor