### PR TITLE
[AutoParallel] improve qwen rms norm custom op performance

### DIFF
--- a/paddlenlp/transformers/qwen/modeling_auto.py
+++ b/paddlenlp/transformers/qwen/modeling_auto.py
@@ -727,6 +727,12 @@ class QWenModelAuto(QWenPretrainedModelAuto):
                         get_mesh(block.ipp),
                         [dist.Replicate(), dist.Replicate()],
                     )
+            else:
+                hidden_states = dist.reshard(
+                    hidden_states,
+                    get_mesh(block.ipp),
+                    [dist.Shard(0), dist.Shard(1)],
+                )
             if self.enable_recompute and self.training and has_gradient and self.recompute_granularity == "full":
                 outputs = self.recompute_training(
                     block,
@@ -879,7 +885,7 @@ class QWenForCausalLM3DAuto(QWenPretrainedModelAuto):
         hidden_states = transformer_outputs[0]
 
         # if labels is None，means we need full output, instead of tensor_parallel_output
-        # tensor_parallel_output is together with ParallelCrossEntropy
+        # tensor_parallel_output is togather with ParallelCrossEntropy
         tensor_parallel_output = (
             self.config.tensor_parallel_output and labels is not None and self.config.tensor_parallel_degree > 1
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models 

### Description
<!-- Describe what this PR does -->
`qwen` 的 `sd4mp2` 动半中，`fused_rms_norm` 的输入 `dims_mapping` 是[0, -1, -1 ]，这在反向执行过程中会引入较多的 `reshard` 通信，此时的 timeline 情况是：
<img width="728" alt="2026e577bdbf650543902e16743fdd78" src="https://github.com/user-attachments/assets/a5d2e6ae-8112-4248-8813-59d54360ca8e" />

修改 `fused_rms_norm` 的输入 `dims_mapping` 是[0, 1, -1 ]，可以反向无需进行 `reshard`，提高性能吞吐，此时的timeline 情况是：
![Uploading image.png…]()

H 卡上 `qwen + layer20 + sd4mp2 + fused+rms_norm` 测试情况：
修改前吞吐：
修改后吞吐：