### PR TITLE
add recompute of postnorm in pp

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -2040,7 +2040,9 @@ class DeepseekV2DecoderLayer(nn.Layer):
         hidden_states = residual + hidden_states
 
         residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
+
+        if not self.using_post_norm_recompute:
+            hidden_states = self.post_attention_layernorm(hidden_states)
 
         return hidden_states, residual
 

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -57,7 +57,12 @@ from paddlenlp.transformers.fused_a2a import (
 )
 from paddlenlp.transformers.moe_layer import FusionMoeNode
 
-from ..fp8_utils import fp8_mlp_bwd, fp8_mlp_fwd
+from ..fp8_utils import (
+    fp8_mlp_bwd,
+    fp8_mlp_bwd_norm_rc,
+    fp8_mlp_fwd,
+    fp8_mlp_fwd_norm_rc,
+)
 
 __all__ = [
     "DeepseekV2ForCausalLMPipe",
@@ -134,13 +139,27 @@ class TensorMeta:
 
 
 class PostProcessNode(ScheduleNode):
-    def __init__(self, send_mtp_embed, training, alpha, config, shared_experts=None, name="PostProcessNode"):
+    def __init__(
+        self,
+        send_mtp_embed,
+        training,
+        alpha,
+        config,
+        shared_experts=None,
+        using_post_norm_recompute=False,
+        name="PostProcessNode",
+    ):
         self.send_mtp_embed = send_mtp_embed
         self.shared_experts = shared_experts
         self.traning = training
         self.config = config
         self.alpha = alpha
+        self.using_post_norm_recompute = using_post_norm_recompute
         self.name = name
+
+        if self.using_post_norm_recompute:
+            assert self.shared_experts is not None
+            assert self.shared_experts.norm_weight is not None and self.shared_experts.norm_eps is not None
 
     def forward(self, inputs):
 
@@ -154,7 +173,16 @@ class PostProcessNode(ScheduleNode):
 
         with paddle.no_grad():
             if self.shared_experts is not None:
-                shared_expert_output = fp8_mlp_fwd(hidden_states, self.shared_experts.w1, self.shared_experts.w2)
+                if self.using_post_norm_recompute:
+                    shared_expert_output = fp8_mlp_fwd_norm_rc(
+                        hidden_states,
+                        self.shared_experts.norm_weight,
+                        self.shared_experts.norm_eps,
+                        self.shared_experts.w1,
+                        self.shared_experts.w2,
+                    )
+                else:
+                    shared_expert_output = fp8_mlp_fwd(hidden_states, self.shared_experts.w1, self.shared_experts.w2)
                 final_hidden_states = final_hidden_states + shared_expert_output
 
         self.x = hidden_states
@@ -171,8 +199,17 @@ class PostProcessNode(ScheduleNode):
         (do3,) = output_grad
 
         assert not self.send_mtp_embed, "not support have mtp have yet"
-
-        dx = fp8_mlp_bwd(do3, self.x, self.shared_experts.w1, self.shared_experts.w2)
+        if self.using_post_norm_recompute:
+            dx = fp8_mlp_bwd_norm_rc(
+                do3,
+                self.x,
+                self.shared_experts.norm_weight,
+                self.shared_experts.norm_eps,
+                self.shared_experts.w1,
+                self.shared_experts.w2,
+            )
+        else:
+            dx = fp8_mlp_bwd(do3, self.x, self.shared_experts.w1, self.shared_experts.w2)
 
         self.x = None
 
@@ -438,78 +475,61 @@ class OverlapedScheduleNode:
 
 
 class FusionFp8DecoderLayerNode(ScheduleNode):
-    def __init__(self, attn_and_gate_node, fp8_fusion_moe_node, post_process_node, mlp_layer, send_mtp_embed, name=""):
+    def __init__(
+        self,
+        attn_and_gate_node,
+        fp8_fusion_moe_node,
+        post_process_node,
+        mlp_layer,
+        send_mtp_embed,
+        using_post_norm_recompute=False,
+        name="",
+    ):
         self.attn_and_gate_node = attn_and_gate_node
         self.fp8_fusion_moe_node = fp8_fusion_moe_node
         self.post_process_node = post_process_node
         self.send_mtp_embed = send_mtp_embed
 
+        self.using_post_norm_recompute = using_post_norm_recompute
         self.name = name
 
         self.moe_group = mlp_layer.moe_group
 
     def attn_forward(self, inputs):
-        if self.send_mtp_embed:
-            (
-                inputs_embeds_mtp,
-                hidden_states,
-                residual,
-                probs,
-                routing_map,
-                l_aux,
-            ) = self.attn_and_gate_node.forward(inputs)
-        else:
-            (
-                hidden_states,
-                residual,
-                probs,
-                routing_map,
-                l_aux,
-            ) = self.attn_and_gate_node.forward(inputs)
+        inputs = self.attn_and_gate_node.forward(inputs)
 
-        hs_2d, token_indices, token_probs = self.fp8_fusion_moe_node.dispatch_quant_node.forward(
-            hidden_states, probs, routing_map
-        )
         if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp,
-                hidden_states,
-                residual,
-                l_aux,
-                hs_2d,
-                token_indices,
-                token_probs,
+            if self.using_post_norm_recompute:
+                inputs_embeds_mtp, hidden_states, residual, probs, routing_map, l_aux, norm_out = inputs
+            else:
+                inputs_embeds_mtp, hidden_states, residual, probs, routing_map, l_aux = inputs
+        else:
+            if self.using_post_norm_recompute:
+                hidden_states, residual, probs, routing_map, l_aux, norm_out = inputs
+            else:
+                hidden_states, residual, probs, routing_map, l_aux = inputs
+
+        if self.using_post_norm_recompute:
+            hs_2d, token_indices, token_probs = self.fp8_fusion_moe_node.dispatch_quant_node.forward(
+                norm_out, probs, routing_map
             )
         else:
-            return (
-                hidden_states,
-                residual,
-                l_aux,
-                hs_2d,
-                token_indices,
-                token_probs,
+            hs_2d, token_indices, token_probs = self.fp8_fusion_moe_node.dispatch_quant_node.forward(
+                hidden_states, probs, routing_map
             )
+
+        # common return values
+        ret = (hidden_states, residual, l_aux, hs_2d, token_indices, token_probs)
+
+        # append mtp embed if needed
+        ret = (inputs_embeds_mtp, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def dispatch_forward(self, inputs, previous_event=None, async_finish=False, allocate_on_comm_stream=False):
         if self.send_mtp_embed:
-            (
-                inputs_embeds_mtp,
-                hidden_states,
-                residual,
-                l_aux,
-                hs_2d,
-                token_indices,
-                token_probs,
-            ) = inputs
+            inputs_embeds_mtp, hidden_states, residual, l_aux, hs_2d, token_indices, token_probs = inputs
         else:
-            (
-                hidden_states,
-                residual,
-                l_aux,
-                hs_2d,
-                token_indices,
-                token_probs,
-            ) = inputs
+            hidden_states, residual, l_aux, hs_2d, token_indices, token_probs = inputs
 
         (hs_dispatched, dispatched_indices, dispatched_probs,) = self.fp8_fusion_moe_node.dispatch_node.forward(
             hs_2d,
@@ -519,25 +539,12 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
             async_finish=async_finish,
             allocate_on_comm_stream=allocate_on_comm_stream,
         )
-        if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp,
-                hidden_states,
-                residual,
-                l_aux,
-                hs_dispatched,
-                dispatched_indices,
-                dispatched_probs,
-            )
-        else:
-            return (
-                hidden_states,
-                residual,
-                l_aux,
-                hs_dispatched,
-                dispatched_indices,
-                dispatched_probs,
-            )
+
+        ret = (hidden_states, residual, l_aux, hs_dispatched, dispatched_indices, dispatched_probs)
+
+        # append mtp embed if needed
+        ret = (inputs_embeds_mtp, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def mlp_forward(self, inputs):
         if self.send_mtp_embed:
@@ -551,22 +558,16 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
                 dispatched_probs,
             ) = inputs
         else:
-            (
-                hidden_states,
-                residual,
-                l_aux,
-                hs_dispatched,
-                dispatched_indices,
-                dispatched_probs,
-            ) = inputs
+            hidden_states, residual, l_aux, hs_dispatched, dispatched_indices, dispatched_probs = inputs
+
         hidden_states_out = self.fp8_fusion_moe_node.mlp_node.forward(
             hs_dispatched, dispatched_indices, dispatched_probs
         )
+        ret = (hidden_states, residual, l_aux, hidden_states_out)
 
-        if self.send_mtp_embed:
-            return (inputs_embeds_mtp, hidden_states, residual, l_aux, hidden_states_out)
-        else:
-            return (hidden_states, residual, l_aux, hidden_states_out)
+        # append mtp embed if needed
+        ret = (inputs_embeds_mtp, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def combine_forward(self, inputs, async_finish=False):
         if self.send_mtp_embed:
@@ -575,10 +576,12 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
             (hidden_states, residual, l_aux, hidden_states_out) = inputs
 
         output_combine = self.fp8_fusion_moe_node.combine_node.forward(hidden_states_out, async_finish=async_finish)
-        if self.send_mtp_embed:
-            return (inputs_embeds_mtp, hidden_states, residual, l_aux, output_combine)
-        else:
-            return (hidden_states, residual, l_aux, output_combine)
+
+        ret = (hidden_states, residual, l_aux, output_combine)
+
+        # append mtp embed if needed
+        ret = (inputs_embeds_mtp, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def post_process_forward(self, inputs):
         if self.send_mtp_embed:
@@ -586,125 +589,57 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         else:
             (hidden_states, residual, l_aux, output_combine) = inputs
         final_hidden_states = self.fp8_fusion_moe_node.combine_quant_node.forward(output_combine)
-        if self.send_mtp_embed:
-            inputs = (inputs_embeds_mtp, hidden_states, residual, l_aux, final_hidden_states)
-        else:
-            inputs = (hidden_states, residual, l_aux, final_hidden_states)
-        inputs = self.post_process_node.forward(inputs)
 
+        inputs = (hidden_states, residual, l_aux, final_hidden_states)
+        inputs = (inputs_embeds_mtp, *inputs) if self.send_mtp_embed else inputs
+
+        inputs = self.post_process_node.forward(inputs)
         return inputs
 
     def post_process_backward(self, output_grad):
+        grad = self.post_process_node.backward(output_grad)
+
         if self.send_mtp_embed:
-            (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                final_hidden_states_grad,
-            ) = self.post_process_node.backward(output_grad)
+            inputs_embeds_mtp_grad, hidden_states_grad, residual_grad, l_aux_grad, final_hidden_states_grad = grad
         else:
-            (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                final_hidden_states_grad,
-            ) = self.post_process_node.backward(output_grad)
+            hidden_states_grad, residual_grad, l_aux_grad, final_hidden_states_grad = grad
+
         output_combine_grad = self.fp8_fusion_moe_node.combine_quant_node.backward(final_hidden_states_grad)
-        if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                output_combine_grad,
-            )
-        else:
-            return (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                output_combine_grad,
-            )
+
+        ret = (hidden_states_grad, residual_grad, l_aux_grad, output_combine_grad)
+        ret = (inputs_embeds_mtp_grad, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def combine_backward(self, output_grad, async_finish=False):
         if self.send_mtp_embed:
-            (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                output_combine_grad,
-            ) = output_grad
+            inputs_embeds_mtp_grad, hidden_states_grad, residual_grad, l_aux_grad, output_combine_grad = output_grad
         else:
-            (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                output_combine_grad,
-            ) = output_grad
+            hidden_states_grad, residual_grad, l_aux_grad, output_combine_grad = output_grad
 
         hidden_states_out_grad = self.fp8_fusion_moe_node.combine_node.backward(
             output_combine_grad,
             async_finish=async_finish,
         )
 
-        if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hidden_states_out_grad,
-            )
-        else:
-            return (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hidden_states_out_grad,
-            )
+        ret = (hidden_states_grad, residual_grad, l_aux_grad, hidden_states_out_grad)
+        ret = (inputs_embeds_mtp_grad, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def mlp_backward_dw(self):
         self.fp8_fusion_moe_node.mlp_node.backward_dw()
 
     def mlp_backward(self, output_grad):
         if self.send_mtp_embed:
-            (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hidden_states_out_grad,
-            ) = output_grad
+            inputs_embeds_mtp_grad, hidden_states_grad, residual_grad, l_aux_grad, hidden_states_out_grad = output_grad
         else:
-            (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hidden_states_out_grad,
-            ) = output_grad
+            hidden_states_grad, residual_grad, l_aux_grad, hidden_states_out_grad = output_grad
         hs_dispatched_grad, dispatched_probs_grad = self.fp8_fusion_moe_node.mlp_node.backward(
             hidden_states_out_grad, with_dw=False
         )
 
-        if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hs_dispatched_grad,
-                dispatched_probs_grad,
-            )
-        else:
-            return (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hs_dispatched_grad,
-                dispatched_probs_grad,
-            )
+        ret = (hidden_states_grad, residual_grad, l_aux_grad, hs_dispatched_grad, dispatched_probs_grad)
+        ret = (inputs_embeds_mtp_grad, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def dispatch_backward(self, output_grad, async_finish=False):
         if self.send_mtp_embed:
@@ -717,28 +652,15 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
                 dispatched_probs_grad,
             ) = output_grad
         else:
-            (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hs_dispatched_grad,
-                dispatched_probs_grad,
-            ) = output_grad
+            hidden_states_grad, residual_grad, l_aux_grad, hs_dispatched_grad, dispatched_probs_grad = output_grad
+
         hs_grad, token_probs_grad = self.fp8_fusion_moe_node.dispatch_node.backward(
             hs_dispatched_grad, dispatched_probs_grad, async_finish=async_finish
         )
 
-        if self.send_mtp_embed:
-            return (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hs_grad,
-                token_probs_grad,
-            )
-        else:
-            return (hidden_states_grad, residual_grad, l_aux_grad, hs_grad, token_probs_grad)
+        ret = (hidden_states_grad, residual_grad, l_aux_grad, hs_grad, token_probs_grad)
+        ret = (inputs_embeds_mtp_grad, *ret) if self.send_mtp_embed else ret
+        return ret
 
     def attn_backward(self, output_grad):
         if self.send_mtp_embed:
@@ -751,34 +673,21 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
                 token_probs_grad,
             ) = output_grad
         else:
-            (
-                hidden_states_grad,
-                residual_grad,
-                l_aux_grad,
-                hs_grad,
-                token_probs_grad,
-            ) = output_grad
+            hidden_states_grad, residual_grad, l_aux_grad, hs_grad, token_probs_grad = output_grad
+
         hidden_states_grad_, probs_grad, routing_map_grad = self.fp8_fusion_moe_node.dispatch_quant_node.backward(
             hs_grad, token_probs_grad
         )
 
-        if self.send_mtp_embed:
-            output_grad = (
-                inputs_embeds_mtp_grad,
-                hidden_states_grad + hidden_states_grad_,
-                residual_grad,
-                probs_grad,
-                routing_map_grad,
-                l_aux_grad,
-            )
-        else:
-            output_grad = (
-                hidden_states_grad + hidden_states_grad_,
-                residual_grad,
-                probs_grad,
-                routing_map_grad,
-                l_aux_grad,
-            )
+        output_grad = (residual_grad, probs_grad, routing_map_grad, l_aux_grad)
+
+        output_grad = (
+            (hidden_states_grad, *output_grad, hidden_states_grad_)
+            if self.using_post_norm_recompute
+            else (hidden_states_grad + hidden_states_grad_, *output_grad)
+        )
+        output_grad = (inputs_embeds_mtp_grad, *output_grad) if self.send_mtp_embed else output_grad
+
         output_grad = self.attn_and_gate_node.backward(output_grad)
         return output_grad
 
@@ -821,7 +730,7 @@ class OverlapedFUsionScheduleNode:
         paddle.base.core.nvprof_nvtx_push("combine_backward")
         output_grad = self.backward_node.combine_backward(output_grad, async_finish=True)
         # get combine event
-        combine_backward_event = deep_ep.get_event_from_comm_stream( self.backward_node.moe_group.id)
+        combine_backward_event = deep_ep.get_event_from_comm_stream(self.backward_node.moe_group.id)
         paddle.base.core.nvprof_nvtx_pop()
 
         paddle.base.core.nvprof_nvtx_push("attn_forward")
@@ -829,8 +738,7 @@ class OverlapedFUsionScheduleNode:
         paddle.base.core.nvprof_nvtx_pop()
         attn_compute_event = deep_ep.get_event_from_calc_stream(self.forward_node.moe_group.id)
 
-
-        combine_backward_event.calc_stream_wait( self.backward_node.moe_group.id )
+        combine_backward_event.calc_stream_wait(self.backward_node.moe_group.id)
         paddle.base.core.nvprof_nvtx_push("mlp_backward_dx")
         output_grad = self.backward_node.mlp_backward(output_grad)
         paddle.base.core.nvprof_nvtx_pop()
@@ -839,7 +747,7 @@ class OverlapedFUsionScheduleNode:
             inputs, previous_event=attn_compute_event, async_finish=True, allocate_on_comm_stream=True
         )
         paddle.base.core.nvprof_nvtx_pop()
-        dispatch_forward_event = deep_ep.get_event_from_comm_stream( self.forward_node.moe_group.id )
+        dispatch_forward_event = deep_ep.get_event_from_comm_stream(self.forward_node.moe_group.id)
 
         paddle.base.core.nvprof_nvtx_push("dispatch_backward")
         output_grad = self.backward_node.dispatch_backward(output_grad, async_finish=True)
@@ -851,7 +759,7 @@ class OverlapedFUsionScheduleNode:
         self.backward_node.mlp_backward_dw()
         paddle.base.core.nvprof_nvtx_pop()
 
-        dispatch_forward_event.calc_stream_wait( self.forward_node.moe_group.id)
+        dispatch_forward_event.calc_stream_wait(self.forward_node.moe_group.id)
         paddle.base.core.nvprof_nvtx_push("mlp_forward")
         inputs = self.forward_node.mlp_forward(inputs)
         paddle.base.core.nvprof_nvtx_pop()
@@ -859,8 +767,7 @@ class OverlapedFUsionScheduleNode:
         paddle.base.core.nvprof_nvtx_push("combine_forward")
         inputs = self.forward_node.combine_forward(inputs, async_finish=True)
         paddle.base.core.nvprof_nvtx_pop()
-        combine_forward_event = deep_ep.get_event_from_comm_stream( self.forward_node.moe_group.id)
-
+        combine_forward_event = deep_ep.get_event_from_comm_stream(self.forward_node.moe_group.id)
 
         dispatch_backward_event.calc_stream_wait(self.backward_node.moe_group.id)
         paddle.base.core.nvprof_nvtx_push("attn_backward")
@@ -1128,25 +1035,26 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
 
         hidden_states, residual = self.self_attn_compute(hidden_states)
         _, _, d_model = hidden_states.shape
-        probs, routing_map, l_aux, _ = self.mlp.router(hidden_states)
 
-        if send_mtp_embed:
-            return (
-                inputs_embeds_mtp,
-                hidden_states,
-                residual,
-                probs,
-                routing_map,
-                l_aux,
-            )
+        if self.using_post_norm_recompute:
+            probs, routing_map, l_aux, _, norm_out = self.mlp.router(hidden_states)
         else:
-            return (
-                hidden_states,
-                residual,
-                probs,
-                routing_map,
-                l_aux,
-            )
+            probs, routing_map, l_aux, _ = self.mlp.router(hidden_states)
+
+        # common return values
+        ret = (
+            hidden_states,
+            residual,
+            probs,
+            routing_map,
+            l_aux,
+        )
+        # append mtp embed if needed
+        ret = (inputs_embeds_mtp, *ret) if send_mtp_embed else ret
+        # append norm_out if using post_norm recompute
+        ret = (*ret, norm_out) if self.using_post_norm_recompute else ret
+
+        return ret
 
     def mlp_compute(self, inputs):
         if isinstance(inputs, list):
@@ -1264,6 +1172,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                         self.mlp.alpha,
                         self.config,
                         self.mlp.shared_experts,
+                        self.config.using_post_norm_recompute,
                         "post_process_node",
                     )
                     return FusionFp8DecoderLayerNode(
@@ -1272,6 +1181,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                         post_process_node=post_process_node,
                         mlp_layer=self.mlp,
                         send_mtp_embed=self.config.send_mtp_embed,
+                        using_post_norm_recompute=self.config.using_post_norm_recompute,
                         name="FusionFp8DecoderLayerNode",
                     )
                 else:

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -305,32 +305,19 @@ def fp8_mlp_fwd(x, w1, w2):
     x_orig_shape = x.shape
     x = x.reshape([-1, x_orig_shape[-1]])
 
