### PR TITLE
[FIX] fix the bug that some gemm config did not be handled

### DIFF
--- a/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
+++ b/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
@@ -69,7 +69,8 @@ void generic_moe_gemm_kernelLauncher(const T* A,
                                      cudaStream_t stream,
                                      int* kernel_occupancy = nullptr) {
   if (gemm_config.split_k_style != SplitKStyle::NO_SPLIT_K) {
-    PADDLE_FATAL("[MoeGemm] Grouped gemm does not support split-k");
+    PADDLE_THROW(
+        phi::errors::Fatal("[MoeGemm] Grouped gemm does not support split-k"));
   }
 
 #ifdef PADDLE_CUDA_BF16
@@ -169,9 +170,9 @@ void generic_moe_gemm_kernelLauncher(const T* A,
   int occupancy = std::min(2, GemmGrouped::maximum_active_blocks());
 
   if (occupancy == 0) {
-    PADDLE_FATAL(
+    PADDLE_THROW(phi::errors::Fatal(
         "[MoE Runner] GPU lacks the shared memory resources to run "
-        "GroupedGEMM kernel");
+        "GroupedGEMM kernel"));
   }
   const int threadblock_count = multi_processor_count * occupancy;
 
@@ -197,7 +198,7 @@ void generic_moe_gemm_kernelLauncher(const T* A,
   if (can_implement != cutlass::Status::kSuccess) {
     std::string err_msg = "MoEFC kernel will fail for params. Error: " +
                           std::string(cutlassGetStatusString(can_implement));
-    PADDLE_FATAL("[MoE Runner] " + err_msg);
+    PADDLE_THROW(phi::errors::Fatal("[MoE Runner] " + err_msg));
   }
 
   auto init_status = gemm.initialize(args);
@@ -243,7 +244,7 @@ struct dispatch_stages {
     std::string err_msg = "Cutlass fpA_intB gemm. Not instantiates for arch " +
                           std::to_string(arch::kMinComputeCapability) +
                           " with stages set to " + std::to_string(Stages);
-    PADDLE_FATAL("[dispatch_stages::dispatch] " + err_msg);
+    PADDLE_THROW(phi::errors::Fatal("[dispatch_stages::dispatch] " + err_msg));
   }
 };
 
@@ -394,7 +395,8 @@ void dispatch_gemm_config(const T* A,
     default:
       std::string err_msg = "dispatch_gemm_config does not support stages " +
                             std::to_string(gemm_config.stages);
-      PADDLE_FATAL("[MoE][dispatch_gemm_config] " + err_msg);
+      PADDLE_THROW(
+          phi::errors::Fatal("[MoE][dispatch_gemm_config] " + err_msg));
       break;
   }
 }
@@ -452,17 +454,18 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
     dispatch_gemm_config_macro(64, 128, 64, 32, 64, 64);
     dispatch_gemm_config_macro(128, 128, 64, 64, 32, 64);
     case CutlassTileConfig::Undefined:
-      PADDLE_FATAL("[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
       break;
     case CutlassTileConfig::ChooseWithHeuristic:
-      PADDLE_FATAL(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-          "already been set by heuristic.");
+          "already been set by heuristic."));
       break;
     default:
-      PADDLE_FATAL(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[dispatch_moe_gemm_to_cutlass] Config is invalid for same "
-          "type MoE tensorop GEMM.");
+          "type MoE tensorop GEMM."));
       break;
   }
 }
@@ -497,40 +500,44 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
       dispatch_gemm_config_macro(32, 128, 64, 32, 32, 64);
       dispatch_gemm_config_macro(64, 128, 64, 64, 64, 64);
       case CutlassTileConfig::Undefined:
-        PADDLE_FATAL("[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
         break;
       case CutlassTileConfig::ChooseWithHeuristic:
-        PADDLE_FATAL(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-            "already been set by heuristic.");
+            "already been set by heuristic."));
         break;
       default:
