### PR TITLE
improve qwen perf

### DIFF
--- a/paddlenlp/transformers/qwen/modeling_auto.py
+++ b/paddlenlp/transformers/qwen/modeling_auto.py
@@ -675,6 +675,7 @@ class QWenModelAuto(QWenPretrainedModelAuto):
                 inputs_embeds = self.wte(input_ids)
 
         hidden_states = inputs_embeds
+        hidden_states = dist.reshard(hidden_states, get_mesh(), [dist.Shard(0), dist.Replicate()])
 
         use_casual_mask = get_use_casual_mask()
         if use_casual_mask:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
qwen 动手在进入 block 之前的 dims_mapping 是 [0, -1, -1]，而在动半进入 block 之前 dims_mapping 是 [0, 1, -1]，现对 动半 添加 reshard ，对齐动手切分状态
qwen sd4mp2 layer20
添加前吞吐：7404 token/cars/s
添加后吞吐：8096(+692, +9.3%) token/cars/s