-    # ===== o1 = deep_gemm(x_fp8, w1_t_fp8) =====
-    x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        x, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-    )
+    _, _, o3 = common_fp8_mlp_fwd(x, w1, w2)
 
-    w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
-    )
-    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=x.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1, num_sms=112)
-
-    # ===== o2 = swiglu(o1) =====
-    o2 = swiglu(o1)
-    o2_fp8, o2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-    )
-
-    # ===== o3 = deep_gemm(o2_fp8, w2_t_fp8) =====
-    w2_t_fp8, w2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
-    )
-    o3 = paddle.empty([o2_fp8.shape[0], w2_t_fp8.shape[0]], dtype=o1.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((o2_fp8, o2_scale.T), (w2_t_fp8, w2_t_scale), o3, num_sms=112)
     if len(x_orig_shape) > 2:
         o3 = o3.reshape([x_orig_shape[0], -1, o3.shape[-1]])
 
+    return o3
+
+
+def fp8_mlp_fwd_norm_rc(x, norm_w, norm_eps, w1, w2):
+    # ===== compute norm_output =====
+    norm_output, _ = fused_ln.fused_rms_norm(x, norm_w, norm_eps)
+    # ===== compute fp8_mlp_fwd =====
+    o3 = fp8_mlp_fwd(norm_output, w1, w2)
     return o3
 
 
@@ -354,6 +341,67 @@ def fp8_mlp_bwd(do3, x, w1, w2):
             x, output_scale_transpose=True, quant_method="1x128", input_transpose=True, return_transpose_only=True
         )
 