-        PADDLE_FATAL(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "[dispatch_moe_gemm_to_cutlass] Config is invalid for "
-            "mixed type tensorop GEMM.");
+            "mixed type tensorop GEMM."));
         break;
     }
   } else {
     switch (gemm_config.tile_config) {
       dispatch_gemm_config_macro(16, 128, 64, 16, 32, 64);
+      dispatch_gemm_config_macro(16, 256, 64, 16, 64, 64);
+      dispatch_gemm_config_macro(64, 64, 64, 32, 32, 64);
       dispatch_gemm_config_macro(32, 128, 64, 32, 32, 64);
+      dispatch_gemm_config_macro(128, 64, 64, 64, 32, 64);
       dispatch_gemm_config_macro(64, 128, 64, 64, 64, 64);
       dispatch_gemm_config_macro(128, 128, 64, 64, 64, 64);
       dispatch_gemm_config_macro(128, 128, 64, 128, 32, 64);
       dispatch_gemm_config_macro(128, 256, 64, 64, 64, 64);
       dispatch_gemm_config_macro(64, 128, 64, 64, 32, 64);
       case CutlassTileConfig::Undefined:
-        PADDLE_FATAL("[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
         break;
       case CutlassTileConfig::ChooseWithHeuristic:
-        PADDLE_FATAL(
+        PADDLE_THROW(common::errors::InvalidArgument(
             "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-            "already been set by heuristic.");
+            "already been set by heuristic."));
         break;
       default:
-        PADDLE_FATAL(
-            "[dispatch_moe_gemm_to_cutlass] Config is invalid for "
-            "mixed type tensorop GEMM.");
+        PADDLE_THROW(common::errors::InvalidArgument(
+            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
         break;
     }
   }
@@ -561,19 +568,19 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
   switch (gemm_config.tile_config) {
     dispatch_gemm_config_macro(128, 128, 8, 64, 64, 8);
     case CutlassTileConfig::Undefined:
-      PADDLE_FATAL(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[dispatch_moe_gemm_to_cutlass][SIMT] gemm config "
-          "undefined.");
+          "undefined."));
       break;
     case CutlassTileConfig::ChooseWithHeuristic:
-      PADDLE_FATAL(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[dispatch_moe_gemm_to_cutlass][SIMT] gemm config should "
-          "have already been set by heuristic.");
+          "have already been set by heuristic."));
       break;
     default:
-      PADDLE_FATAL(
+      PADDLE_THROW(common::errors::InvalidArgument(
           "[dispatch_moe_gemm_to_cutlass][SIMT] Unsupported config "
-          "for float MoE gemm.");
+          "for float MoE gemm."));
       break;
   }
 }

--- a/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
+++ b/csrc/gpu/moe/fused_moe/cutlass_kernels/moe_gemm/fused_moe_gemm_kernels_template.h
@@ -69,8 +69,8 @@ void generic_moe_gemm_kernelLauncher(const T* A,
                                      cudaStream_t stream,
                                      int* kernel_occupancy = nullptr) {
   if (gemm_config.split_k_style != SplitKStyle::NO_SPLIT_K) {
-    PADDLE_THROW(
-        phi::errors::Fatal("[MoeGemm] Grouped gemm does not support split-k"));
+    throw std::runtime_error(
+        "[MoeGemm] Grouped gemm does not support split-k");
   }
 
 #ifdef PADDLE_CUDA_BF16
@@ -170,9 +170,9 @@ void generic_moe_gemm_kernelLauncher(const T* A,
   int occupancy = std::min(2, GemmGrouped::maximum_active_blocks());
 
   if (occupancy == 0) {
-    PADDLE_THROW(phi::errors::Fatal(
+    throw std::runtime_error(
         "[MoE Runner] GPU lacks the shared memory resources to run "
-        "GroupedGEMM kernel"));
+        "GroupedGEMM kernel");
   }
   const int threadblock_count = multi_processor_count * occupancy;
 
@@ -198,7 +198,7 @@ void generic_moe_gemm_kernelLauncher(const T* A,
   if (can_implement != cutlass::Status::kSuccess) {
     std::string err_msg = "MoEFC kernel will fail for params. Error: " +
                           std::string(cutlassGetStatusString(can_implement));
-    PADDLE_THROW(phi::errors::Fatal("[MoE Runner] " + err_msg));
+    throw std::runtime_error("[MoE Runner] " + err_msg);
   }
 
   auto init_status = gemm.initialize(args);
@@ -244,7 +244,7 @@ struct dispatch_stages {
     std::string err_msg = "Cutlass fpA_intB gemm. Not instantiates for arch " +
                           std::to_string(arch::kMinComputeCapability) +
                           " with stages set to " + std::to_string(Stages);
-    PADDLE_THROW(phi::errors::Fatal("[dispatch_stages::dispatch] " + err_msg));
+    throw std::runtime_error("[dispatch_stages::dispatch] " + err_msg);
   }
 };
 
@@ -395,8 +395,8 @@ void dispatch_gemm_config(const T* A,
     default:
       std::string err_msg = "dispatch_gemm_config does not support stages " +
                             std::to_string(gemm_config.stages);
-      PADDLE_THROW(
-          phi::errors::Fatal("[MoE][dispatch_gemm_config] " + err_msg));
+      throw std::runtime_error(
+          "[MoE][dispatch_gemm_config] " + err_msg);
       break;
   }
 }
@@ -454,18 +454,18 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
     dispatch_gemm_config_macro(64, 128, 64, 32, 64, 64);
     dispatch_gemm_config_macro(128, 128, 64, 64, 32, 64);
     case CutlassTileConfig::Undefined:
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
+      throw std::runtime_error(
+          "[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
       break;
     case CutlassTileConfig::ChooseWithHeuristic:
-      PADDLE_THROW(common::errors::InvalidArgument(
+      throw std::runtime_error(
           "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-          "already been set by heuristic."));
+          "already been set by heuristic.");
       break;
     default:
-      PADDLE_THROW(common::errors::InvalidArgument(
+      throw std::runtime_error(
           "[dispatch_moe_gemm_to_cutlass] Config is invalid for same "
-          "type MoE tensorop GEMM."));
+          "type MoE tensorop GEMM.");
       break;
   }
 }
@@ -500,18 +500,18 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
       dispatch_gemm_config_macro(32, 128, 64, 32, 32, 64);
       dispatch_gemm_config_macro(64, 128, 64, 64, 64, 64);
       case CutlassTileConfig::Undefined:
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
+        throw std::runtime_error(
+            "[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
         break;
       case CutlassTileConfig::ChooseWithHeuristic:
-        PADDLE_THROW(common::errors::InvalidArgument(
+        throw std::runtime_error(
             "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-            "already been set by heuristic."));
+            "already been set by heuristic.");
         break;
       default:
-        PADDLE_THROW(common::errors::InvalidArgument(
+        throw std::runtime_error(
             "[dispatch_moe_gemm_to_cutlass] Config is invalid for "
-            "mixed type tensorop GEMM."));
+            "mixed type tensorop GEMM.");
         break;
     }
   } else {
@@ -526,18 +526,20 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
       dispatch_gemm_config_macro(128, 128, 64, 128, 32, 64);
       dispatch_gemm_config_macro(128, 256, 64, 64, 64, 64);
       dispatch_gemm_config_macro(64, 128, 64, 64, 32, 64);
+      dispatch_gemm_config_macro(256, 128, 64, 64, 64, 64);
       case CutlassTileConfig::Undefined:
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
+        throw std::runtime_error(
+            "[dispatch_moe_gemm_to_cutlass] gemm config undefined.");
         break;
       case CutlassTileConfig::ChooseWithHeuristic:
-        PADDLE_THROW(common::errors::InvalidArgument(
+        throw std::runtime_error(
             "[dispatch_moe_gemm_to_cutlass] gemm config should have "
-            "already been set by heuristic."));
+            "already been set by heuristic.");
         break;
       default:
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "[dispatch_moe_gemm_to_cutlass] gemm config undefined."));
+        throw std::runtime_error(
+            "[dispatch_moe_gemm_to_cutlass] Config is invalid for "
+            "mixed type tensorop GEMM.");
         break;
     }
   }
