### PR TITLE
[tests] migrate to unittest.assertEqual

### DIFF
--- a/tests/transformers/speecht5/test_feature_extraction.py
+++ b/tests/transformers/speecht5/test_feature_extraction.py
@@ -333,7 +333,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         feat_dict["return_attention_mask"] = True
         feat_extract = self.feature_extraction_class(**feat_dict)
         speech_inputs = self.feat_extract_tester.prepare_inputs_for_target()
-        input_lenghts = [len(x) for x in speech_inputs]
+        input_lengths = [len(x) for x in speech_inputs]
         input_name = feat_extract.model_input_names[0]
 
         processed = BatchFeature({input_name: speech_inputs})
@@ -343,18 +343,18 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         processed = feat_extract.pad(processed, padding="longest", return_tensors="np")
         self.assertIn("attention_mask", processed)
         self.assertListEqual(list(processed.attention_mask.shape), list(processed[input_name].shape[:2]))
-        self.assertListEqual(processed.attention_mask.sum(-1).tolist(), input_lenghts)
+        self.assertListEqual(processed.attention_mask.sum(-1).tolist(), input_lengths)
 
     def test_attention_mask_with_truncation_target(self):
         feat_dict = self.feat_extract_dict
         feat_dict["return_attention_mask"] = True
         feat_extract = self.feature_extraction_class(**feat_dict)
         speech_inputs = self.feat_extract_tester.prepare_inputs_for_target()
-        input_lenghts = [len(x) for x in speech_inputs]
+        input_lengths = [len(x) for x in speech_inputs]
         input_name = feat_extract.model_input_names[0]
 
         processed = BatchFeature({input_name: speech_inputs})
-        max_length = min(input_lenghts)
+        max_length = min(input_lengths)
 
         feat_extract.feature_size = feat_extract.num_mel_bins  # hack!
 
@@ -393,7 +393,7 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         input_speech = self._load_datasamples(1)
         feature_extractor = SpeechT5FeatureExtractor()
         input_values = feature_extractor(input_speech, return_tensors="pd").input_values
-        self.assertEquals(input_values.shape, [1, 93680])
+        self.assertEqual(input_values.shape, [1, 93680])
         self.assertTrue(paddle.allclose(input_values[0, :30], EXPECTED_INPUT_VALUES, atol=1e-6))
 
     def test_integration_target(self):
@@ -409,5 +409,5 @@ class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         input_speech = self._load_datasamples(1)
         feature_extractor = SpeechT5FeatureExtractor()
         input_values = feature_extractor(audio_target=input_speech, return_tensors="pd").input_values
-        self.assertEquals(input_values.shape, [1, 366, 80])
+        self.assertEqual(input_values.shape, [1, 366, 80])
         self.assertTrue(paddle.allclose(input_values[0, 0, :30], EXPECTED_INPUT_VALUES, atol=1e-4))

--- a/tests/transformers/yuan/test_tokenizer.py
+++ b/tests/transformers/yuan/test_tokenizer.py
@@ -45,5 +45,5 @@ class YuanTokenizationTest(unittest.TestCase):
                 context_data=context_data,
             )
             for idx, round in enumerate(conversation_result["conversations"]):
-                self.assertEquals(tokenizer.decode(round[0]), decode_outputs[idx][0])
-                self.assertEquals(tokenizer.decode(round[1]), decode_outputs[idx][1])
+                self.assertEqual(tokenizer.decode(round[0]), decode_outputs[idx][0])
+                self.assertEqual(tokenizer.decode(round[1]), decode_outputs[idx][1])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
Refactoring

### PR changes
Tests

### Description
This small PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```
