### PR TITLE
Update model_utils.py

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -859,7 +859,7 @@ def faster_set_state_dict(model, state_dict, model_state_dict=None, strict_dtype
     return error_msgs
 
 
-def _load_state_dict_into_model(model_to_load, state_dict, start_prefix, model_to_load_state_dict):
+def _load_state_dict_into_model(model_to_load, state_dict, start_prefix, model_to_load_state_dict={}):
     # torch will cast dtype in load_state_dict, but paddle strictly check dtype
     if len(start_prefix) > 0:
         for key in list(state_dict.keys()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->


Error Log:
```
[2025-05-24 01:11:58,573] [    INFO] - [timelog] checkpoint saving time: 23.38s (2025-05-24 01:11:58) 
[2025-05-24 01:11:58,573] [    INFO] - 
Training completed. 

[2025-05-24 01:11:58,573] [    INFO] - Loading best model from ./checkpoints/sft_ckpts/checkpoint-250 (score: 0.5545060999606454).
Traceback (most recent call last):
  File "/workspace/models/mat_llm/PaddleNLP/llm/run_finetune.py", line 723, in <module>
    main()
  File "/workspace/models/mat_llm/PaddleNLP/llm/run_finetune.py", line 458, in main
    train_result = trainer.train(resume_from_checkpoint=checkpoint)
  File "/workspace/models/mat_llm/PaddleNLP/paddlenlp/trainer/trainer.py", line 991, in train
    return self._inner_training_loop(
  File "/workspace/models/mat_llm/PaddleNLP/paddlenlp/trainer/trainer.py", line 1430, in _inner_training_loop
    self.unified_checkpoint_handler.load_unified_checkpoint(
  File "/workspace/models/mat_llm/PaddleNLP/paddlenlp/trainer/unified_checkpoint/unified_checkpoint.py", line 188, in load_unified_checkpoint
    load_single_card_checkpoint(model, resume_from_checkpoint)
  File "/workspace/models/mat_llm/PaddleNLP/paddlenlp/trainer/unified_checkpoint/load_save_single_card.py", line 187, in load_single_card_checkpoint
    error_msgs = _load_state_dict_into_model(model, state_dict, "")
TypeError: _load_state_dict_into_model() missing 1 required positional argument: 'model_to_load_state_dict'
(paddlenlp) λ yq01-inf-hic-k8s-a100-aa24-0087 /workspace/models/mat_llm/PaddleNLP/llm git log
commit ddcb722e3d37be8b5cd283a6a509dc0a25b56bd6 (HEAD -> develop, origin/develop, origin/HEAD)

```

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/bec7dc20-f99b-4211-a664-bc361222d94d" />



