### PR TITLE
Update serialization 

### DIFF
--- a/paddlenlp/utils/serialization.py
+++ b/paddlenlp/utils/serialization.py
@@ -29,6 +29,7 @@ from paddlenlp.utils.env import PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME
 
 MZ_ZIP_LOCAL_DIR_HEADER_SIZE = 30
 
+
 _TYPES = {
     "F64": np.float64,
     "F32": np.float32,
@@ -206,7 +207,7 @@ def dumpy(*args, **kwarsg):
 
 def load_torch(path: str, **pickle_load_args):
     from paddlenlp.transformers.utils import device_guard
-    
+
     if path.endswith(PYTORCH_WEIGHTS_NAME) or os.path.split(path)[-1].startswith("pytorch_model-"):
         import torch
 

--- a/paddlenlp/utils/serialization.py
+++ b/paddlenlp/utils/serialization.py
@@ -25,7 +25,6 @@ import paddle
 from _io import BufferedReader
 from safetensors import deserialize
 
-from paddlenlp.transformers.utils import device_guard
 from paddlenlp.utils.env import PYTORCH_WEIGHTS_NAME, SAFE_WEIGHTS_NAME
 
 MZ_ZIP_LOCAL_DIR_HEADER_SIZE = 30
@@ -206,6 +205,8 @@ def dumpy(*args, **kwarsg):
 
 
 def load_torch(path: str, **pickle_load_args):
+    from paddlenlp.transformers.utils import device_guard
+    
     if path.endswith(PYTORCH_WEIGHTS_NAME) or os.path.split(path)[-1].startswith("pytorch_model-"):
         import torch
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
BugFixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
```python
___________________________________________________________ ERROR collecting tests/models/test_internvl2.py ___________________________________________________________
ImportError while importing test module '/home/PaddleMIX/tests/models/test_internvl2.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/models/test_internvl2.py:26: in <module>
    from paddlemix.models.internvl2.conversation import get_conv_template
paddlemix/__init__.py:16: in <module>
    from .datasets import *
paddlemix/datasets/__init__.py:19: in <module>
    from .chatml_dataset import *
paddlemix/datasets/chatml_dataset.py:18: in <module>
    from paddlenlp.transformers.tokenizer_utils import ChatTemplateMixin
PaddleNLP/paddlenlp/__init__.py:34: in <module>
    from paddlenlp.utils.log import logger
PaddleNLP/paddlenlp/utils/__init__.py:33: in <module>
    from .serialization import load_torch
PaddleNLP/paddlenlp/utils/serialization.py:28: in <module>
    from paddlenlp.transformers.utils import device_guard
PaddleNLP/paddlenlp/transformers/__init__.py:17: in <module>
    from .model_utils import PretrainedModel, register_base_model
PaddleNLP/paddlenlp/transformers/model_utils.py:77: in <module>
    from ..generation import GenerationConfig, GenerationMixin
PaddleNLP/paddlenlp/generation/__init__.py:33: in <module>
    from .streamers import BaseStreamer, TextIteratorStreamer, TextStreamer
PaddleNLP/paddlenlp/generation/streamers.py:18: in <module>
    from paddlenlp.transformers.tokenizer_utils import PretrainedTokenizer
PaddleNLP/paddlenlp/transformers/tokenizer_utils.py:47: in <module>
    from ..data.vocab import Vocab
PaddleNLP/paddlenlp/data/__init__.py:18: in <module>
    from .data_collator import *
PaddleNLP/paddlenlp/data/data_collator.py:26: in <module>
    from ..transformers import BertTokenizer
E   ImportError: cannot import name 'BertTokenizer' from partially initialized module 'paddlenlp.transformers' (most likely due to a circular import) (/home/PaddleMIX/PaddleNLP/paddlenlp/transformers/__init__.py)
```