+    dx = common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2, apply_backward_hook=True)
+
+    if len(x_orig_shape) > 2:
+        dx = dx.reshape([x_orig_shape[0], -1, dx.shape[-1]])
+
+    return dx
+
+
+def fp8_mlp_bwd_norm_rc(do3, x, norm_w, norm_eps, w1, w2):
+    # ===== recompute norm_output =====
+    norm_output, invar = fused_ln.fused_rms_norm(x, norm_w, norm_eps)
+
+    # ===== compute fp8_mlp_fwd =====
+    d_norm_output = fp8_mlp_bwd(do3, norm_output, w1, w2)
+
+    # ===== compute norm grad =====
+    dx, d_rms_norm_weight = fused_ln.fused_rms_norm_grad_func(x, norm_w, invar, d_norm_output, norm_eps)
+
+    if hasattr(norm_w, "main_grad"):
+        if norm_w.main_grad is None:
+            norm_w.main_grad = paddle.zeros(shape=norm_w.shape, dtype=paddle.float32)
+        norm_w.main_grad += d_rms_norm_weight
+    else:
+        if norm_w.grad is None:
+            norm_w.grad = paddle.zeros(shape=norm_w.shape, dtype=paddle.float32)
+        norm_w.grad += d_rms_norm_weight
+
+    if hasattr(norm_w, "_apply_backward_hook"):
+        norm_w._apply_backward_hook()
+
+    return dx
+
+
+def common_fp8_mlp_fwd(x, w1, w2):
+    # ===== o1 = deep_gemm(x_fp8, w1_t_fp8) =====
+    x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        x, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+    )
+
+    w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
+    )
+    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=x.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1, num_sms=112)
+
+    # ===== o2 = swiglu(o1) =====
+    o2 = swiglu(o1)
+    o2_fp8, o2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=False
+    )
+
+    # ===== o3 = deep_gemm(o2_fp8, w2_t_fp8) =====
+    w2_t_fp8, w2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
+        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
+    )
+    o3 = paddle.empty([o2_fp8.shape[0], w2_t_fp8.shape[0]], dtype=o1.dtype)
+    deep_gemm.gemm_fp8_fp8_bf16_nt((o2_fp8, o2_scale.T), (w2_t_fp8, w2_t_scale), o3, num_sms=112)
+    return x_fp8, x_scale, o3
+
+
+def common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2, apply_backward_hook=False):
     w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
         w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
     )
