### PR TITLE
Add post norm recompute.

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -181,6 +181,7 @@ class DeepseekV2Config(PretrainedConfig):
         using_flex_token=False,
         use_dualpipev=False,
         send_mtp_embed=False,
+        using_post_norm_recompute=False,
         recompute_fwd_gate_up=False,
         is_split_group_gemm=False,
         **kwargs,
@@ -233,6 +234,7 @@ class DeepseekV2Config(PretrainedConfig):
         self.using_flex_token = using_flex_token
         self.use_dualpipev = use_dualpipev
         self.send_mtp_embed = send_mtp_embed
+        self.using_post_norm_recompute = using_post_norm_recompute
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.is_split_group_gemm = is_split_group_gemm
 

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -940,7 +940,7 @@ class DeepseekV2MoE(MoELayer):
         if config.n_shared_experts is not None:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
             if self.using_post_norm_recompute:
-                assert isinstance(DeepseekV2MLPClass, FP8Mlp)
+                assert DeepseekV2MLPClass is FP8Mlp
                 self.shared_experts = DeepseekV2MLPClass(
                     config=config,
                     intermediate_size=intermediate_size,

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -74,7 +74,7 @@ from ..model_outputs import (
 from ..model_utils import PretrainedModel, register_base_model
 from ..moe_gate import PretrainedMoEGate
 from ..moe_layer import MoELayer
-from ..utils import device_guard
+from ..utils import cast_if_needed, device_guard
 from . import fp8_linear as linear_utils
 from .configuration import DeepseekV2Config
 
@@ -737,6 +737,41 @@ class DeepseekV2MLP(nn.Layer):
         return out
 
 
+class FusedNormGateFunc(paddle.autograd.PyLayer):
+    """recompute of postnorm and gate"""
+
+    @staticmethod
+    def forward(ctx, x, rms_norm_weight, moe_gate_weight, eps):
+        ctx.dtype = paddle.float32
+        norm_output, invar = fused_ln.fused_rms_norm(x, rms_norm_weight, eps)
+        with paddle.amp.auto_cast(False):
+            gate_logits = F.linear(cast_if_needed(norm_output, ctx.dtype), cast_if_needed(moe_gate_weight, ctx.dtype))
+
+        ctx.save_for_backward(x, rms_norm_weight, moe_gate_weight, eps)
+        return gate_logits, norm_output
+
+    @staticmethod
+    def backward(ctx, d_gate_logits, d_norm_output):
+        x, rms_norm_weight, moe_gate_weight, eps = ctx.saved_tensor()
+        # recompute rmsnorm
+        norm_output, invar = fused_ln.fused_rms_norm(x, rms_norm_weight, eps)
+        d_norm_output_linear, d_moe_gate_weight = paddle._C_ops.matmul_grad(
+            cast_if_needed(norm_output, ctx.dtype),
+            cast_if_needed(moe_gate_weight, ctx.dtype),
+            d_gate_logits,
+            False,
+            False,
+        )
+        d_norm_output_linear, d_moe_gate_weight = cast_if_needed(
+            d_norm_output_linear, norm_output.dtype
+        ), cast_if_needed(d_moe_gate_weight, moe_gate_weight.dtype)
+
+        d_norm_output = d_norm_output + d_norm_output_linear
+        dx, d_rms_norm_weight = fused_ln.fused_rms_norm_grad_func(x, rms_norm_weight, invar, d_norm_output, eps)
+
+        return dx, d_rms_norm_weight, d_moe_gate_weight
+
+
 class FakeGate(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, hidden_states, weight):
@@ -756,7 +791,16 @@ class FakeGate(paddle.autograd.PyLayer):
 
 
 class MoEGate(PretrainedMoEGate):
-    def __init__(self, config, num_experts, expert_hidden_size, **kwargs):
+    def __init__(
+        self,
+        config,
+        num_experts,
+        expert_hidden_size,
+        using_post_norm_recompute=False,
+        norm_weight=None,
+        norm_eps=None,
+        **kwargs
+    ):
         super().__init__(config, num_experts, expert_hidden_size, **kwargs)
         # [hidden_size, n_expert]
 
@@ -771,6 +815,8 @@ class MoEGate(PretrainedMoEGate):
         )
 
         self.config = config
+        self.using_post_norm_recompute = using_post_norm_recompute
+
         if config.topk_method == "noaux_tc":
             self.e_score_correction_bias = paddle.create_parameter(
                 shape=[num_experts],
@@ -779,6 +825,10 @@ class MoEGate(PretrainedMoEGate):
             )
             self.e_score_correction_bias.is_distributed = True
 
+        if self.using_post_norm_recompute:
+            assert norm_weight is not None and norm_eps is not None
+            self.norm_weight = norm_weight
+            self.norm_eps = norm_eps
         self.using_flex_token = False
 
     def forward(self, hidden_states):
@@ -789,23 +839,33 @@ class MoEGate(PretrainedMoEGate):
         _, _, h_dim = hidden_states.shape
 
         # compute gating score
-        with paddle.amp.auto_cast(False):
-            hidden_states = hidden_states.cast(self.weight.dtype)
+        if self.using_post_norm_recompute:
+            logits, norm_out = FusedNormGateFunc.apply(hidden_states, self.norm_weight, self.weight, self.norm_eps)
+        else:
+            with paddle.amp.auto_cast(False):
+                hidden_states = hidden_states.cast(self.weight.dtype)
+                if hasattr(self.config, "using_fake_gate") and self.config.using_fake_gate:
+                    logits = FakeGate.apply(hidden_states, self.weight)
+                else:
+                    logits = F.linear(hidden_states, self.weight, None)
 
-            if hasattr(self.config, "using_fake_gate") and self.config.using_fake_gate:
-                logits = FakeGate.apply(hidden_states, self.weight)
-            else:
-                logits = F.linear(hidden_states, self.weight, None)
+        scores = self.gate_score_func(logits=logits)
+        scores = scores.cast(paddle.float32)
 
-            scores = self.gate_score_func(logits=logits)
-            scores = scores.cast(paddle.float32)
-
+        # Compute all possible return values
         if self.using_flex_token:
-            scores, routing_map, exp_counts, l_aux, l_zloss = self.topkgating_nodrop(scores)
-            return scores, routing_map, l_aux, l_zloss
+            scores, routing_map, exp_counts, l_aux, l_zloss = self.topkgating_nodrop(
+                scores
+            )  # (scores, routing_map, exp_counts, l_aux, l_zloss)
+            ret = (scores, routing_map, l_aux, l_zloss)
+        else:
+            ret = self.topkgating(scores)  # (capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss)
 
-        capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss = self.topkgating(scores)
-        return capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss
+        # Append norm_out if needed
+        if self.using_post_norm_recompute:
+            ret = (*ret, norm_out)
+
+        return ret
 
 
 class AddAuxiliaryLoss(paddle.autograd.PyLayer):
@@ -833,8 +893,12 @@ class DeepseekV2MoE(MoELayer):
     A mixed expert module containing shared experts.
     """
 
-    def __init__(self, config: DeepseekV2Config):
+    def __init__(self, config: DeepseekV2Config, norm_weight=None, norm_eps=None):
         assert config.tensor_parallel_degree <= 1, "tensor_parallel_degree should be 1"
+
+        self.using_post_norm_recompute = config.using_post_norm_recompute
+        if self.using_post_norm_recompute:
+            assert norm_weight is not None and norm_eps is not None
 
         gate = MoEGate(
             config=config,
@@ -847,6 +911,9 @@ class DeepseekV2MoE(MoELayer):
             norm_topk_prob=config.norm_topk_prob,
             routed_scaling_factor=config.routed_scaling_factor,
             drop_tokens=False,
+            using_post_norm_recompute=self.using_post_norm_recompute,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
         )
         DeepseekV2MLPClass = FP8Mlp if DSV3_USE_FP8_GEMM else DeepseekV2MLP
 
@@ -862,6 +929,7 @@ class DeepseekV2MoE(MoELayer):
             gate=gate,
             capacity=2.0,
             moe_group="expert",
+            using_post_norm_recompute=self.using_post_norm_recompute,
         )
 
         moe_grad_group = fleet.get_hybrid_communicate_group().expert_grad_comm_group
@@ -871,11 +939,44 @@ class DeepseekV2MoE(MoELayer):
         self.alpha = config.aux_loss_alpha
         if config.n_shared_experts is not None:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
-            self.shared_experts = DeepseekV2MLPClass(config=config, intermediate_size=intermediate_size, is_moe=False)
+            if self.using_post_norm_recompute:
+                assert isinstance(DeepseekV2MLPClass, FP8Mlp)
+                self.shared_experts = DeepseekV2MLPClass(
+                    config=config,
+                    intermediate_size=intermediate_size,
+                    is_moe=False,
+                    using_post_norm_recompute=self.using_post_norm_recompute,
+                    norm_weight=norm_weight,
+                    norm_eps=norm_eps,
+                )
+            else:
+                self.shared_experts = DeepseekV2MLPClass(
+                    config=config, intermediate_size=intermediate_size, is_moe=False
+                )
 
     def forward(self, hidden_states):
-        final_hidden_states, l_aux, l_zloss = super().forward(hidden_states)
-        final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
+        if self.using_post_norm_recompute:
+            super().update_flex_token()
+            if self.using_flex_token:
+                probs, routing_map, l_aux, l_zloss, norm_out = self.router(hidden_states)
+                final_hidden_states, l_aux, l_zloss = super().forward(
+                    norm_out, probs=probs, routing_map=routing_map, l_aux=l_aux, l_zloss=l_zloss
+                )
+            else:
+                capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss, norm_out = self.gate(hidden_states)
+                final_hidden_states, l_aux, l_zloss = super().forward(
+                    norm_out,
+                    capacity=capacity,
+                    topk_weight=topk_weight,
+                    topk_ids=topk_ids,
+                    token_priority=token_priority,
+                    l_aux=l_aux,
+                    l_zloss=l_zloss,
+                )
+            final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
+        else:
+            final_hidden_states, l_aux, l_zloss = super().forward(hidden_states)
+            final_hidden_states = self.post_process(hidden_states, final_hidden_states, l_aux)
         return final_hidden_states
 
     def post_process(self, hidden_states, final_hidden_states, l_aux):
@@ -1774,6 +1875,7 @@ class DeepseekV2DecoderLayer(nn.Layer):
         self.enable_recompute = False
         self.layerwise_recompute = layerwise_recompute
         self.recompute_granularity = config.recompute_granularity
+        self.using_post_norm_recompute = config.using_post_norm_recompute
 
         self.hidden_size = config.hidden_size
 
@@ -1781,17 +1883,23 @@ class DeepseekV2DecoderLayer(nn.Layer):
 
         DeepseekV2MLPClass = FP8Mlp if DSV3_USE_FP8_GEMM else DeepseekV2MLP
 
-        self.mlp = (
-            DeepseekV2MoE(config)
-            if (
-                config.n_routed_experts is not None
-                and layer_idx >= config.first_k_dense_replace
-                and layer_idx % config.moe_layer_freq == 0
-            )
-            else DeepseekV2MLPClass(config)
-        )
         self.input_layernorm = DeepseekV2RMSNorm(config)
         self.post_attention_layernorm = DeepseekV2RMSNorm(config)
+
+        if (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            self.mlp = (
+                DeepseekV2MoE(
+                    config, self.post_attention_layernorm.weight, self.post_attention_layernorm.variance_epsilon
+                )
+                if config.using_post_norm_recompute
+                else DeepseekV2MoE(config)
+            )
+        else:
+            self.mlp = DeepseekV2MLPClass(config)
 
     def forward(
         self,
@@ -1871,7 +1979,9 @@ class DeepseekV2DecoderLayer(nn.Layer):
         # Fully Connected
         residual = hidden_states
 
-        hidden_states = self.post_attention_layernorm(hidden_states)
+        if not (self.using_post_norm_recompute and isinstance(self.mlp, DeepseekV2MoE)):
+            hidden_states = self.post_attention_layernorm(hidden_states)
+
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
 

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -16,6 +16,7 @@ import paddle
 import paddle.nn.functional as F
 
 try:
+    import fused_ln
     from paddle.incubate.nn.functional import swiglu
 except ImportError:
 
@@ -457,41 +458,113 @@ def fp8_mlp_bwd(do3, x, w1, w2):
     return dx
 
 
+def common_fp8_mlp_fwd(x, w1, w2):
+    # ===== o1 = deep_gemm(x_fp8, w1_t_fp8) =====
+    x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        x, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+    )
+
+    _, _, w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True
+    )
+    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=x.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_sacle), o1)
+
+    # ===== o2 = swiglu(o1) =====
+    o2 = swiglu(o1)
+    o2_fp8, o2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+    )
+
+    # ===== o3 = deep_gemm(o2_fp8, w2_t_fp8) =====
+    _, _, w2_t_fp8, w2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=True
+    )
+    o3 = paddle.empty([o2_fp8.shape[0], w2_t_fp8.shape[0]], dtype=o1.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((o2_fp8, o2_scale.T), (w2_t_fp8, w2_t_scale), o3)
+    return x_fp8, x_scale, o3
+
+
+def common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2):
+    _, _, w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True
+    )
+    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=do3.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_sacle), o1)
+
+    # ===== [recompute] o2 = swiglu(o1) =====
+    o2 = swiglu(o1)
+
+    # ===== do2 = deep_gemm(do3_fp8, w2_fp8)
+    if do3.shape[0] % 512 != 0:
+        do3_fp8, do3_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+        )
+        do3 = padding(do3, 0)
+        _, _, do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+        )
+    else:
+        do3_fp8, do3_scale, do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+        )
+    w2_fp8, w2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=False
+    )
+    do2 = paddle.empty([do3_fp8.shape[0], w2_fp8.shape[0]], do3.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((do3_fp8, do3_scale.T), (w2_fp8, w2_scale), do2)
+
+    # ===== dw2 = deep_gemm(o2_t_fp8, do3_t_fp8)
+    o2 = padding(o2, 0)
+    _, _, o2_t_fp8, o2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+    )
+
+    dw2 = kitchen_fp8_gemm(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, True, True, rtn_dtype=paddle.float32)
+
+    # ===== do1 = swiglu_grad(o1, None, do2) =====
+    do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
+
+    # ===== dx = deep_gemm(do1_fp8, w1_fp8)
+    if do1.shape[0] % 512 != 0:
+        do1_fp8, do1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+        )
+        do1 = padding(do1, 0)
+        _, _, do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+        )
+    else:
+        do1_fp8, do1_scale, do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+        )
+    w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=False
+    )
+    dx = paddle.empty([do1_fp8.shape[0], w1_fp8.shape[0]], do1.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((do1_fp8, do1_scale.T), (w1_fp8, w1_sacle), dx)
+
+    # ===== dw1 = deep_gemm(x_t_fp8, do1_t_fp8)
+    dw1 = kitchen_fp8_gemm(x_t_fp8, x_t_scale, do1_t_fp8, do1_t_scale, True, True, rtn_dtype=paddle.float32)
+
+    return dx, dw1, dw2
+
+
 class FP8MlpFunction(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, x, w1, w2):
-        # deep_gemm only support 2D
+        # ===== reshape for deep_gemm, since deep_gemm only support 2D =====
         x_orig_shape = x.shape
         x = x.reshape([-1, x_orig_shape[-1]])
 
-        # ===== o1 = deep_gemm(x_fp8, w1_t_fp8) =====
-        x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            x, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-        )
+        # ===== call func common_fp8_mlp_fwd =====
+        x_fp8, x_scale, o3 = common_fp8_mlp_fwd(x, w1, w2)
 
-        _, _, w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True
-        )
-        o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=x.dtype)
-        deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_sacle), o1)
-
-        # ===== o2 = swiglu(o1) =====
-        o2 = swiglu(o1)
-        o2_fp8, o2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            o2, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-        )
-
-        # ===== o3 = deep_gemm(o2_fp8, w2_t_fp8) =====
-        _, _, w2_t_fp8, w2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            w2, output_scale_transpose=False, quant_method="128x128", input_transpose=True
-        )
-        o3 = paddle.empty([o2_fp8.shape[0], w2_t_fp8.shape[0]], dtype=o1.dtype)
-        deep_gemm.gemm_fp8_fp8_bf16_nt((o2_fp8, o2_scale.T), (w2_t_fp8, w2_t_scale), o3)
+        # ===== reshape to origin shape =====
         if len(x_orig_shape) > 2:
             o3 = o3.reshape([x_orig_shape[0], -1, o3.shape[-1]])
 
         # ===== save for backward =====
-
         ctx.save_for_backward(
             x_fp8,
             x_scale,
@@ -503,18 +576,15 @@ class FP8MlpFunction(paddle.autograd.PyLayer):
 
     @staticmethod
     def backward(ctx, do3):
-        # deep_gemm only support 2D
+        # ===== reshape for deep_gemm, since deep_gemm only support 2D =====
         do3_orig_shape = do3.shape
         do3 = do3.reshape([-1, do3_orig_shape[-1]])
 
+        # ===== recive saved tensors =====
         x_fp8, x_scale, w1, w2, x_orig_shape = ctx.saved_tensor()
-        x_orig_shape = x_orig_shape.numpy()
 
-        _, _, w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True
-        )
-        o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=do3.dtype)
-        deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_sacle), o1)
+        # ===== compute x_t_fp8, x_t_scale for dw1 =====
+        x_orig_shape = x_orig_shape.numpy()
 
         x_dequant_fp16 = paddle.incubate.nn.functional.fused_act_dequant(x_fp8, x_scale.T.contiguous())
         x_dequant_fp16 = padding(x_dequant_fp16, 0)
@@ -523,69 +593,93 @@ class FP8MlpFunction(paddle.autograd.PyLayer):
             x_dequant_fp16, output_scale_transpose=True, quant_method="1x128", input_transpose=True
         )
 
-        # ===== [recompute] o2 = swiglu(o1) =====
-        o2 = swiglu(o1)
+        # ===== call func common_fp8_mlp_bwd =====
+        dx, dw1, dw2 = common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2)
 
-        # ===== do2 = deep_gemm(do3_fp8, w2_fp8)
-        if do3.shape[0] % 512 != 0:
-            do3_fp8, do3_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do3, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-            )
-            do3 = padding(do3, 0)
-            _, _, do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-            )
-        else:
-            do3_fp8, do3_scale, do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-            )
-        w2_fp8, w2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            w2, output_scale_transpose=False, quant_method="128x128", input_transpose=False
-        )
-        do2 = paddle.empty([do3_fp8.shape[0], w2_fp8.shape[0]], do3.dtype)
-        deep_gemm.gemm_fp8_fp8_bf16_nt((do3_fp8, do3_scale.T), (w2_fp8, w2_scale), do2)
-
-        # ===== dw2 = deep_gemm(o2_t_fp8, do3_t_fp8)
-        o2 = padding(o2, 0)
-        _, _, o2_t_fp8, o2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            o2, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-        )
-
-        dw2 = kitchen_fp8_gemm(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, True, True, rtn_dtype=paddle.float32)
-
-        # ===== do1 = swiglu_grad(o1, None, do2) =====
-        do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
-
-        # ===== dx = deep_gemm(do1_fp8, w1_fp8)
-        if do1.shape[0] % 512 != 0:
-            do1_fp8, do1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do1, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-            )
-            do1 = padding(do1, 0)
-            _, _, do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-            )
-        else:
-            do1_fp8, do1_scale, do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-                do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-            )
-        w1_fp8, w1_sacle = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            w1, output_scale_transpose=False, quant_method="128x128", input_transpose=False
-        )
-        dx = paddle.empty([do1_fp8.shape[0], w1_fp8.shape[0]], do1.dtype)
-        deep_gemm.gemm_fp8_fp8_bf16_nt((do1_fp8, do1_scale.T), (w1_fp8, w1_sacle), dx)
+        # ===== reshape to origin shape =====
         if len(x_orig_shape) > 2:
             dx = dx.reshape([x_orig_shape[0], -1, dx.shape[-1]])
 
-        # ===== dw1 = deep_gemm(x_t_fp8, do1_t_fp8)
-        dw1 = kitchen_fp8_gemm(x_t_fp8, x_t_scale, do1_t_fp8, do1_t_scale, True, True, rtn_dtype=paddle.float32)
         return dx, dw1, dw2
 
 
+class FP8NormMlpRecomputeFunction(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, x, norm_w, w1, w2, norm_eps):
+        # ===== compute norm_output =====
+        norm_output, invar = fused_ln.fused_rms_norm(x, norm_w, norm_eps)
+        # ===== reshape for deep_gemm, since deep_gemm only support 2D =====
+        x_orig_shape = norm_output.shape
+        norm_output = norm_output.reshape([-1, x_orig_shape[-1]])
+
+        # ===== call func common_fp8_mlp_fwd =====
+        _, _, o3 = common_fp8_mlp_fwd(norm_output, w1, w2)
+
+        # ===== reshape to origin shape =====
+        if len(x_orig_shape) > 2:
+            o3 = o3.reshape([x_orig_shape[0], -1, o3.shape[-1]])
+
+        # ===== save for backward =====
+        ctx.save_for_backward(
+            x,
+            norm_w,
+            w1,
+            w2,
+            norm_eps,
+            paddle.to_tensor(x_orig_shape, dtype="int64", place=paddle.CPUPlace()),
+        )
+        return o3
+
+    @staticmethod
+    def backward(ctx, do3):
+        # ===== reshape for deep_gemm, since deep_gemm only support 2D =====
+        do3_orig_shape = do3.shape
+        do3 = do3.reshape([-1, do3_orig_shape[-1]])
+
+        # ===== recive saved tensors =====
+        x, norm_w, w1, w2, norm_eps, x_orig_shape = ctx.saved_tensor()
+
+        # ===== recompute norm =====
+        x_orig_shape = x_orig_shape.numpy()
+        norm_output, invar = fused_ln.fused_rms_norm(x, norm_w, norm_eps)
+
+        # ===== compute x_t_fp8, x_t_scale for dw1 =====
+        x_fp8, x_scale, x_t_fp8, x_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+            norm_output, output_scale_transpose=True, quant_method="1x128", input_transpose=True
+        )
+
+        # ===== call func common_fp8_mlp_bwd =====
+        d_norm_output, dw1, dw2 = common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2)
+
+        # ===== reshape to origin shape =====
+        if len(x_orig_shape) > 2:
+            d_norm_output = d_norm_output.reshape([x_orig_shape[0], -1, d_norm_output.shape[-1]])
+
+        # ===== compute norm grad =====
+        dx, d_rms_norm_weight = fused_ln.fused_rms_norm_grad_func(x, norm_w, invar, d_norm_output, norm_eps)
+
+        return dx, d_rms_norm_weight, dw1, dw2
+
+
 class FP8Mlp(paddle.nn.Layer):
-    def __init__(self, config, hidden_size=None, intermediate_size=None, is_moe=False):
+    def __init__(
+        self,
+        config,
+        hidden_size=None,
+        intermediate_size=None,
+        is_moe=False,
+        using_post_norm_recompute=False,
+        norm_weight=None,
+        norm_eps=None,
+    ):
         super().__init__()
         self.config = config
+        self.using_post_norm_recompute = using_post_norm_recompute
+        if self.using_post_norm_recompute:
+            assert norm_weight is not None and norm_eps is not None
+            self.norm_weight = norm_weight
+            self.norm_eps = norm_eps
+
         self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
         self.intermediate_size = config.intermediate_size if intermediate_size is None else intermediate_size
 
@@ -601,7 +695,10 @@ class FP8Mlp(paddle.nn.Layer):
         )
 
     def forward(self, x):
-        return FP8MlpFunction.apply(x, self.w1, self.w2)
+        if self.using_post_norm_recompute:
+            return FP8NormMlpRecomputeFunction.apply(x, self.w1, self.w2, self.norm_weight, self.norm_eps)
+        else:
+            return FP8MlpFunction.apply(x, self.w1, self.w2)
 
 
 def split_group_gemm(x_fp8, x_scale, w_fp8, w_scale, tokens_per_expert, gemm_out):

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -584,8 +584,6 @@ class FP8MlpFunction(paddle.autograd.PyLayer):
         x_fp8, x_scale, w1, w2, x_orig_shape = ctx.saved_tensor()
 
         # ===== compute x_t_fp8, x_t_scale for dw1 =====
-        x_orig_shape = x_orig_shape.numpy()
-
         x_dequant_fp16 = paddle.incubate.nn.functional.fused_act_dequant(x_fp8, x_scale.T.contiguous())
         x_dequant_fp16 = padding(x_dequant_fp16, 0)
 
@@ -640,10 +638,10 @@ class FP8NormMlpRecomputeFunction(paddle.autograd.PyLayer):
         x, norm_w, w1, w2, norm_eps, x_orig_shape = ctx.saved_tensor()
 
         # ===== recompute norm =====
-        x_orig_shape = x_orig_shape.numpy()
         norm_output, invar = fused_ln.fused_rms_norm(x, norm_w, norm_eps)
 
         # ===== compute x_t_fp8, x_t_scale for dw1 =====
+        norm_output = norm_output.reshape([-1, x_orig_shape[-1]])
         x_fp8, x_scale, x_t_fp8, x_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
             norm_output, output_scale_transpose=True, quant_method="1x128", input_transpose=True
         )
@@ -696,7 +694,7 @@ class FP8Mlp(paddle.nn.Layer):
 
     def forward(self, x):
         if self.using_post_norm_recompute:
-            return FP8NormMlpRecomputeFunction.apply(x, self.w1, self.w2, self.norm_weight, self.norm_eps)
+            return FP8NormMlpRecomputeFunction.apply(x, self.norm_weight, self.w1, self.w2, self.norm_eps)
         else:
             return FP8MlpFunction.apply(x, self.w1, self.w2)
 

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -188,6 +188,7 @@ class MoELayer(nn.Layer):
         capacity: int = 1.0,
         moe_group: str = "data",
         all_to_all_dropout=0.0,
+        using_post_norm_recompute=False,
     ):
         super().__init__()
 
@@ -245,6 +246,8 @@ class MoELayer(nn.Layer):
         )
         self.token_drop_steps = config.token_drop_steps
         self.using_flex_token = False
+
+        self.using_post_norm_recompute = using_post_norm_recompute
         self._post_init()
 
     def update_flex_token(self):
@@ -280,17 +283,36 @@ class MoELayer(nn.Layer):
                     p.no_sync = not self.is_dummy_moe
                     # logger.info(f"expert param={p.name}, no-sync={p.no_sync}")
 
-    def forward(self, hidden_states: paddle.Tensor):
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        probs=None,
+        routing_map=None,
+        capacity=None,
+        topk_weight=None,
+        topk_ids=None,
+        token_priority=None,
+        l_aux=None,
+        l_zloss=None,
+    ):
         self.update_flex_token()
 
         if self.using_flex_token:
-            return self.forward_flex_token(hidden_states)
+            return self.forward_flex_token(hidden_states, probs, routing_map, l_aux, l_zloss)
         else:
-            return self.forward_drop_token(hidden_states)
+            return self.forward_drop_token(
+                hidden_states, capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss
+            )
 
     def forward_drop_token(
         self,
         hidden_state: paddle.Tensor,
+        capacity=None,
+        topk_weight=None,
+        topk_ids=None,
+        token_priority=None,
+        l_aux=None,
+        l_zloss=None,
     ):
         """MoE Layer forward function
             1. Gate Forward.
@@ -312,7 +334,17 @@ class MoELayer(nn.Layer):
         # topk_ids    : sk
         # token_priority    : se
         # self.exp_counts  :
-        capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss = self.gate(hidden_state)
+        if self.using_post_norm_recompute:
+            assert (
+                capacity is not None
+                and topk_weight is not None
+                and topk_ids is not None
+                and token_priority is not None
+                and l_aux is not None
+                and l_zloss is not None
+            )
+        else:
+            capacity, topk_weight, topk_ids, token_priority, l_aux, l_zloss = self.gate(hidden_state)
 
         """MoE expert dispatch from: https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py"""
         cnts = paddle.zeros([topk_ids.shape[0], len(self.experts)], dtype=topk_ids.dtype)
@@ -391,10 +423,13 @@ class MoELayer(nn.Layer):
 
         return final_out, l_aux, l_zloss
 
-    def forward_flex_token(self, hidden_states: paddle.Tensor):
+    def forward_flex_token(self, hidden_states: paddle.Tensor, probs=None, routing_map=None, l_aux=None, l_zloss=None):
         _, _, d_model = hidden_states.shape
         # reshaped_input = hidden_states.reshape([-1, d_model])
-        probs, routing_map, l_aux, l_zloss = self.router(hidden_states)
+        if self.using_post_norm_recompute:
+            assert probs is not None and routing_map is not None and l_aux is not None and l_zloss is not None
+        else:
+            probs, routing_map, l_aux, l_zloss = self.router(hidden_states)
         if DSV3_USE_FP8_GEMM:
             if DSV3_USE_FP8_DISPATCH:
                 output = FusionMoe.apply(

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -1002,3 +1002,10 @@ def caculate_llm_per_token_flops(
     # 2 for mul + add in matmul
     # 1 for forward, 2 for backwards since we caluate gradients for input_x and input_y
     return 2 * (layer_num * (flops_per_transformer * 3 + flops_recompute_transformer) + 3 * flops_loggits) / seq_length
+
+
+def cast_if_needed(x, dtype):
+    """
+    cast_if_needed
+    """
+    return x.cast(dtype) if x.dtype != dtype else x


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
为ds_v3添加了「**post_norm和gate**」，「**post_norm和shared expert**」的recompute重计算，反向时重新计算post_norm，以节省post_norm输出显存。
为组成recompute pylayer需调整模型结构，整体思路是**尽量不更改现有接口，如需修改，则尽量修改接口输入避免修改接口输出，输入中尽量添加可选参数**，避免影响其余模型及配置运行。
具体调整如下：
1. 添加了 FusedNormGateFunc pylayer及 using_post_norm_recompute config，实现post_norm+gate重计算功能
2. 添加了 FP8NormMlpRecomputeFunction，其与FP8MlpFunction为同级别函数，增加了重计算postnorm功能，抽取了FP8NormMlpRecomputeFunction、FP8MlpFunction公共部分为common_fp8_mlp_fwd、common_fp8_mlp_bwd
3. 升级MoeGate、DeepseekV2MoE、FP8Mlp，添加可选分支判断是否执行 norm_gate_recompute
4. 修改MoeGate接口，输入增加 norm_weight 及 norm_eps，输出增加 norm_out
5. 修改DeepseekV2MoE构造函数，增加 norm_weight 及 norm_eps，并将super().forward中gate相关功能提取到子类forward中实现recompute，避免过多对父类(MoELayer)进行修改
6. 父类(MoELayer)构造函数添加using_norm_gate_recompute，用来跳过gate计算，forward函数增加可选输入接受gate输出结构，避免修改输出接口