### PR TITLE
Add adaptived recomptue of o1

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -185,6 +185,7 @@ class DeepseekV2Config(PretrainedConfig):
         recompute_fwd_gate_up=0,
         is_split_group_gemm=False,
         fakse_gate_restrict_balance=False,
+        adaptive_remained_recompute_fwd_gate_up=False,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -239,6 +240,7 @@ class DeepseekV2Config(PretrainedConfig):
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.is_split_group_gemm = is_split_group_gemm
         self.fakse_gate_restrict_balance = fakse_gate_restrict_balance
+        self.adaptive_remained_recompute_fwd_gate_up = adaptive_remained_recompute_fwd_gate_up
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -185,7 +185,7 @@ class DeepseekV2Config(PretrainedConfig):
         recompute_fwd_gate_up=0,
         is_split_group_gemm=False,
         fakse_gate_restrict_balance=False,
-        adaptive_remained_recompute_fwd_gate_up=False,
+        adaptive_remained_O1_recompute_ratio=0,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -240,7 +240,7 @@ class DeepseekV2Config(PretrainedConfig):
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.is_split_group_gemm = is_split_group_gemm
         self.fakse_gate_restrict_balance = fakse_gate_restrict_balance
-        self.adaptive_remained_recompute_fwd_gate_up = adaptive_remained_recompute_fwd_gate_up
+        self.adaptive_remained_O1_recompute_ratio = adaptive_remained_O1_recompute_ratio
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1192,9 +1192,15 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
             if self.mlp.using_flex_token:
                 if DSV3_USE_FP8_GEMM:
                     attn_and_gate_node = ScheduleNode(self.attn_compute_for_fusion, name="attn_and_gate_node")
+
+                    recompute_fwd_gate_up_ = 1 if self.layer_idx in self.config.recompute_fwd_gate_up_list else 0
+                    recompute_fwd_gate_up_ = (
+                        -1 if self.config.adaptive_remained_recompute_fwd_gate_up else recompute_fwd_gate_up_
+                    )
+
                     fp8_fusion_moe_node = FusionMoeNode(
                         self.mlp,
-                        recompute_fwd_gate_up=self.config.recompute_fwd_gate_up,
+                        recompute_fwd_gate_up=recompute_fwd_gate_up_,
                         is_split_group_gemm=self.config.is_split_group_gemm,
                         name="fp8_fusion_moe_node",
                     )

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1195,7 +1195,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
 
                     recompute_fwd_gate_up_ = 1 if self.layer_idx in self.config.recompute_fwd_gate_up_list else 0
                     recompute_fwd_gate_up_ = (
-                        -1 if self.config.adaptive_remained_recompute_fwd_gate_up else recompute_fwd_gate_up_
+                        -1 if self.config.adaptive_remained_O1_recompute_ratio else recompute_fwd_gate_up_
                     )
 
                     fp8_fusion_moe_node = FusionMoeNode(

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -704,10 +704,17 @@ class FusionMlpNode:
             recompute_fwd_gate_up=recompute_fwd_gate_up,
             is_split_group_gemm=is_split_group_gemm,
         )
+
+        self.seq_length = custom_map.config.seq_length
+        self.num_experts_per_tok = custom_map.config.num_experts_per_tok
+        self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.dispatched_indices = None
         self.dispatched_probs = None
         self.tokens_per_expert = None
         self.router_topk = max_topk