@@ -388,34 +436,37 @@ def fp8_mlp_bwd(do3, x, w1, w2):
         o2, output_scale_transpose=True, quant_method="1x128", input_transpose=True, return_transpose_only=True
     )
 
-    if hasattr(w2, "main_grad"):
-        if w2.main_grad is None:
-            w2.main_grad = paddle.zeros(shape=w2.shape, dtype=paddle.float32)
-        kitchen_fp8_gemm(
-            o2_t_fp8,
-            o2_t_scale,
-            do3_t_fp8,
-            do3_t_scale,
-            True,
-            True,
-            w2.main_grad,
-            paddle.float32,
-        )
+    if apply_backward_hook:
+        if hasattr(w2, "main_grad"):
+            if w2.main_grad is None:
+                w2.main_grad = paddle.zeros(shape=w2.shape, dtype=paddle.float32)
+            kitchen_fp8_gemm(
+                o2_t_fp8,
+                o2_t_scale,
+                do3_t_fp8,
+                do3_t_scale,
+                True,
+                True,
+                w2.main_grad,
+                paddle.float32,
+            )
+        else:
+            if w2.grad is None:
+                w2.grad = paddle.zeros(shape=w2.shape, dtype=paddle.float32)
+            kitchen_fp8_gemm(
+                o2_t_fp8,
+                o2_t_scale,
+                do3_t_fp8,
+                do3_t_scale,
+                True,
+                True,
+                w2.grad,
+                paddle.float32,
+            )
+        if hasattr(w2, "_apply_backward_hook"):
+            w2._apply_backward_hook()
     else:
