### PR TITLE
open gpt dp CI test

### DIFF
--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -2218,7 +2218,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.55853844 # output of dropout is different after supporting spmd
+    loss_base=10.55853653 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2290,7 +2290,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.56579494 # output of dropout is different after supporting spmd
+    loss_base=10.5657959 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2363,7 +2363,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.59993172     # note: need to debug
-    loss_base=10.57174873 # output of dropout is different after supporting spmd
+    loss_base=10.57174778 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -159,11 +159,11 @@ function llm_gpt_case_list_auto() {
     fun_list=(
         # The test name must have "llm_gpt_dygraph_auto_" as a prefix, 
         # which will be used for tracking the execution status of the case.
-        # llm_gpt_dygraph_auto_bs8_fp32_DP2
-        # llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
-        # llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
-        # llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
-        # llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate
+        llm_gpt_dygraph_auto_bs8_fp32_DP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2
+        llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2
+        llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2
+        llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate
         llm_gpt_pir_auto_bs4_TP2
         llm_gpt_pir_auto_bs4_TP2_PP2
         llm_gpt_pir_auto_bs8_DP2_TP2_PP2
@@ -2218,7 +2218,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.55848312 # output of dropout is different after supporting spmd
+    loss_base=10.55853844 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2290,7 +2290,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.56786537 # output of dropout is different after supporting spmd
+    loss_base=10.56579494 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2363,7 +2363,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.59993172     # note: need to debug
-    loss_base=10.57312012 # output of dropout is different after supporting spmd
+    loss_base=10.57174873 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2436,7 +2436,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.57452488
+    loss_base=10.57304478
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2510,7 +2510,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.566679
+    loss_base=10.56716251
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -2222,7 +2222,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.55920792 # after add dropout spmd
+        loss_base=10.56019211 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2290,7 +2290,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.56579494 # output of dropout is different after supporting spmd
+    loss_base=10.5760107 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2363,7 +2363,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.59993172     # note: need to debug
-    loss_base=10.57174873 # output of dropout is different after supporting spmd
+    loss_base=10.57701015 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2436,7 +2436,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.57304478
+    loss_base=10.57861042
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2510,7 +2510,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.56716251
+    loss_base=10.56166935
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -2290,7 +2290,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.5760107 # output of dropout is different after supporting spmd
+    loss_base=10.56579494 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2363,7 +2363,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.59993172     # note: need to debug
-    loss_base=10.57701015 # output of dropout is different after supporting spmd
+    loss_base=10.57174873 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2436,7 +2436,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.57861042
+    loss_base=10.57304478
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
@@ -2510,7 +2510,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.56166935
+    loss_base=10.56716251
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -2294,7 +2294,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.57873726 # after add dropout spmd
+        loss_base=10.5760107 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2367,7 +2367,7 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.5769043 # after add dropout spmd
+        loss_base=10.57701015 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2440,7 +2440,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.57843781 # after add dropout spmd
+        loss_base=10.57861042 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2514,7 +2514,7 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2_intermediate() {
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.56109619 # after add dropout spmd
+        loss_base=10.56166935 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -99,63 +99,64 @@ IS_A100=$(is_a100)
 ####################################
 get_diff_TO_case(){
     cd ${nlp_dir}
-    if [ $IS_A100 -ne 0 ];then
-        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-            arr_file_name=(${file_name//// })
-            dir1=${arr_file_name[0]}
-            dir2=${arr_file_name[1]}
-            dir3=${arr_file_name[2]}
-            dir4=${arr_file_name[3]}
-            file_item=$dir1/$dir2/$dir3/$dir4
-            echo "file_name:"${file_name}, "path:"${file_item}
-            if [ ! -f ${file_name} ];then # 针对pr删掉文件
-                continue
-            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-                continue
-            else
-                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-                        case_list[${#case_list[*]}]=gpt-3_auto
-                        case_list[${#case_list[*]}]=gpt-3_dygraph
-                    fi
-                done
-                for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
-                    if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
-                        case_list[${#case_list[*]}]=llama_auto
-                    fi
-                done
-                for ((i=0; i<${#target_lists_for_deepseek[@]}; i++)); do
-                    if [[ ${file_item} == *${target_lists_for_deepseek[i]}* ]];then
-                        case_list[${#case_list[*]}]=deepseek_auto
-                    fi
-                done
-            fi
-        done
-    else
-        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-            arr_file_name=(${file_name//// })
-            dir1=${arr_file_name[0]}
-            dir2=${arr_file_name[1]}
-            dir3=${arr_file_name[2]}
-            dir4=${arr_file_name[3]}
-            file_item=$dir1/$dir2/$dir3/$dir4
-            echo "file_name:"${file_name}, "path:"${file_item}
-            if [ ! -f ${file_name} ];then # 针对pr删掉文件
-                continue
-            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-                continue
-            else
-                case_list[${#case_list[*]}]=gpt-3_auto
-                case_list[${#case_list[*]}]=llama_auto
-                case_list[${#case_list[*]}]=deepseek_auto
-                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-                        case_list[${#case_list[*]}]=gpt-3_dygraph
-                    fi
-                done
-            fi
-        done
-    fi
+    case_list[${#case_list[*]}]=gpt-3_auto
+    # if [ $IS_A100 -ne 0 ];then
+    #     for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+    #         arr_file_name=(${file_name//// })
+    #         dir1=${arr_file_name[0]}
+    #         dir2=${arr_file_name[1]}
+    #         dir3=${arr_file_name[2]}
+    #         dir4=${arr_file_name[3]}
+    #         file_item=$dir1/$dir2/$dir3/$dir4
+    #         echo "file_name:"${file_name}, "path:"${file_item}
+    #         if [ ! -f ${file_name} ];then # 针对pr删掉文件
+    #             continue
+    #         elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+    #             continue
+    #         else
+    #             for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+    #                 if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+    #                     case_list[${#case_list[*]}]=gpt-3_auto
+    #                     case_list[${#case_list[*]}]=gpt-3_dygraph
+    #                 fi
+    #             done
+    #             for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
+    #                 if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
+    #                     case_list[${#case_list[*]}]=llama_auto
+    #                 fi
+    #             done
+    #             for ((i=0; i<${#target_lists_for_deepseek[@]}; i++)); do
+    #                 if [[ ${file_item} == *${target_lists_for_deepseek[i]}* ]];then
+    #                     case_list[${#case_list[*]}]=deepseek_auto
+    #                 fi
+    #             done
+    #         fi
+    #     done
+    # else
+    #     for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+    #         arr_file_name=(${file_name//// })
+    #         dir1=${arr_file_name[0]}
+    #         dir2=${arr_file_name[1]}
+    #         dir3=${arr_file_name[2]}
+    #         dir4=${arr_file_name[3]}
+    #         file_item=$dir1/$dir2/$dir3/$dir4
+    #         echo "file_name:"${file_name}, "path:"${file_item}
+    #         if [ ! -f ${file_name} ];then # 针对pr删掉文件
+    #             continue
+    #         elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+    #             continue
+    #         else
+    #             case_list[${#case_list[*]}]=gpt-3_auto
+    #             case_list[${#case_list[*]}]=llama_auto
+    #             case_list[${#case_list[*]}]=deepseek_auto
+    #             for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+    #                 if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+    #                     case_list[${#case_list[*]}]=gpt-3_dygraph
+    #                 fi
+    #             done
+    #         fi
+    #     done
+    # fi
 }
 ####################################
 function contain_case(){

--- a/scripts/distribute/run_ci.sh
+++ b/scripts/distribute/run_ci.sh
@@ -99,64 +99,63 @@ IS_A100=$(is_a100)
 ####################################
 get_diff_TO_case(){
     cd ${nlp_dir}
-    case_list[${#case_list[*]}]=gpt-3_auto
-    # if [ $IS_A100 -ne 0 ];then
-    #     for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-    #         arr_file_name=(${file_name//// })
-    #         dir1=${arr_file_name[0]}
-    #         dir2=${arr_file_name[1]}
-    #         dir3=${arr_file_name[2]}
-    #         dir4=${arr_file_name[3]}
-    #         file_item=$dir1/$dir2/$dir3/$dir4
-    #         echo "file_name:"${file_name}, "path:"${file_item}
-    #         if [ ! -f ${file_name} ];then # 针对pr删掉文件
-    #             continue
-    #         elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-    #             continue
-    #         else
-    #             for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-    #                 if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-    #                     case_list[${#case_list[*]}]=gpt-3_auto
-    #                     case_list[${#case_list[*]}]=gpt-3_dygraph
-    #                 fi
-    #             done
-    #             for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
-    #                 if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
-    #                     case_list[${#case_list[*]}]=llama_auto
-    #                 fi
-    #             done
-    #             for ((i=0; i<${#target_lists_for_deepseek[@]}; i++)); do
-    #                 if [[ ${file_item} == *${target_lists_for_deepseek[i]}* ]];then
-    #                     case_list[${#case_list[*]}]=deepseek_auto
-    #                 fi
-    #             done
-    #         fi
-    #     done
-    # else
-    #     for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
-    #         arr_file_name=(${file_name//// })
-    #         dir1=${arr_file_name[0]}
-    #         dir2=${arr_file_name[1]}
-    #         dir3=${arr_file_name[2]}
-    #         dir4=${arr_file_name[3]}
-    #         file_item=$dir1/$dir2/$dir3/$dir4
-    #         echo "file_name:"${file_name}, "path:"${file_item}
-    #         if [ ! -f ${file_name} ];then # 针对pr删掉文件
-    #             continue
-    #         elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
-    #             continue
-    #         else
-    #             case_list[${#case_list[*]}]=gpt-3_auto
-    #             case_list[${#case_list[*]}]=llama_auto
-    #             case_list[${#case_list[*]}]=deepseek_auto
-    #             for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
-    #                 if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
-    #                     case_list[${#case_list[*]}]=gpt-3_dygraph
-    #                 fi
-    #             done
-    #         fi
-    #     done
-    # fi
+    if [ $IS_A100 -ne 0 ];then
+        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+            arr_file_name=(${file_name//// })
+            dir1=${arr_file_name[0]}
+            dir2=${arr_file_name[1]}
+            dir3=${arr_file_name[2]}
+            dir4=${arr_file_name[3]}
+            file_item=$dir1/$dir2/$dir3/$dir4
+            echo "file_name:"${file_name}, "path:"${file_item}
+            if [ ! -f ${file_name} ];then # 针对pr删掉文件
+                continue
+            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+                continue
+            else
+                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+                        case_list[${#case_list[*]}]=gpt-3_auto
+                        case_list[${#case_list[*]}]=gpt-3_dygraph
+                    fi
+                done
+                for ((i=0; i<${#target_lists_for_llama[@]}; i++)); do
+                    if [[ ${file_item} == *${target_lists_for_llama[i]}* ]];then
+                        case_list[${#case_list[*]}]=llama_auto
+                    fi
+                done
+                for ((i=0; i<${#target_lists_for_deepseek[@]}; i++)); do
+                    if [[ ${file_item} == *${target_lists_for_deepseek[i]}* ]];then
+                        case_list[${#case_list[*]}]=deepseek_auto
+                    fi
+                done
+            fi
+        done
+    else
+        for file_name in `git diff --numstat upstream/${AGILE_COMPILE_BRANCH} |awk '{print $NF}'`;do
+            arr_file_name=(${file_name//// })
+            dir1=${arr_file_name[0]}
+            dir2=${arr_file_name[1]}
+            dir3=${arr_file_name[2]}
+            dir4=${arr_file_name[3]}
+            file_item=$dir1/$dir2/$dir3/$dir4
+            echo "file_name:"${file_name}, "path:"${file_item}
+            if [ ! -f ${file_name} ];then # 针对pr删掉文件
+                continue
+            elif [[ ${file_name##*.} == "md" ]] || [[ ${file_name##*.} == "rst" ]] || [[ ${dir1} == "docs" ]];then
+                continue
+            else
+                case_list[${#case_list[*]}]=gpt-3_auto
+                case_list[${#case_list[*]}]=llama_auto
+                case_list[${#case_list[*]}]=deepseek_auto
+                for ((i=0; i<${#target_lists_for_gpt[@]}; i++)); do
+                    if [[ ! ${dir3} =~ "benchmarks" ]] && [[ ${file_item} == *${target_lists_for_gpt[i]}* ]];then
+                        case_list[${#case_list[*]}]=gpt-3_dygraph
+                    fi
+                done
+            fi
+        done
+    fi
 }
 ####################################
 function contain_case(){


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
重新打开 GPT dp 自动并行 CI 测试
Paddle 中修改了 gelu 的切分推导，从之前默认使用兜底规则修改成使用 ElementwiseUnaryInferSpmd 切分推导规则 ( https://github.com/PaddlePaddle/Paddle/pull/73279 ) 这样会给 gpt 动半模型引入合理的精度 diff，为了便于该 PR 便于合入，先暂时关闭了 GPT dp 自动并行 CI 测试 ( https://github.com/PaddlePaddle/PaddleNLP/pull/10736 )

GPT 动半精度问题：

- 修改 gelu 规则前后，mp8、pp8 是精度 md5 对齐的。
- 修改 gelu 规则前后，dp8 会产生精度 diff。
dp8情况下，模型里面有 gelu->matmul，此时 gelu 的 dims_mapping 是 [0, -1, 1]，matmul weight 的  dims_mapping 是 [0, 1]，此时，gelu 全局输入和输出的 md5 可以对齐，但 matmul 的全局结果有 diff，差别只是切分状态不一致
修改前：gelu 输出是 [-1,-1,-1]，matmul 输入要切分成 [-1,-1, 1]，输出是[-1,-1,-1]，partial(1)
修改后：gelu 输出是 [0 ,-1,  1]，matmul 输入保持不变 [0 ,-1, 1]，输出是[0, -1,-1]，partial(1)
组网中分别 hack gelu 结果是相同的 [-1,-1,-1] 和 [0 ,-1,  1]，此时修改前后 loss 是 md5 对齐的
因此精度问题是由于 matmul 不同切分状态造成的合理 diff

这里对 GPT dp 自动并行 CI 测试的 loss_base 进行了修改
