### PR TITLE
[AutoParallel] fix GPT embedding placements

### DIFF
--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -658,7 +658,7 @@ class GPTEmbeddingsAuto(nn.Layer):
             config.hidden_size,
         )
         self.word_embeddings.weight = dist.shard_tensor(
-            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Replicate()]
+            self.word_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
         )
         self.position_embeddings.weight = dist.shard_tensor(
             self.position_embeddings.weight, get_mesh(), [dist.Replicate(), dist.Shard(1)]
@@ -699,6 +699,7 @@ class GPTEmbeddingsAuto(nn.Layer):
         # The 'with' block ensures the correct seed context is used
         with seed_guard_context(current_seed):
             embeddings = self.dropout(embeddings)
+        embeddings = dist.reshard(embeddings, get_mesh(), [dist.Replicate(), dist.Replicate()])
         return embeddings
 
 
@@ -1176,7 +1177,7 @@ class GPTLMHeadAuto(nn.Layer):
                 shape=[config.vocab_size, config.hidden_size],
                 dtype=paddle.get_default_dtype(),
             )
-            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(0)])
+            self.weight = dist.shard_tensor(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(1)])
 
     def forward(self, hidden_states, tensor_parallel_output=None):
 
@@ -1187,7 +1188,7 @@ class GPTLMHeadAuto(nn.Layer):
         if tensor_parallel_output is None:
             tensor_parallel_output = self.config.tensor_parallel_output
 
-        y = dist.reshard(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(0)])
+        y = dist.reshard(self.weight, get_mesh(self.ipp), [dist.Replicate(), dist.Shard(1)])
         logits = paddle.matmul(hidden_states, y, transpose_y=self.transpose_y)
         return logits
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
GPT 动半下，修改 placemetns 以提高性能
1、修改 embedding 和 lmhead 层 weight 的 placemetns 为列切
2、修改 `GPTEmbeddingsAuto` 层输出的 placemetns 为 replicate

- 修改前：
`GPTEmbeddingsAuto` 输出为 `[Replicate(), Reshard(2)]`，导致每次进入 encoder 层的状态都为 `[Replicate(), Reshard(2)]`，在进行 `residual + dropout` 计算时，有 `[Replicate(), Reshard(2)]` ->   `[Replicate(), Replicate()]`，这在前向和反向中会引入 allgather 通信
GPT 单机8卡 H卡 最优配置 20layer 吞吐(token/card/s)：7902.79 

- 修改后：
`GPTEmbeddingsAuto` 输出为 `[Replicate(), Replicate()]`， encoder 层输入的状态也为 replicate，在进行 `residual + dropout` 计算时，可以直接进行 replicate 计算，不引入额外通信
 GPT 单机8卡 H卡 最优配置 20layer 吞吐(token/card/s)：8305.75(+402.96,+5.1%)