-        if w2.grad is None:
-            w2.grad = paddle.zeros(shape=w2.shape, dtype=paddle.float32)
-        kitchen_fp8_gemm(
-            o2_t_fp8,
-            o2_t_scale,
-            do3_t_fp8,
-            do3_t_scale,
-            True,
-            True,
-            w2.grad,
-            paddle.float32,
-        )
-    if hasattr(w2, "_apply_backward_hook"):
-        w2._apply_backward_hook()
+        dw2 = kitchen_fp8_gemm(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, True, True, rtn_dtype=paddle.float32)
 
     # ===== do1 = swiglu_grad(o1, None, do2) =====
     do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
@@ -438,132 +489,45 @@ def fp8_mlp_bwd(do3, x, w1, w2):
     )
     dx = paddle.empty([do1_fp8.shape[0], w1_fp8.shape[0]], do1.dtype)
     deep_gemm.gemm_fp8_fp8_bf16_nt((do1_fp8, do1_scale.T), (w1_fp8, w1_scale), dx, num_sms=112)
-    if len(x_orig_shape) > 2:
-        dx = dx.reshape([x_orig_shape[0], -1, dx.shape[-1]])
 
     # ===== dw1 = deep_gemm(x_t_fp8, do1_t_fp8)
-    if hasattr(w1, "main_grad"):
-        if w1.main_grad is None:
-            w1.main_grad = paddle.zeros(shape=w1.shape, dtype=paddle.float32)
-        kitchen_fp8_gemm(
-            x_t_fp8,
-            x_t_scale,
-            do1_t_fp8,
-            do1_t_scale,
-            True,
-            True,
-            w1.main_grad,
-            paddle.float32,
-        )
+    if apply_backward_hook:
+        if hasattr(w1, "main_grad"):
+            if w1.main_grad is None:
+                w1.main_grad = paddle.zeros(shape=w1.shape, dtype=paddle.float32)
+            kitchen_fp8_gemm(
+                x_t_fp8,
+                x_t_scale,
+                do1_t_fp8,
+                do1_t_scale,
+                True,
+                True,
+                w1.main_grad,
+                paddle.float32,
+            )
+        else:
+            if w1.grad is None:
+                w1.grad = paddle.zeros(shape=w1.shape, dtype=paddle.float32)
+            kitchen_fp8_gemm(
+                x_t_fp8,
+                x_t_scale,
+                do1_t_fp8,
+                do1_t_scale,
+                True,
+                True,
+                w1.grad,
+                paddle.float32,
+            )
+        if hasattr(w1, "_apply_backward_hook"):
+            w1._apply_backward_hook()
     else:
