### PR TITLE
Support fastsafetensors to load model

### DIFF
--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -3135,24 +3135,27 @@ def load_sharded_checkpoint_as_one(folder, variant=None, return_numpy=False):
 
     shard_files = list(set(index["weight_map"].values()))
     loader = safe_load_file if load_safe else partial(paddlenlp_load, map_location="np" if return_numpy else "cpu")
-
+    ret = {}
     try:
-        # Not use `fastsafe_open` because the end of `with` will destroy the cuda memory, tensor can not use.
-        from fastsafetensors import SafeTensorsFileLoader, SingleGroup
+        from fastsafetensors import fastsafe_open
 
         path = [os.path.join(folder, shard_file) for shard_file in shard_files]
-        device = "gpu" if paddle.is_compiled_with_cuda() else "cpu"
-        not_use_gds = True
+        device = "gpu" if paddle.device.cuda.device_count() else "cpu"
+        not_use_gds = False
         # Check load time of files
         for _ in tqdm(range(1)):
-            loader = SafeTensorsFileLoader(
-                SingleGroup(), device=device, nogds=not_use_gds, debug_log=False, framework="paddle"
-            )
-            loader.add_filenames({0: path})
-            bufs_pp = loader.copy_files_to_device(max_copy_block_size=256 * 1024 * 1024)
-            key_dims = {key: -1 for key in loader.get_keys()}
-            ret = bufs_pp.as_dict(key_dims)
+            with fastsafe_open(
+                filenames=path,
+                nogds=not_use_gds,
+                device=device,
+                max_copy_block_size=256 * 1024 * 1024,
+                framework="paddle",
+            ) as f:
+                for key in f.get_keys():
+                    # Must clone, because cuda memory will be destroyed after `with` end.
+                    ret[key] = f.get_tensor(key).clone().detach()
     except:
+
         for shard_file in tqdm(shard_files):
             state_dict = loader(os.path.join(folder, shard_file))
             ret.update(state_dict)

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -3136,10 +3136,26 @@ def load_sharded_checkpoint_as_one(folder, variant=None, return_numpy=False):
     shard_files = list(set(index["weight_map"].values()))
     loader = safe_load_file if load_safe else partial(paddlenlp_load, map_location="np" if return_numpy else "cpu")
 