@@ -568,19 +570,19 @@ void dispatch_moe_gemm_to_cutlass(const T* A,
   switch (gemm_config.tile_config) {
     dispatch_gemm_config_macro(128, 128, 8, 64, 64, 8);
     case CutlassTileConfig::Undefined:
-      PADDLE_THROW(common::errors::InvalidArgument(
+      throw std::runtime_error(
           "[dispatch_moe_gemm_to_cutlass][SIMT] gemm config "
-          "undefined."));
+          "undefined.");
       break;
     case CutlassTileConfig::ChooseWithHeuristic:
-      PADDLE_THROW(common::errors::InvalidArgument(
+      throw std::runtime_error(
           "[dispatch_moe_gemm_to_cutlass][SIMT] gemm config should "
-          "have already been set by heuristic."));
+          "have already been set by heuristic.");
       break;
     default:
-      PADDLE_THROW(common::errors::InvalidArgument(
+      throw std::runtime_error(
           "[dispatch_moe_gemm_to_cutlass][SIMT] Unsupported config "
-          "for float MoE gemm."));
+          "for float MoE gemm.");
       break;
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Models

### Description
<!-- Describe what this PR does -->

跑模型时出现GEMM 的invalid configure问题
```shell
CUDA_VISIBLE_DEVICES=0,1
python -m paddle.distributed.launch --gpus 0,1 predictor.py --model_name_or_path mistralai/Mixtral-8x7B-Instruct-v0.1 --dtype bfloat16 --quant_type weight_only_int8 --mode dynamic --inference_model --append_attn
```

![image](https://github.com/user-attachments/assets/b7cb8b20-3d3e-42a1-bb64-f581eb5ca8cc)

原因：

模型执行时需要先进行gemm configure搜索，在获取的candidate_configure里，paddle中的三个gemm configure没有在dispatch_moe_gemm_to_cutlass中进行处理，导致触发PADDLE_FATAL直接中断执行进程。

修复方案：

1. 添加缺失的configure处理
2. 在搜索gemm_configure的相关代码中，用PADDLE_THROW替换PADDLE_FATAL


