### PR TITLE
Add recompute for post_norm and moe_gate

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -181,6 +181,7 @@ class DeepseekV2Config(PretrainedConfig):
         using_flex_token=False,
         use_dualpipev=False,
         send_mtp_embed=False,
+        using_norm_gate_recompute=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -231,6 +232,7 @@ class DeepseekV2Config(PretrainedConfig):
         self.using_flex_token = using_flex_token
         self.use_dualpipev = use_dualpipev
         self.send_mtp_embed = send_mtp_embed
+        self.using_norm_gate_recompute = using_norm_gate_recompute
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -1953,7 +1953,7 @@ class DeepseekV2DecoderLayer(nn.Layer):
         # Fully Connected
         residual = hidden_states
 
-        if not self.using_norm_gate_recompute:
+        if not (self.using_norm_gate_recompute and isinstance(self.mlp, DeepseekV2MoE)):
             hidden_states = self.post_attention_layernorm(hidden_states)
 
         hidden_states = self.mlp(hidden_states)

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -74,7 +74,7 @@ from ..model_outputs import (
 from ..model_utils import PretrainedModel, register_base_model
 from ..moe_gate import PretrainedMoEGate
 from ..moe_layer import MoELayer
-from ..utils import device_guard
+from ..utils import cast_if_needed, device_guard
 from . import fp8_linear as linear_utils
 from .configuration import DeepseekV2Config
 
@@ -737,6 +737,41 @@ class DeepseekV2MLP(nn.Layer):
         return out
 
 
+class FusedNormGateFunc(paddle.autograd.PyLayer):
+    """recompute of postnorm and gate"""
+
+    @staticmethod
+    def forward(ctx, x, rms_norm_weight, moe_gate_weight, eps):
+        ctx.dtype = paddle.float32
+        norm_output, invar = fused_ln.fused_rms_norm(x, rms_norm_weight, eps)
+        with paddle.amp.auto_cast(False):
+            gate_logits = F.linear(cast_if_needed(norm_output, ctx.dtype), cast_if_needed(moe_gate_weight, ctx.dtype))
+
+        ctx.save_for_backward(x, rms_norm_weight, moe_gate_weight, eps)
+        return gate_logits, norm_output
+
+    @staticmethod
+    def backward(ctx, d_gate_logits, d_norm_output):
+        x, rms_norm_weight, moe_gate_weight, eps = ctx.saved_tensor()
+        # recompute rmsnorm
+        norm_output, invar = fused_ln.fused_rms_norm(x, rms_norm_weight, eps)
+        d_norm_output_linear, d_moe_gate_weight = paddle._C_ops.matmul_grad(
+            cast_if_needed(norm_output, ctx.dtype),
+            cast_if_needed(moe_gate_weight, ctx.dtype),
+            d_gate_logits,
+            False,
+            False,
+        )
+        d_norm_output_linear, d_moe_gate_weight = cast_if_needed(
+            d_norm_output_linear, norm_output.dtype
+        ), cast_if_needed(d_moe_gate_weight, moe_gate_weight.dtype)
+
+        d_norm_output = d_norm_output + d_norm_output_linear
+        dx, d_rms_norm_weight = fused_ln.fused_rms_norm_grad_func(x, rms_norm_weight, invar, d_norm_output, eps)
+
+        return dx, d_rms_norm_weight, d_moe_gate_weight
+
+
 class FakeGate(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, hidden_states, weight):
@@ -756,7 +791,7 @@ class FakeGate(paddle.autograd.PyLayer):
 
 
 class MoEGate(PretrainedMoEGate):
-    def __init__(self, config, num_experts, expert_hidden_size, **kwargs):
+    def __init__(self, config, num_experts, expert_hidden_size, norm_weight=None, norm_eps=None, **kwargs):
         super().__init__(config, num_experts, expert_hidden_size, **kwargs)
         # [hidden_size, n_expert]
 
@@ -778,7 +813,10 @@ class MoEGate(PretrainedMoEGate):
                 default_initializer=nn.initializer.Constant(0.0),
             )
             self.e_score_correction_bias.is_distributed = True
