### PR TITLE
[LLM] Fix quantization without qlora

### DIFF
--- a/llm/run_quantization.py
+++ b/llm/run_quantization.py
@@ -104,12 +104,21 @@ def main():
             raise ValueError("Please specific dtype: --fp16 or --bf16")
     else:
         dtype = "float32"
-    quantization_config = dict(
-        weight_quantize_algo=model_args.weight_quantize_algo,
-        qlora_weight_blocksize=model_args.qlora_weight_blocksize,
-        qlora_weight_double_quant=model_args.qlora_weight_double_quant,
-        qlora_weight_double_quant_block_size=model_args.qlora_weight_double_quant_block_size,
-    )
+
+    if hasattr(model_args, "qlora_weight_blocksize"):
+        quantization_config = dict(
+            weight_quantize_algo=model_args.weight_quantize_algo,
+            qlora_weight_blocksize=model_args.qlora_weight_blocksize,
+            qlora_weight_double_quant=model_args.qlora_weight_double_quant,
+            qlora_weight_double_quant_block_size=model_args.qlora_weight_double_quant_block_size,
+        )
+    else:
+        quantization_config = dict(
+            weight_quantize_algo=model_args.weight_quantize_algo,
+            weight_blocksize=model_args.weight_blocksize,
+            weight_double_quant=model_args.weight_double_quant,
+            weight_double_quant_block_size=model_args.weight_double_quant_block_size,
+        )
 
     model_config = AutoConfig.from_pretrained(
         model_args.model_name_or_path,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
修复了进行量化时没有进行qlora的模型报错的问题。
报错信息：
```
[2025-05-22 08:51:36,258] [   DEBUG] - top_k                         : 1
[2025-05-22 08:51:36,258] [   DEBUG] - top_p                         : 1.0
[2025-05-22 08:51:36,258] [   DEBUG] - 
[2025-05-22 08:51:36,258] [ WARNING] - Process rank: -1, device: gpu, world_size: 1, distributed training: False, 16-bits training: False
Traceback (most recent call last):
  File "/home/aistudio/PaddleNLP/llm/run_quantization.py", line 570, in <module>
    main()
  File "/home/aistudio/PaddleNLP/llm/run_quantization.py", line 109, in main
    qlora_weight_blocksize=model_args.qlora_weight_blocksize,
AttributeError: 'ModelConfig' object has no attribute 'qlora_weight_blocksize'. Did you mean: 'weight_blocksize'?
```

修改后可以正常进行量化。

Modified:
```llm/run_quantization.py```

@DrownFish19