### PR TITLE
Update lora_quantization_layers.py

### DIFF
--- a/paddlenlp/peft/lora/lora_quantization_layers.py
+++ b/paddlenlp/peft/lora/lora_quantization_layers.py
@@ -23,7 +23,7 @@ from paddle.distributed.fleet.utils.sequence_parallel_utils import (
     mark_as_sequence_parallel_parameter,
 )
 
-from ...quantization.quantization_linear import quant_weight_linear
+from ...quantization.quantization_linear import quant_weight_linear, get_act_scale_group
 from ...utils.log import logger
 from .utils import rng_ctx
 
@@ -44,7 +44,17 @@ class QuantizationLoRABaseLinear(nn.Layer):
         else:
             self.quant_scale = layer.quant_scale
         self.bias = layer.bias
-
+        self.state = 0
+        if self.weight_quantize_algo in ["a8w8linear", "a8w4linear", "fp8linear"]:
+            self.act_scale = self.create_parameter(
+                shape=[1],
+                dtype=self._dtype,
+                is_bias=False,
+                default_initializer=nn.initializer.Constant(value=0.0),
+            )
+            self.act_scale.is_distributed = False
+            self.act_scale.stop_gradient = True
+            self.group = get_act_scale_group(is_row=True)
         # LoRA related parameters
         self.lora_config = lora_config
         if not isinstance(self.lora_config.r, int) or self.lora_config.r <= 0:
@@ -77,7 +87,10 @@ class QuantizationLoRABaseLinear(nn.Layer):
             if (self.weight_quantize_algo in ["fp4", "nf4"] and self.quantization_config.qlora_weight_double_quant)
             else None,
             bias=self.bias if add_bias else None,
+            act_state=(self.state, self.training, self.act_scale, self.group)
         )
+        if self.training:
+            self.state += 1
         return output
 
     def merge(self):


### PR DESCRIPTION
Fix parallel QLoRA in reference to paddlenlp/quantization/quantization_linear.py

The original lora_quantization_layers.py is in paddlenlp/peft/lora

In class QuantizationLoRABaseLinear:
In method __init__:
insert codes '
        self.state = 0
        if self.weight_quantize_algo in ["a8w8linear", "a8w4linear", "fp8linear"]:
            self.act_scale = self.create_parameter(
                shape=[1],
                dtype=self._dtype,
                is_bias=False,
                default_initializer=nn.initializer.Constant(value=0.0),
            )
            self.act_scale.is_distributed = False
            self.act_scale.stop_gradient = True
            self.group = get_act_scale_group(is_row=True)
        else:
            raise NotImplementedError(
                f"Not supported weight_quantize_algo {self.weight_quantize_algo}"
            )
'
between 'self.bias = layer.bias' and 'self.lora_config = lora_config'

In method forward:
insert 'act_state=(self.state, self.training, self.act_scale, self.group)' in the parameter list of 'output=quant_weight_linear'

insert codes '
        if self.training:
            self.state += 1
'
before 'return output'

However, after such change, in different cases, I found that loss would start to converge with different beginnings (I have deleted all checkpoints every time I start a new case):

1. No parallelism: 7.68577909
<img width="2280" height="1286" alt="c513e1950276abb2b9ce3ef3318fd588" src="https://github.com/user-attachments/assets/89750f1c-9ed7-4e55-99db-465fc05d5143" />

2. tensor parallelism with paddle.distributed.launch: 14.6875057
<img width="2280" height="1264" alt="06e7970ba2a23e10e79c7991343f2855" src="https://github.com/user-attachments/assets/c0dade4d-778b-453c-946e-e4d80f3227de" />

3. paddle.distributed.launch: 7.88057899
<img width="2280" height="1264" alt="862df2c2c3f946fd37bb80116a21a2cd" src="https://github.com/user-attachments/assets/a9c708a5-c872-4b0a-99fc-d9d3fb0e6b4d" />

4. pipeline parallelism with paddle.distributed.launch: 13.96667099
<img width="2280" height="1264" alt="a8a56f2950f844f80888f6c3a2f0e6da" src="https://github.com/user-attachments/assets/21ab4341-2b32-494d-88ff-d1fbc2637ac3" />