-
+        if hasattr(self.config, "using_norm_gate_recompute") and self.config.using_norm_gate_recompute:
+            assert norm_weight is not None and norm_eps is not None
+            self.norm_weight = norm_weight
+            self.norm_eps = norm_eps
         self.using_flex_token = False
 
     def forward(self, hidden_states):
@@ -789,23 +827,33 @@ class MoEGate(PretrainedMoEGate):
         _, _, h_dim = hidden_states.shape
 
         # compute gating score
-        with paddle.amp.auto_cast(False):
-            hidden_states = hidden_states.cast(self.weight.dtype)
+        if hasattr(self.config, "using_norm_gate_recompute") and self.config.using_norm_gate_recompute:
+            logits, norm_out = FusedNormGateFunc.apply(hidden_states, self.norm_weight, self.weight, self.norm_eps)
+        else:
+            with paddle.amp.auto_cast(False):
+                hidden_states = hidden_states.cast(self.weight.dtype)
+                if hasattr(self.config, "using_fake_gate") and self.config.using_fake_gate:
+                    logits = FakeGate.apply(hidden_states, self.weight)
+                else:
+                    logits = F.linear(hidden_states, self.weight, None)
 
-            if hasattr(self.config, "using_fake_gate") and self.config.using_fake_gate:
-                logits = FakeGate.apply(hidden_states, self.weight)
-            else:
-                logits = F.linear(hidden_states, self.weight, None)
+        scores = self.gate_score_func(logits=logits)
+        scores = scores.cast(paddle.float32)
 
-            scores = self.gate_score_func(logits=logits)
-            scores = scores.cast(paddle.float32)
-
+        # Compute all possible return values
         if self.using_flex_token:
-            scores, routing_map, exp_counts, l_aux, l_zloss = self.topkgating_nodrop(scores)
-            return scores, routing_map, l_aux, l_zloss
+            scores, routing_map, exp_counts, l_aux, l_zloss = self.topkgating_nodrop(
+                scores
+            )  # (scores, routing_map, exp_counts, l_aux, l_zloss)
+            ret = (scores, routing_map, l_aux, l_zloss)
+        else:
+            ret = self.topkgating(scores)  # (capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss)
 
-        capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss = self.topkgating(scores)
-        return capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss
+        # Append norm_out if needed
+        if hasattr(self.config, "using_norm_gate_recompute") and self.config.using_norm_gate_recompute:
+            ret = (*ret, norm_out)
+
+        return ret
 
 
 class AddAuxiliaryLoss(paddle.autograd.PyLayer):