-        if w1.grad is None:
-            w1.grad = paddle.zeros(shape=w1.shape, dtype=paddle.float32)
-        kitchen_fp8_gemm(
-            x_t_fp8,
-            x_t_scale,
-            do1_t_fp8,
-            do1_t_scale,
-            True,
-            True,
-            w1.grad,
-            paddle.float32,
-        )
-    if hasattr(w1, "_apply_backward_hook"):
-        w1._apply_backward_hook()
+        dw1 = kitchen_fp8_gemm(x_t_fp8, x_t_scale, do1_t_fp8, do1_t_scale, True, True, rtn_dtype=paddle.float32)
 
-    return dx
-
-
-def common_fp8_mlp_fwd(x, w1, w2):
-    # ===== o1 = deep_gemm(x_fp8, w1_t_fp8) =====
-    x_fp8, x_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        x, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-    )
-
-    w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
-    )
-    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=x.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1)
-
-    # ===== o2 = swiglu(o1) =====
-    o2 = swiglu(o1)
-    o2_fp8, o2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-    )
-
-    # ===== o3 = deep_gemm(o2_fp8, w2_t_fp8) =====
-    w2_t_fp8, w2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
-    )
-    o3 = paddle.empty([o2_fp8.shape[0], w2_t_fp8.shape[0]], dtype=o1.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((o2_fp8, o2_scale.T), (w2_t_fp8, w2_t_scale), o3)
-    return x_fp8, x_scale, o3
-
-
-def common_fp8_mlp_bwd(do3, x_fp8, x_scale, x_t_fp8, x_t_scale, w1, w2):
-    w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=True, return_transpose_only=True
-    )
-    o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=do3.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1)
-
-    # ===== [recompute] o2 = swiglu(o1) =====
-    o2 = swiglu(o1)
-
-    # ===== do2 = deep_gemm(do3_fp8, w2_fp8)
-    if do3.shape[0] % 512 != 0:
-        do3_fp8, do3_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-        )
-        do3 = padding(do3, 0)
-        do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True, return_transpose_only=True
-        )
+    if apply_backward_hook:
+        return dx
     else:
-        do3_fp8, do3_scale, do3_t_fp8, do3_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do3, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-        )
-    w2_fp8, w2_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w2, output_scale_transpose=False, quant_method="128x128", input_transpose=False
-    )
-    do2 = paddle.empty([do3_fp8.shape[0], w2_fp8.shape[0]], do3.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((do3_fp8, do3_scale.T), (w2_fp8, w2_scale), do2)
-
-    # ===== dw2 = deep_gemm(o2_t_fp8, do3_t_fp8)
-    o2 = padding(o2, 0)
-    o2_t_fp8, o2_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        o2, output_scale_transpose=True, quant_method="1x128", input_transpose=True, return_transpose_only=True
-    )
-
-    dw2 = kitchen_fp8_gemm(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, True, True, rtn_dtype=paddle.float32)
-
-    # ===== do1 = swiglu_grad(o1, None, do2) =====
-    do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
-
-    # ===== dx = deep_gemm(do1_fp8, w1_fp8)
-    if do1.shape[0] % 512 != 0:
-        do1_fp8, do1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=False
-        )
-        do1 = padding(do1, 0)
-        do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True, return_transpose_only=True
-        )
-    else:
-        do1_fp8, do1_scale, do1_t_fp8, do1_t_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-            do1, output_scale_transpose=True, quant_method="1x128", input_transpose=True
-        )
-    w1_fp8, w1_scale = paddle.incubate.nn.functional.fp8_quant_blockwise(
-        w1, output_scale_transpose=False, quant_method="128x128", input_transpose=False
-    )
-    dx = paddle.empty([do1_fp8.shape[0], w1_fp8.shape[0]], do1.dtype)
-    deep_gemm.gemm_fp8_fp8_bf16_nt((do1_fp8, do1_scale.T), (w1_fp8, w1_scale), dx)
-
-    # ===== dw1 = deep_gemm(x_t_fp8, do1_t_fp8)
-    dw1 = kitchen_fp8_gemm(x_t_fp8, x_t_scale, do1_t_fp8, do1_t_scale, True, True, rtn_dtype=paddle.float32)
-
-    return dx, dw1, dw2
+        assert dw1 is not None and dw2 is not None
+        return dx, dw1, dw2
 
 
 class FP8MlpFunction(paddle.autograd.PyLayer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
本PR功能是在开启DualPipe场景下启动postnorm与gate、shared expert的recompute，并对冗余代码进行整理，开启后no_fake_gate+no_o1_recompute场景，pp4sd2，8expert下，MoeDecoderLayer显存占用961-->784，具体改动如下：
1. 新增fp8_mlp_bwd_norm_rc、fp8_mlp_fwd_norm_rc 实现pp场景下shared_expert与postnorm的recompute
3. 统一pp与非pp场景下shared_expert的调用流程，抽象common_fp8_mlp_bwd、common_fp8_mlp_fwd，添加apply_backward_hook区分pp与非pp场景