+
+    def set_recompute_fwd_gate_up(self, recompute_fwd_gate_up):
+        self.experts_group_gemm_node.recompute_fwd_gate_up = recompute_fwd_gate_up
 
     def reset_statue(self, with_dw=False):
         """
@@ -771,6 +778,15 @@ class FusionMlpNode:
             dispatched_indices._record_stream()
             dispatched_probs._record_stream()
 
+            # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
+            if self.recompute_fwd_gate_up == -1:
+                if unzipped_tokens.shape[0] > self.seq_length * self.num_experts_per_tok * 2:
+                    # logger.debug(f"recompute_fwd_gate_up changed to True, Because the receives {unzipped_tokens.shape[0]} Tensors greater then {self.seq_length*self.num_experts_per_tok*2}.")
+                    self.set_recompute_fwd_gate_up(True)
+                else:
+                    # logger.debug(f"recompute_fwd_gate_up changed to False, Because the receives {unzipped_tokens.shape[0]} Tensors less then {self.seq_length*self.num_experts_per_tok*2}.")
+                    self.set_recompute_fwd_gate_up(False)
+
             # 2 experts
             padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
             expert_out = self.experts_group_gemm_node.forward(
@@ -791,6 +807,13 @@ class FusionMlpNode:
             hs_2d_dispatched._record_stream()
             dispatched_indices._record_stream()
             dispatched_probs._record_stream()
+
+            # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
+            if self.recompute_fwd_gate_up == -1:
+                if unzipped_tokens.shape[0] > self.seq_length * self.num_experts_per_tok * 2:
+                    self.set_recompute_fwd_gate_up(True)
+                else:
+                    self.set_recompute_fwd_gate_up(False)
 
             # 2 experts
             padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -786,10 +786,10 @@ class FusionMlpNode:
                     unzipped_tokens.shape[0]
                     > self.seq_length * self.num_experts_per_tok * self.adaptive_remained_O1_recompute_ratio
                 ):
-                    # logger.debug(f"recompute_fwd_gate_up changed to True, Because the receives {unzipped_tokens.shape[0]} Tensors greater then {self.seq_length*self.num_experts_per_tok*2}.")
+                    # logger.debug(f"recompute_fwd_gate_up changed to True, Because the receives {unzipped_tokens.shape[0]} Tensors greater then {self.seq_length*self.num_experts_per_tok*self.adaptive_remained_O1_recompute_ratio}.")
                     self.set_recompute_fwd_gate_up(True)
                 else:
-                    # logger.debug(f"recompute_fwd_gate_up changed to False, Because the receives {unzipped_tokens.shape[0]} Tensors less then {self.seq_length*self.num_experts_per_tok*2}.")
+                    # logger.debug(f"recompute_fwd_gate_up changed to False, Because the receives {unzipped_tokens.shape[0]} Tensors less then {self.seq_length*self.num_experts_per_tok*self.adaptive_remained_O1_recompute_ratio}.")
                     self.set_recompute_fwd_gate_up(False)
 
             # 2 experts

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -707,6 +707,8 @@ class FusionMlpNode:
 
         self.seq_length = custom_map.config.seq_length
         self.num_experts_per_tok = custom_map.config.num_experts_per_tok
+        self.adaptive_remained_O1_recompute_ratio = custom_map.config.adaptive_remained_O1_recompute_ratio
+
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.dispatched_indices = None
         self.dispatched_probs = None
@@ -780,7 +782,10 @@ class FusionMlpNode:
 
             # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
             if self.recompute_fwd_gate_up == -1:
-                if unzipped_tokens.shape[0] > self.seq_length * self.num_experts_per_tok * 2:
+                if (
+                    unzipped_tokens.shape[0]
+                    > self.seq_length * self.num_experts_per_tok * self.adaptive_remained_O1_recompute_ratio
+                ):
                     # logger.debug(f"recompute_fwd_gate_up changed to True, Because the receives {unzipped_tokens.shape[0]} Tensors greater then {self.seq_length*self.num_experts_per_tok*2}.")
                     self.set_recompute_fwd_gate_up(True)
                 else:
@@ -810,7 +815,10 @@ class FusionMlpNode:
 
             # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
             if self.recompute_fwd_gate_up == -1:
-                if unzipped_tokens.shape[0] > self.seq_length * self.num_experts_per_tok * 2:
+                if (
+                    unzipped_tokens.shape[0]
+                    > self.seq_length * self.num_experts_per_tok * self.adaptive_remained_O1_recompute_ratio
+                ):
                     self.set_recompute_fwd_gate_up(True)
                 else:
                     self.set_recompute_fwd_gate_up(False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
本PR增加自适应 O1 recompute 功能，具体功能如下：
1. 新增 adaptive_remained_O1_recompute_ratio flag，0代表关闭，数字代表不均衡阈值，例如1.3，则代表超出专家处理Tokens超出均衡值30%时，开启O1 recompute
2. adaptive_remained_O1_recompute_ratio 与 recompute_fwd_gate_up 可配合使用，recompute_fwd_gate_up 填入数字可强制控制 pp chunck 中开启几个 O1 recompute，该chunck中剩余 O1 将交由adaptive_remained_O1_recompute_ratio自适应控制
3. 非pp场景：recompute_fwd_gate_up为false，adaptive_remained_O1_recompute_ratio不为0则全部开启自适应