@@ -833,7 +881,7 @@ class DeepseekV2MoE(MoELayer):
     A mixed expert module containing shared experts.
     """
 
-    def __init__(self, config: DeepseekV2Config):
+    def __init__(self, config: DeepseekV2Config, norm_weight=None, norm_eps=None):
         assert config.tensor_parallel_degree <= 1, "tensor_parallel_degree should be 1"
 
         gate = MoEGate(
@@ -847,8 +895,12 @@ class DeepseekV2MoE(MoELayer):
             norm_topk_prob=config.norm_topk_prob,
             routed_scaling_factor=config.routed_scaling_factor,
             drop_tokens=False,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
         )
         DeepseekV2MLPClass = FP8Mlp if DSV3_USE_FP8_GEMM else DeepseekV2MLP
+
+        self.using_norm_gate_recompute = config.using_norm_gate_recompute
 
         super().__init__(
             config=config,
@@ -862,6 +914,7 @@ class DeepseekV2MoE(MoELayer):
             gate=gate,
             capacity=2.0,
             moe_group="expert",
+            using_norm_gate_recompute=self.using_norm_gate_recompute,
         )
 
         moe_grad_group = fleet.get_hybrid_communicate_group().expert_grad_comm_group
@@ -874,8 +927,30 @@ class DeepseekV2MoE(MoELayer):
             self.shared_experts = DeepseekV2MLPClass(config=config, intermediate_size=intermediate_size, is_moe=False)
 
     def forward(self, hidden_states):
-        final_hidden_states, l_aux, l_zloss = super().forward(hidden_states)
-        final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
+        if self.using_norm_gate_recompute:
+            super().update_flex_token()
+            if self.using_flex_token:
+                probs, routing_map, l_aux, l_zloss, norm_out = self.router(hidden_states)
+                hidden_states = norm_out
+                final_hidden_states, l_aux, l_zloss = super().forward(
+                    hidden_states, probs=probs, routing_map=routing_map, l_aux=l_aux, l_zloss=l_zloss
+                )
+            else:
+                capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss, norm_out = self.gate(hidden_states)
+                hidden_states = norm_out
+                final_hidden_states, l_aux, l_zloss = super().forward(
+                    hidden_states,
+                    capacity=capacity,
+                    topk_weight=topk_weight,
+                    topk_ids=topk_ids,
+                    token_priority=token_priority,
+                    l_aux=l_aux,
+                    l_zloss=l_zloss,
+                )
+            final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
+        else:
+            final_hidden_states, l_aux, l_zloss = super().forward(hidden_states)
+            final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
         return final_hidden_states
 
     def post_process(self, hidden_states, final_hidden_states, l_aux):
@@ -1774,6 +1849,7 @@ class DeepseekV2DecoderLayer(nn.Layer):
         self.enable_recompute = False
         self.layerwise_recompute = layerwise_recompute
         self.recompute_granularity = config.recompute_granularity
+        self.using_norm_gate_recompute = config.using_norm_gate_recompute
 
         self.hidden_size = config.hidden_size
 
@@ -1781,17 +1857,23 @@ class DeepseekV2DecoderLayer(nn.Layer):
 
         DeepseekV2MLPClass = FP8Mlp if DSV3_USE_FP8_GEMM else DeepseekV2MLP
 
-        self.mlp = (
-            DeepseekV2MoE(config)
-            if (
-                config.n_routed_experts is not None
-                and layer_idx >= config.first_k_dense_replace
-                and layer_idx % config.moe_layer_freq == 0
-            )
-            else DeepseekV2MLPClass(config)
-        )
         self.input_layernorm = DeepseekV2RMSNorm(config)
         self.post_attention_layernorm = DeepseekV2RMSNorm(config)
+
+        if (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            self.mlp = (
+                DeepseekV2MoE(
+                    config, self.post_attention_layernorm.weight, self.post_attention_layernorm.variance_epsilon
+                )
+                if config.using_norm_gate_recompute
+                else DeepseekV2MoE(config)
+            )
+        else:
+            self.mlp = DeepseekV2MLPClass(config)
 
     def forward(
         self,
@@ -1871,7 +1953,9 @@ class DeepseekV2DecoderLayer(nn.Layer):
         # Fully Connected
         residual = hidden_states
 
-        hidden_states = self.post_attention_layernorm(hidden_states)
+        if not self.using_norm_gate_recompute:
+            hidden_states = self.post_attention_layernorm(hidden_states)
+
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
 

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -171,6 +171,7 @@ class MoELayer(nn.Layer):
         capacity: int = 1.0,
         moe_group: str = "data",
         all_to_all_dropout=0.0,
+        using_norm_gate_recompute=False,
     ):
         super().__init__()
 
@@ -228,6 +229,8 @@ class MoELayer(nn.Layer):
         )
         self.token_drop_steps = config.token_drop_steps
         self.using_flex_token = False
+
+        self.using_norm_gate_recompute = using_norm_gate_recompute
         self._post_init()
 
     def update_flex_token(self):
@@ -263,17 +266,36 @@ class MoELayer(nn.Layer):
                     p.no_sync = not self.is_dummy_moe
                     # logger.info(f"expert param={p.name}, no-sync={p.no_sync}")
 
-    def forward(self, hidden_states: paddle.Tensor):
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        probs=None,
+        routing_map=None,
+        capacity=None,
+        topk_weight=None,
+        topk_ids=None,
+        token_priority=None,
+        l_aux=None,
+        l_zloss=None,
+    ):
         self.update_flex_token()
 
         if self.using_flex_token:
-            return self.forward_flex_token(hidden_states)
+            return self.forward_flex_token(hidden_states, probs, routing_map, l_aux, l_zloss)
         else:
-            return self.forward_drop_token(hidden_states)
+            return self.forward_drop_token(
+                hidden_states, capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss
+            )
 
     def forward_drop_token(
         self,
         hidden_state: paddle.Tensor,
+        capacity=None,
+        topk_weight=None,
+        topk_ids=None,
+        token_priority=None,
+        l_aux=None,
+        l_zloss=None,
     ):
         """MoE Layer forward function
             1. Gate Forward.
