### PR TITLE
[fix] add parameters arg into AdamWMini

### DIFF
--- a/paddlenlp/utils/optimizer.py
+++ b/paddlenlp/utils/optimizer.py
@@ -36,8 +36,61 @@ from ..quantization.qat_utils import dequantize, quantize
 
 
 class AdamWMini(AdamW):
+    """A memory-efficient AdamW optimizer variant for transformer models.
+
+    This optimizer implements specialized memory-saving techniques for different types
+    of transformer blocks (embeddings, attention layers, MLPs, etc.). It requires
+    named parameters for proper operation.
+
+    Reference:
+        Adam-mini: Use Fewer Learning Rates To Gain More
+        Paper: https://arxiv.org/pdf/2406.16793
+
+    Args:
+        parameters (list|tuple, optional): List/Tuple of parameters to optimize.
+            When `named_parameters` is None, this will be used but may lead to
+            incorrect behavior. Defaults to None.
+        named_parameters (list|tuple, optional): List/Tuple of (name, parameter) pairs.
+            This is the recommended way to initialize the optimizer. Defaults to None.
+        learning_rate (float|_LRScheduler, optional): The learning rate. Defaults to 0.001.
+        beta1 (float, optional): The exponential decay rate for the 1st moment estimates.
+            Defaults to 0.9.
+        beta2 (float, optional): The exponential decay rate for the 2nd moment estimates.
+            Defaults to 0.999.
+        epsilon (float, optional): A small constant for numerical stability. Defaults to 1e-8.
+        weight_decay (float, optional): Weight decay coefficient. Defaults to 0.0.
+        use_lowprecision_moment (bool, optional): Whether to use low-precision moments.
+            Defaults to False.
+        lr_ratio (callable, optional): Function to compute learning rate ratios per parameter.
+            Defaults to None.
+        apply_decay_param_fun (callable, optional): Function to determine which parameters
+            should have weight decay applied. Defaults to None.
+        grad_clip (GradientClipBase, optional): Gradient clipping strategy. Defaults to None.
+        lazy_mode (bool, optional): Whether to enable lazy mode. Defaults to False.
+        multi_precision (bool, optional): Whether to use multi-precision. Defaults to False.
+        amsgrad (bool, optional): Whether to use AMSGrad variant. Defaults to False.
+        dim (int, optional): Model dimension. Defaults to 2048.
+        n_heads (int, optional): Number of attention heads. Defaults to 32.
+        n_kv_heads (int, optional): Number of key/value heads. Defaults to None.
+        verbose (bool, optional): Whether to print debug information. Defaults to True.
+        name (str, optional): Name of the optimizer. Defaults to None.
+
+    Raises:
+        ValueError: If both `parameters` and `named_parameters` are specified.
+        ValueError: If `dim`, `n_heads` or `n_kv_heads` are invalid.
+        ValueError: If `n_heads` is not divisible by `n_kv_heads`.
+
+    Note:
+        Only one of `parameters` or `named_parameters` can be specified. When `named_parameters`
+        is None, the optimizer will use `parameters` but this may lead to incorrect behavior
+        since AdamWMini relies on parameter names for proper operation.
+
+        Warning: `named_parameters` is None, AdamWMini will use `parameters` instead, which may be incorrect.
+    """
+
     def __init__(
         self,
+        parameters=None,
         named_parameters=None,
         learning_rate=0.001,
         beta1=0.9,
@@ -83,12 +136,19 @@ class AdamWMini(AdamW):
             raise ValueError(f"Invalid n_kv_heads value: {self.n_kv_heads}")
         if not self.n_heads % self.n_kv_heads == 0:
             raise ValueError(f"n_heads {self.n_heads} must be divisible by n_kv_heads {self.n_kv_heads}")
+        if parameters is not None and named_parameters is not None:
+            raise ValueError("Only one of `parameters` or `named_parameters` can be specified.")
+        if named_parameters is None:
+            logger.warning(
+                "Warning: `named_parameters` is None, AdamWMini will use `parameters` instead, which may be incorrect."
+            )
 
-        parameters = []
-        for param_name, param in named_parameters:
-            param_name = param_name.lower()
-            param.name = param_name
-            parameters.append(param)
+        if parameters is None and named_parameters is not None:
+            parameters = []
+            for param_name, param in named_parameters:
+                param_name = param_name.lower()
+                param.name = param_name
+                parameters.append(param)
 
         super().__init__(
             learning_rate=learning_rate,

--- a/scripts/regression/run_ci.sh
+++ b/scripts/regression/run_ci.sh
@@ -36,6 +36,7 @@ target_lists_for_llm=(
     "paddlenlp/trl"
     "llm"
     "tests/llm"
+    "tests/utils/test_optimizers"
     "csrc"
     "scripts/regression"
 )

--- a/tests/utils/test_optimizers/test_adamw_mini.py
+++ b/tests/utils/test_optimizers/test_adamw_mini.py
@@ -131,7 +131,7 @@ class TestAdamWMini(unittest.TestCase):
         model = SimpleTransformerPaddle()
 
         optimizer = AdamWMini(
-            model.named_parameters(),
+            named_parameters=model.named_parameters(),
             learning_rate=lr,
             weight_decay=weight_decay,
             beta1=beta1,
@@ -150,3 +150,50 @@ class TestAdamWMini(unittest.TestCase):
             loss.backward()
             optimizer.step()
             optimizer.clear_grad()
+
+    def test_adamw_parameters(self):
+        lr = 1e-3
+        beta1 = 0.8
+        beta2 = 0.888
+        epsilon = 1e-8
+        weight_decay = 0.0
+        dim = 2048
+        n_heads = 32
+        model = SimpleTransformerPaddle()
+
+        optimizer = AdamWMini(
+            parameters=model.parameters(),
+            learning_rate=lr,
+            weight_decay=weight_decay,
+            beta1=beta1,
+            beta2=beta2,
+            epsilon=epsilon,
+            dim=dim,
+            n_heads=n_heads,
+        )
+
+        for _ in range(2):
+            x_np, _ = generate_data()
+            x = paddle.to_tensor(x_np, dtype="int64")
+
+            output = model(x)
+            loss = paddle.mean(output)
+            loss.backward()
+            optimizer.step()
+            optimizer.clear_grad()
+
+    def test_error_args(self):
+        with self.assertRaises(ValueError):
+            model = SimpleTransformerPaddle()
+
+            _ = AdamWMini(
+                parameters=model.parameters(),
+                named_parameters=model.named_parameters(),
+                learning_rate=1e-3,
+                weight_decay=0.01,
+                beta1=0.9,
+                beta2=0.999,
+                epsilon=1e-8,
+                dim=2048,
+                n_heads=32,
+            )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
- 在 AdamWMini 中增加 `parameters` 参数，以兼容 paddle 中的 optimizers
- 增加测试用例，并加入 llm 的测试中
- 增加 AdamWMini 的 docstring

本地测试通过：

``` shell

(venv39dev)  ✘ shun@shun-B660M-Pro-RS  ~/Documents/Projects/paddle/megemini/PaddleNLP/tests/utils/test_optimizers   adam_mini_param_arg ✚  python -m unittest test_adamw_mini.py
/home/shun/venv39dev/lib/python3.9/site-packages/paddle/utils/cpp_extension/extension_utils.py:711: UserWarning: No ccache found. Please be aware that recompiling all source files may be required. You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md
  warnings.warn(warning_message)
W0625 18:21:21.107420 83151 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 6.1, Driver API Version: 12.2, Runtime API Version: 11.7
W0625 18:21:21.108110 83151 gpu_resources.cc:164] device: 0, cuDNN Version: 8.5.
W0625 18:21:21.767901 83151 gpu_resources.cc:306] WARNING: device: 0. The installed Paddle is compiled with CUDNN 8.9, but CUDNN version in your machine is 8.5, which may cause serious incompatible bug. Please recompile or reinstall Paddle with compatible CUDNN version.
/home/shun/venv39dev/lib/python3.9/site-packages/paddle/base/dygraph/math_op_patch.py:183: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  return int(np.array(var))
[2025-06-25 18:21:22,070] [    INFO] - 
Adam-mini found blocks:
[2025-06-25 18:21:22,071] [    INFO] - - 1 embedding layers
[2025-06-25 18:21:22,071] [    INFO] - - 1 output layers
[2025-06-25 18:21:22,071] [    INFO] - - 2 Query and Key layers
[2025-06-25 18:21:22,071] [    INFO] - - 1 Value layers
[2025-06-25 18:21:22,071] [    INFO] - - 1 Attention projection layers
[2025-06-25 18:21:22,071] [    INFO] - - 2 MLP layers

.[2025-06-25 18:21:22,333] [ WARNING] - Warning: `named_parameters` is None, AdamWMini will use `parameters` instead, which may be incorrect.
[2025-06-25 18:21:22,337] [    INFO] - 
Adam-mini found blocks:
[2025-06-25 18:21:22,337] [    INFO] - - 1 embedding layers
[2025-06-25 18:21:22,337] [    INFO] - - 0 output layers
[2025-06-25 18:21:22,337] [    INFO] - - 0 Query and Key layers
[2025-06-25 18:21:22,337] [    INFO] - - 0 Value layers
[2025-06-25 18:21:22,337] [    INFO] - - 0 Attention projection layers
[2025-06-25 18:21:22,337] [    INFO] - - 14 MLP layers

[2025-06-25 18:21:22,337] [ WARNING] - Warning: No output layers found (ignore if using weight tying)
[2025-06-25 18:21:22,337] [ WARNING] - Warning: No Query/Key layers found
[2025-06-25 18:21:22,337] [ WARNING] - Warning: No Value layers found
[2025-06-25 18:21:22,337] [ WARNING] - Warning: No attention projection layers found
..
----------------------------------------------------------------------
Ran 3 tests in 1.658s

OK

```

注意：上述测试需要修改 `paddlenlp/trainer/trainer_utils.py`，去掉 `from ..transformers import get_gpt_pp_schedule, get_llama_pp_schedule`，否则提示引入错误：

``` shell

E   ImportError: cannot import name 'get_gpt_pp_schedule' from 'paddlenlp.transformers' (/home/shun/Documents/Projects/paddle/megemini/PaddleNLP/paddlenlp/transformers/__init__.py)

```

这个 https://github.com/PaddlePaddle/PaddleNLP/pull/10759 PR 对 import 做的修改，

``` python

try:
    from .modeling_auto_pp import *
except (ImportError, ModuleNotFoundError):
    # Temporarily adapt to the release version of Paddle, which can be removed later.
    pass

```

会导致导入错误，至少我这里是这样 ... ...

关联 https://github.com/PaddlePaddle/PaddleNLP/pull/10413

 @DrownFish19 帮忙看看，感谢 ～