-    ret = {}
-    for shard_file in tqdm(shard_files):
-        state_dict = loader(os.path.join(folder, shard_file))
-        ret.update(state_dict)
+    try:
+        # Not use `fastsafe_open` because the end of `with` will destroy the cuda memory, tensor can not use.
+        from fastsafetensors import SafeTensorsFileLoader, SingleGroup
+
+        path = [os.path.join(folder, shard_file) for shard_file in shard_files]
+        device = "gpu" if paddle.is_compiled_with_cuda() else "cpu"
+        not_use_gds = True
+        # Check load time of files
+        for _ in tqdm(range(1)):
+            loader = SafeTensorsFileLoader(
+                SingleGroup(), device=device, nogds=not_use_gds, debug_log=False, framework="paddle"
+            )
+            loader.add_filenames({0: path})
+            bufs_pp = loader.copy_files_to_device(max_copy_block_size=256 * 1024 * 1024)
+            key_dims = {key: -1 for key in loader.get_keys()}
+            ret = bufs_pp.as_dict(key_dims)
+    except:
+        for shard_file in tqdm(shard_files):
+            state_dict = loader(os.path.join(folder, shard_file))
+            ret.update(state_dict)
 
     if not return_numpy:
         for key in list(ret.keys()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

支持使用fastsafetensor加载模型

fastsafetensor安装：

```
# 需要同时安装torch和paddle（暂时）
git clone https://github.com/foundation-model-stack/fastsafetensors.git
cd fastsafetensors
make install

# 只需要安装paddle
git clone -b only_paddle https://github.com/zeroRains/fastsafetensors.git
cd fastsafetensors
make install

```
已向原仓库提交pr，后续可以直接pip install安装：

> ps: pr已合入，可以直接clone官方仓库，对方预计两周内在PyPI上发版

https://github.com/foundation-model-stack/fastsafetensors/pull/16

GPU：RTX A6000 

测试指令：

```shell
cd llm

# 用这里的model_name变量替换下面指令的$model_name
model_name="Qwen/Qwen2.5-7B-Instruct"
# model_name="meta-llama/Meta-Llama-3-8B-Instruct"

time python ./predict/predictor.py --model_name_or_path $model_name --dtype float16 --mode dynamic --decode_strategy greedy_search --inference_model 1 --block_attn 1 --append_attn 1
```

测试记录：

pr中修改部分有一个not_use_gds的变量，设置为true时就是不使用GDS，设置为false时就是使用GDS

|  method | node | dtyp | model |   GDS  | load files time(s) | end2end execute time(s) | 备注 |
| ---- | --- |---- | ---- |----|----|----|----|
| base| 1 | float16 | meta-llama/Meta-Llama-3-8B-Instruct |  × | 11 | 46.648 |  |
| fastsafetensors | 1 | float16 | meta-llama/Meta-Llama-3-8B-Instruct | √ | 80 | 115.363 |  |
| fastsafetensors | 1 | float16 | meta-llama/Meta-Llama-3-8B-Instruct | × | 2 | 38.081 |  |
| base | 1 | float16 | Qwen/Qwen2.5-7B-Instruct | × | 75 | 94.809 |  |
| fastsafetensors | 1 | float16 | Qwen/Qwen2.5-7B-Instruct | √ | 54            | 76.694                  |  |
| fastsafetensors | 1 | float16 | Qwen/Qwen2.5-7B-Instruct | × | 2 | 15.197 |  |


环境准备：

参考[官方提供的安装方式](https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html)

以ubuntu20.04为例子

GPU Direct Storage(GDS)环境安装：
GDS需要对显卡驱动的一些部分进行更新，在docker容器内安装可能会失效，建议在宿主机安装。此外GDS是对SSD进行直接访问，使用GDS读取的文件需要放在SSD的磁盘中。另外文件格式最好是xfs，ext4其他格式可以找找GDS官方目前支持的文件格式(可以通过`df -Th`检查每个磁盘的文件类型)。

1. 检查是否安装cuda，cuda版本是否符合以及cuda中是否有GDS工具包

首先要确认当前驱动所能支持的cuda最高到哪个版本，使用`nvidia-smi`的指令可以检查到当前cuda支持的最高版本（`CUDA Version: 12.8`）。

接着使用`nvcc -V`检查当前是否已经安装了cuda （找不到指令的话，可以到`/usr/local/cuda/bin`中找找，如果文件夹不存在就是没有安装cuda）。

由于`Hopper`架构需要cuda12.x才能使用，因此低于cuda12.x的情况需要卸载重新安装（可以到`/usr/local/cuda/bin`中找到`cuda-uninstaller`的执行文件然后执行，没有的话可以直接删除cuda文件夹）。

如果是当前就是cuda12.x，需要检查是否存在GDS工具包，如果没有也要卸载重装。检查方式见下面的代码行。

如果找不到文件则说明没有安装GDS，需要重装cuda。如果输出结果与下面的输出结果差不多，可以跳到后面的`5.GDS环境测试`，尝试看看能不能使用GDS环境，如果执行成功就不需要再做任何步骤了，说明本来就有GDS环境

```shell
# 执行指令
/usr/local/cuda/gds/tools/gdscheck -p

# 结果
 GDS release version: 1.4.0.31
 nvidia_fs version:  2.13 libcufile version: 2.12
 Platform: x86_64
 ============
 ENVIRONMENT:
 ============
 =====================
 DRIVER CONFIGURATION:
 =====================
 NVMe               : Unsupported
 NVMeOF             : Unsupported
 SCSI               : Unsupported
 ScaleFlux CSD      : Unsupported
 NVMesh             : Unsupported
 DDN EXAScaler      : Unsupported
 IBM Spectrum Scale : Unsupported
 NFS                : Unsupported
 BeeGFS             : Unsupported
 WekaFS             : Unsupported
 Userspace RDMA     : Unsupported
 --Mellanox PeerDirect : Disabled
 --rdma library        : Not Loaded (libcufile_rdma.so)
 --rdma devices        : Not configured
 --rdma_device_status  : Up: 0 Down: 0
 =====================
 CUFILE CONFIGURATION:
 =====================
 properties.use_compat_mode : true
 properties.force_compat_mode : false
 properties.gds_rdma_write_support : true
 properties.use_poll_mode : false
 properties.poll_mode_max_size_kb : 4
 properties.max_batch_io_size : 128
 properties.max_batch_io_timeout_msecs : 5
 properties.max_direct_io_size_kb : 1024
 properties.max_device_cache_size_kb : 131072
 properties.max_device_pinned_mem_size_kb : 18014398509481980
 properties.posix_pool_slab_size_kb : 4 1024 16384 
 properties.posix_pool_slab_count : 128 64 32 
 properties.rdma_peer_affinity_policy : RoundRobin
 properties.rdma_dynamic_routing : 0
 fs.generic.posix_unaligned_writes : false
 fs.lustre.posix_gds_min_kb: 0
 fs.beegfs.posix_gds_min_kb: 0
 fs.weka.rdma_write_support: false
 fs.gpfs.gds_write_support: false
 profile.nvtx : false
 profile.cufile_stats : 0
 miscellaneous.api_check_aggressive : false
 =========
 GPU INFO:
 =========
 GPU index 0 NVIDIA RTX A6000 bar:1 bar size (MiB):256 supports GDS, IOMMU State: Disabled
 ==============
 PLATFORM INFO:
 ==============
 IOMMU: disabled
 Platform verification succeeded
```

2. 检查iommu

按照官方提供的安装方式，`iommu`需要被关闭

```shell
# 执行指令，如果没有返回任何东西，可以跳过这一节了
dmesg | grep -i iommu

# 关闭 iommu
sudo vi /etc/default/grub

# 找到GRUB_CMDLINE_LINUX_DEFAULT=的内容，如果没有就自己添加
# 如果intel的cpu就用intel_iommu，amd就用amd_iommu
GRUB_CMDLINE_LINUX_DEFAULT="intel_iommu=off"

# 如果GRUB_CMDLINE_LINUX_DEFAULT中还有其他内容，就直接加个空格，然后添加上面的指令，比如
GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 amd_iommu=off"

# 然后更新重启
sudo update-grub
sudo reboot
```

3. MLNX_OFED安装

另外，官方文档中还说了如果要支持GDS还需要安装[MLNX_OFED](https://docs.nvidia.com/gpudirect-storage/troubleshooting-guide/index.html#mofed-req-install)

可以到[MLNX_OFED官网](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/)选择对应的包进行下载

```shell
wget https://content.mellanox.com/ofed/MLNX_OFED-5.8-6.0.4.2/MLNX_OFED_LINUX-5.8-6.0.4.2-ubuntu20.04-x86_64.tgz
tar -zxvf  MLNX_OFED_LINUX-5.8-6.0.4.2-ubuntu20.04-x86_64.tgz
cd MLNX_OFED_LINUX-5.8-6.0.4.2-ubuntu20.04-x86_64
# 完整安装
./mlnxofedinstall --with-nvmf --with-nfsrdma --enable-gds --add-kernel-support --dkms
```
按着上面的步骤安装好就可以了，这个步骤可能会安装失败而且概率很大，如果是缺少什么依赖按照提示安装就行，但如果是其他原因比如xxx.conf不存在或者python脚本执行错误之类的，这个就看看具体是什么再找找有没有解决办法了。

如果实在解决不了，也可以简单一点直接执行，大概率能安装上，但是可能后续的nvidia-fs就安装不上了。这个不好说。
```shel
# 简易安装
./mlnxofedinstall
```
如果简单的方法还是装不上，那就不装了，后续还是有概率能用GDS的。

4. 下载cuda安装包和cudnn

然后到Nvidia官方下载正确的驱动:
[cuda](https://developer.nvidia.com/cuda-12-6-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=runfile_local)
[cudnn](https://developer.nvidia.com/rdp/cudnn-archive)

下面以cuda12.6的安装为例：

```shell
# 下载并执行cuda安装
wget https://developer.download.nvidia.com/compute/cuda/12.6.0/local_installers/cuda_12.6.0_560.28.03_linux.run
sudo sh cuda_12.6.0_560.28.03_linux.run

# 接着按照提示来到这个界面，按照下面的选择进行cuda安装。
# 这里的nvidia-fs是否选择取决于完整的MLNX_OFED是否安装成功
# 如果安装成功了，可以选择，大概率是能安装上的
# 如果是成功安装简易版本，也可以选择，可能能装上
# 如果是没安装成功，那就别选了，大概率安装不上
│ CUDA Installer                                                               │
│ - [ ] Driver                                                                 │
│      [ ] 560.28.03                                                           │
│ + [X] CUDA Toolkit 12.6                                                      │
│   [X] CUDA Demo Suite 12.6                                                   │
│   [X] CUDA Documentation 12.6                                                │
│ - [X] Kernel Objects                                                         │
│      [X] nvidia-fs                                                           │
│   Options                                                                    │
│   Install 

```
安装好后使用GDS Tools的工具包检查一下环境
```shell
/usr/local/cuda/gds/tools/gdscheck -p

# 结果
 GDS release version: 1.4.0.31
 nvidia_fs version:  2.13 libcufile version: 2.12
 Platform: x86_64
 ============
 ENVIRONMENT:
 ============
 =====================
 DRIVER CONFIGURATION:
 =====================
 NVMe               : Unsupported
 NVMeOF             : Unsupported
 SCSI               : Unsupported
 ScaleFlux CSD      : Unsupported
 NVMesh             : Unsupported
 DDN EXAScaler      : Unsupported
 IBM Spectrum Scale : Unsupported
 NFS                : Unsupported
 BeeGFS             : Unsupported
 WekaFS             : Unsupported
 Userspace RDMA     : Unsupported
 --Mellanox PeerDirect : Disabled
 --rdma library        : Not Loaded (libcufile_rdma.so)
 --rdma devices        : Not configured
 --rdma_device_status  : Up: 0 Down: 0
 =====================
 CUFILE CONFIGURATION:
 =====================
 properties.use_compat_mode : true
 properties.force_compat_mode : false
 properties.gds_rdma_write_support : true
 properties.use_poll_mode : false
 properties.poll_mode_max_size_kb : 4
 properties.max_batch_io_size : 128
 properties.max_batch_io_timeout_msecs : 5
 properties.max_direct_io_size_kb : 1024
 properties.max_device_cache_size_kb : 131072
 properties.max_device_pinned_mem_size_kb : 18014398509481980
 properties.posix_pool_slab_size_kb : 4 1024 16384 
 properties.posix_pool_slab_count : 128 64 32 
 properties.rdma_peer_affinity_policy : RoundRobin
 properties.rdma_dynamic_routing : 0
 fs.generic.posix_unaligned_writes : false
 fs.lustre.posix_gds_min_kb: 0
 fs.beegfs.posix_gds_min_kb: 0
 fs.weka.rdma_write_support: false
 fs.gpfs.gds_write_support: false
 profile.nvtx : false
 profile.cufile_stats : 0
 miscellaneous.api_check_aggressive : false
 =========
 GPU INFO:
 =========
 GPU index 0 NVIDIA RTX A6000 bar:1 bar size (MiB):256 supports GDS, IOMMU State: Disabled
 ==============
 PLATFORM INFO:
 ==============
 IOMMU: disabled
 Platform verification succeeded
```

结果一致，说明差不多安装好了。由于Paddle的使用还需要cudnn，所以cudnn也需要安装一下，需要到官方下去下载压缩包[cudnn](https://developer.nvidia.com/rdp/cudnn-archive)

```shell
tar -xvf cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz
cd cudnn-linux-x86_64-8.9.7.29_cuda12-archive
cp include/cudnn*.h /usr/local/cuda/include
cp lib/libcudnn* /usr/local/cuda/lib64
chmod a+r /usr/local/cuda/include/cudnn*.h 
chmod a+r /usr/local/cuda/lib64/libcudnn*
```

然后将cuda环境加入环境变量
```shell
vim ~/.bashrc

# 添加下面两行
export PATH=/usr/local/cuda/bin:$PATH
export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH

# 应用一下
source ~/.bashrc
```
然后就可以去试试GDS环境是否可用了

5. GDS环境测试：
```shell
# 假设/data目录正好对应SSD硬盘
# 创建一个1GB的文件
time dd if=/dev/zero of=/data/dd.txt bs=40M count=25
# 然后调用gds tools里的工具进行检测
/usr/local/cuda/gds/tools/gdsio -f /data/dd.txt -d 0 -w 4 -s 10G -i 1M -I 0 -x 0
# 然后等待返回结果和下面差不多，就是GDS环境可用了。如果出现注册失败等类似字样，就是GDS环境不可用。
IoType: READ XferType: GPUD Threads: 4 DataSetSize: 332800/409600(KiB) IOSize: 1024(KiB) Throughput: 5.513085 GiB/sec, Avg_Latency: 957.994689 usecs ops: 325 total_time 0.057569 secs
```

> ps: GDS安装比较玄学，我在两台机器上安装了GDS，第一台是安装了完整的MLNX_OFED和nvidia-fs的，能够成功用GDS读取SSD中的文件。另一台是只安装了简易版的MLNX_OFED，nvidia-fs是没安装的，也没有SSD，但是也能用GDS。_(:з」∠)_
> 另外这里还有[其他的安装教程](https://www.chenshaowen.com/blog/how-to-enable-gds-on-gpu-host.html)，我试过了，最后HDD的硬盘全都识别不出来了，而且GDS好像也还不可用（可能只有我这样？）。