@@ -295,7 +317,17 @@ class MoELayer(nn.Layer):
         # topk_ids    : sk
         # token_priority    : se
         # self.exp_counts  :
-        capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss = self.gate(hidden_state)
+        if self.using_norm_gate_recompute:
+            assert (
+                capacity is not None
+                and topk_weight is not None
+                and topk_ids is not None
+                and token_priority is not None
+                and l_aux is not None
+                and l_zloss is not None
+            )
+        else:
+            capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss = self.gate(hidden_state)
 
         """MoE expert dispatch from: https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py"""
         cnts = paddle.zeros([topk_ids.shape[0], len(self.experts)], dtype=topk_ids.dtype)
@@ -374,10 +406,13 @@ class MoELayer(nn.Layer):
 
         return final_out, l_aux, l_zloss
 
-    def forward_flex_token(self, hidden_states: paddle.Tensor):
+    def forward_flex_token(self, hidden_states: paddle.Tensor, probs=None, routing_map=None, l_aux=None, l_zloss=None):
         _, _, d_model = hidden_states.shape
         # reshaped_input = hidden_states.reshape([-1, d_model])
-        probs, routing_map, l_aux, l_zloss = self.router(hidden_states)
+        if self.using_norm_gate_recompute:
+            assert probs is not None and routing_map is not None and l_aux is not None and l_zloss is not None
+        else:
+            probs, routing_map, l_aux, l_zloss = self.router(hidden_states)
         if DSV3_USE_FP8_GEMM:
             hidden_states, token_indices, token_probs = self.token_dispatcher.pre_dispatch(
                 hidden_states, probs, routing_map

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -1002,3 +1002,10 @@ def caculate_llm_per_token_flops(
     # 2 for mul + add in matmul
     # 1 for forward, 2 for backwards since we caluate gradients for input_x and input_y
     return 2 * (layer_num * (flops_per_transformer * 3 + flops_recompute_transformer) + 3 * flops_loggits) / seq_length
+
+
+def cast_if_needed(x, dtype):
+    """
+    cast_if_needed
+    """
+    return x.cast(dtype) if x.dtype != dtype else x


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
为ds_v3添加了post_norm和gate的recompute重计算，反向时重新计算post_norm，以节省post_norm输出显存。
为组成recompute pylayer需调整模型结构，整体思路是**尽量不更改现有接口，如需修改，则尽量修改接口输入避免修改接口输出，输入中尽量添加可选参数**，避免影响其余模型及配置运行。
具体调整如下：
1. 添加了 FusedNormGateFunc pylayer及 using_norm_gate_recompute config，实现post_norm+gate重计算功能
2. 升级MoeGate、DeepseekV2MoE，添加可选分支判断是否执行 norm_gate_recompute
3. 修改MoeGate接口，输入增加 norm_weight 及 norm_eps，输出增加 norm_out
4. 修改DeepseekV2MoE构造函数，增加 norm_weight 及 norm_eps，并将super().forward中gate相关功能提取到子类forward中实现recompute，避免过多对父类(MoELayer)进行修改
5. 父类(MoELayer)构造函数添加using_norm_gate_recompute，用来跳过gate计算，forward函数增加可选输入接受gate输出结构，避免修改输出接口