### PR TITLE
[AutoParallel] GPT support  shared parameters

### DIFF
--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -529,7 +529,7 @@ class GPTDecoderLayerAuto(nn.Layer):
         self.linear2 = nn.Linear(config.intermediate_size, config.hidden_size, bias_attr=True)
 
         self.linear1.weight = dist.shard_tensor(self.linear1.weight, get_mesh(ipp), [dist.Replicate(), dist.Shard(1)])
-        self.linear1.bias = dist.shard_tensor(self.linear1.bias, get_mesh(ipp), [dist.Replicate(), dist.Shard(0)])
+        self.linear1.bias = dist.shard_tensor(self.linear1.bias, get_mesh(ipp), [dist.Replicate(), dist.Replicate()])
         self.linear2.weight = dist.shard_tensor(self.linear2.weight, get_mesh(ipp), [dist.Replicate(), dist.Shard(0)])
         self.linear2.bias = dist.shard_tensor(self.linear2.bias, get_mesh(ipp), [dist.Replicate(), dist.Replicate()])
         # fix : change nn.LayerNorm(config.hidden_size, epsilon=1e-5, bias_attr=True) to GPTLayerNorm()
@@ -658,7 +658,7 @@ class GPTEmbeddingsAuto(nn.Layer):
             config.hidden_size,
         )
         self.word_embeddings.weight = dist.shard_tensor(
-            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Replicate()]
+            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
         )
         self.position_embeddings.weight = dist.shard_tensor(
             self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
@@ -699,6 +699,7 @@ class GPTEmbeddingsAuto(nn.Layer):
         # The 'with' block ensures the correct seed context is used
         with seed_guard_context(current_seed):
             embeddings = self.dropout(embeddings)
+        embeddings = dist.reshard(embeddings, get_mesh(), [dist.Replicate(), dist.Replicate()])
         return embeddings
 
 
@@ -1176,7 +1177,7 @@ class GPTLMHeadAuto(nn.Layer):
                 shape=[config.vocab_size, config.hidden_size],
                 dtype=paddle.get_default_dtype(),
             )
-            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(0)])
+            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(1)])
 
     def forward(self, hidden_states, tensor_parallel_output=None):
 

--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -661,7 +661,7 @@ class GPTEmbeddingsAuto(nn.Layer):
             self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(0)]
         )
         self.position_embeddings.weight = dist.shard_tensor(
-            self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Replicate()]
+            self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(0)]
         )
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 

--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -529,7 +529,7 @@ class GPTDecoderLayerAuto(nn.Layer):
         self.linear2 = nn.Linear(config.intermediate_size, config.hidden_size, bias_attr=True)
 
         self.linear1.weight = dist.shard_tensor(self.linear1.weight, get_mesh(ipp), [dist.Replicate(), dist.Shard(1)])
-        self.linear1.bias = dist.shard_tensor(self.linear1.bias, get_mesh(ipp), [dist.Replicate(), dist.Replicate()])
+        self.linear1.bias = dist.shard_tensor(self.linear1.bias, get_mesh(ipp), [dist.Replicate(), dist.Shard(0)])
         self.linear2.weight = dist.shard_tensor(self.linear2.weight, get_mesh(ipp), [dist.Replicate(), dist.Shard(0)])
         self.linear2.bias = dist.shard_tensor(self.linear2.bias, get_mesh(ipp), [dist.Replicate(), dist.Replicate()])
         # fix : change nn.LayerNorm(config.hidden_size, epsilon=1e-5, bias_attr=True) to GPTLayerNorm()
@@ -699,7 +699,7 @@ class GPTEmbeddingsAuto(nn.Layer):
         # The 'with' block ensures the correct seed context is used
         with seed_guard_context(current_seed):
             embeddings = self.dropout(embeddings)
-        embeddings = dist.reshard(embeddings, get_mesh(), [dist.Replicate(), dist.Replicate()])
+        embeddings = dist.reshard(embeddings, get_mesh(), [dist.Shard(0), dist.Replicate()])
         return embeddings
 
 

--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -658,10 +658,10 @@ class GPTEmbeddingsAuto(nn.Layer):
             config.hidden_size,
         )
         self.word_embeddings.weight = dist.shard_tensor(
-            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
+            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(0)]
         )
         self.position_embeddings.weight = dist.shard_tensor(
-            self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
+            self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Replicate()]
         )
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
@@ -1177,7 +1177,7 @@ class GPTLMHeadAuto(nn.Layer):
                 shape=[config.vocab_size, config.hidden_size],
                 dtype=paddle.get_default_dtype(),
             )
-            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(1)])
+            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(0)])
 
     def forward(self, hidden_states, tensor_parallel_output=None):
 

--- a/paddlenlp/transformers/gpt/modeling_auto_pp.py
+++ b/paddlenlp/transformers/gpt/modeling_auto_pp.py
@@ -158,7 +158,7 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
             new_model = GPTChunk(
                 layer_lists[stage_idx * chunk_size : (stage_idx + 1) * chunk_size], is_first=False, is_last=False
             )
-        stage = PipelineStage(new_model, stage_idx, chunk_num, group=group, shared_map=shared_mp)
+        stage = PipelineStage(new_model, stage_idx, chunk_num, group=group, shared_parameters=shared_mp)
         return stage
 
     stages = []

--- a/paddlenlp/transformers/gpt/modeling_auto_pp.py
+++ b/paddlenlp/transformers/gpt/modeling_auto_pp.py
@@ -139,6 +139,13 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
 
     layer_lists = model.layers
 
+    
+    shared_params_names = {
+            "gpt_shared_weight": ["embedding_0.w_0.dist", "gptlm_head_auto_0.w_0.dist"]
+        }
+
+    shared_mp = build_shared_param_map(model, shared_params_names)
+
     def _build_stage(model, stage_idx, group):
         new_model = None
         if stage_idx == 0:
@@ -151,7 +158,7 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
             new_model = GPTChunk(
                 layer_lists[stage_idx * chunk_size : (stage_idx + 1) * chunk_size], is_first=False, is_last=False
             )
-        stage = PipelineStage(new_model, stage_idx, chunk_num, group=group)
+        stage = PipelineStage(new_model, stage_idx, chunk_num, group=group, shared_map=shared_mp)
         return stage
 
     stages = []
@@ -159,6 +166,27 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
         stage = _build_stage(model, stage_idx + i * pp_degree, group)
         stages.append(stage)
     return stages
+
+def build_shared_param_map(model, shared_params_names):
+    shared_mp = []
+    for key, pair in shared_params_names.items():
+        assert len(pair) == 2, (
+            "Only exactly two parameters are supported for sharing."
+        )
+        ori_name = pair[0]
+        sync_name = pair[1]
+        ori_param = get_param_from_name(ori_name, model)
+        sync_param = get_param_from_name(sync_name, model)
+        shared_mp.append({
+            "params": [ori_param, sync_param]
+        })
+    return shared_mp
+
+def get_param_from_name(param_name, model):
+    for param in model.parameters():
+        if param.name == param_name:
+            return param
+    raise ValueError(f"{param_name} not found in model parameters")
 
 
 def get_gpt_pp_schedule(model, n_microbatches, loss_fn, mode, pp_degree, group):

--- a/paddlenlp/transformers/gpt/modeling_auto_pp.py
+++ b/paddlenlp/transformers/gpt/modeling_auto_pp.py
@@ -139,10 +139,7 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
 
     layer_lists = model.layers
 
-    
-    shared_params_names = {
-            "gpt_shared_weight": ["embedding_0.w_0.dist", "gptlm_head_auto_0.w_0.dist"]
-        }
+    shared_params_names = {"gpt_shared_weight": ["embedding_0.w_0.dist", "gptlm_head_auto_0.w_0.dist"]}
 
     shared_mp = build_shared_param_map(model, shared_params_names)
 
@@ -167,20 +164,18 @@ def manual_model_split(model, stage_idx, group, mode, pp_degree):
         stages.append(stage)
     return stages
 
+
 def build_shared_param_map(model, shared_params_names):
     shared_mp = []
     for key, pair in shared_params_names.items():
-        assert len(pair) == 2, (
-            "Only exactly two parameters are supported for sharing."
-        )
+        assert len(pair) == 2, "Only exactly two parameters are supported for sharing."
         ori_name = pair[0]
         sync_name = pair[1]
         ori_param = get_param_from_name(ori_name, model)
         sync_param = get_param_from_name(sync_name, model)
-        shared_mp.append({
-            "params": [ori_param, sync_param]
-        })
+        shared_mp.append({"params": [ori_param, sync_param]})
     return shared_mp
+
 
 def get_param_from_name(param_name, model):
     for param in model.parameters():

--- a/scripts/distribute/ci_case_auto.sh
+++ b/scripts/distribute/ci_case_auto.sh
@@ -2506,11 +2506,11 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.55853653 # output of dropout is different after supporting spmd
+    loss_base=10.55727577 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.56019211 # after add dropout spmd
+        loss_base=10.56668472 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2578,11 +2578,11 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2() {
     ips=-1
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
-    loss_base=10.5657959 # output of dropout is different after supporting spmd
+    loss_base=10.49585533 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.5760107 # after add dropout spmd
+        loss_base=10.51038742 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2651,11 +2651,11 @@ function llm_gpt_dygraph_auto_bs8_fp32_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.59993172     # note: need to debug
-    loss_base=10.57174778 # output of dropout is different after supporting spmd
+    loss_base=10.49603939 # output of dropout is different after supporting spmd
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.57701015 # after add dropout spmd
+        loss_base=10.51580238 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="
@@ -2724,11 +2724,11 @@ function llm_gpt_dygraph_auto_bs8_fp16_DP2-MP2-PP2() {
     mem=-1
     echo "result: loss=$loss ips=$ips mem=$mem loss_md5=$loss_md5"
     # loss_base=10.58456802     # note: need to debug
-    loss_base=10.57304478
+    loss_base=10.49809837
     ips_base=-1
     mem_base=-1
     if [ $IS_A100 -ne 0 ];then
-        loss_base=10.57861042 # after add dropout spmd
+        loss_base=10.51762962 # after add dropout spmd
     fi
     check_result $FUNCNAME ${loss_base} ${loss} ${ips_base} ${ips} ${mem_base} ${mem}
     echo "=========== $FUNCNAME run  end ==========="


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Other


### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Other
### Description
<!-- Describe what this PR does -->
对 gpt-13b 动半模型进行如下优化：

1. 支持共享参数优化，在 pp 下支持对 embedding weight 和 lm_head weight 共享优化 ，修改它们切分状态相同且都为列切
2. 修改 embedding weight 的切分状态为 [dist.Relicate(), dist.Shard(0)]，与 lmhead weight 的切分状态保持一致，减少共享参数时因为状态不一致引入的通信
3. 修改 embedding auto 层输出状态为 [dist.Shard(0), dist.Relicate()]，减少最优策略下 encoder 层引入的 allgather 通信