### PR TITLE
Add sequence and output dimension subbatch

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -188,6 +188,9 @@ class DeepseekV2Config(PretrainedConfig):
         adaptive_remained_O1_recompute_ratio=0,
         offline_quant_expert_weight=True,
         clear_origin_weight_when_offline_quant=True,
+        mlp_bwd_subbatch_rows=0,
+        mlp_fwd_subbatch_rows=0,
+        output_subbatch_rows=0,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -245,6 +248,9 @@ class DeepseekV2Config(PretrainedConfig):
         self.adaptive_remained_O1_recompute_ratio = adaptive_remained_O1_recompute_ratio
         self.offline_quant_expert_weight = offline_quant_expert_weight
         self.clear_origin_weight_when_offline_quant = clear_origin_weight_when_offline_quant
+        self.mlp_bwd_subbatch_rows = mlp_bwd_subbatch_rows
+        self.mlp_fwd_subbatch_rows = mlp_fwd_subbatch_rows
+        self.output_subbatch_rows = output_subbatch_rows
 
         super().__init__(
             pad_token_id=pad_token_id,

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1340,9 +1340,8 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
 
                     # recompute_fwd_gate_up_ may be 1, 0 or -1, 1 means recompute, 0 means disable recompute, -1 means adaptive recompute.
                     recompute_fwd_gate_up_ = 1 if self.layer_idx in self.config.recompute_fwd_gate_up_list else 0
-                    recompute_fwd_gate_up_ = (
-                        -1 if self.config.adaptive_remained_O1_recompute_ratio else recompute_fwd_gate_up_
-                    )
+                    if recompute_fwd_gate_up_ == 0 and self.config.adaptive_remained_O1_recompute_ratio:
+                        recompute_fwd_gate_up_ = -1
 
                     fp8_fusion_moe_node = FusionMoeNode(
                         self.mlp,

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1338,6 +1338,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                 if DSV3_USE_FP8_GEMM:
                     attn_and_gate_node = ScheduleNode(self.attn_compute_for_fusion, name="attn_and_gate_node")
 
+                    # recompute_fwd_gate_up_ may be 1, 0 or -1, 1 means recompute, 0 means disable recompute, -1 means adaptive recompute.
                     recompute_fwd_gate_up_ = 1 if self.layer_idx in self.config.recompute_fwd_gate_up_list else 0
                     recompute_fwd_gate_up_ = (
                         -1 if self.config.adaptive_remained_O1_recompute_ratio else recompute_fwd_gate_up_
@@ -1347,6 +1348,9 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                         self.mlp,
                         recompute_fwd_gate_up=recompute_fwd_gate_up_,
                         is_split_group_gemm=self.config.is_split_group_gemm,
+                        mlp_fwd_subbatch_rows=self.config.mlp_fwd_subbatch_rows,
+                        mlp_bwd_subbatch_rows=self.config.mlp_bwd_subbatch_rows,
+                        output_subbatch_rows=self.config.output_subbatch_rows,
                         name="fp8_fusion_moe_node",
                     )
                     post_process_node = PostProcessNode(

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -259,6 +259,10 @@ class FP8LinearFunctionBase:
         """
         统一处理 expert_w 的梯度计算（支持 main_grad 和普通 grad)
         """
+
+        if input_t is None or input_t.numel() == 0:
+            return
+
         if hasattr(weight, "main_grad"):
             if weight.main_grad is None:
                 weight.main_grad = paddle.zeros(shape=weight.shape, dtype=paddle.float32)

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -780,52 +780,34 @@ class FP8GroupGemmMlpFunctionNode:
     ):
         self.experts = custom_map.experts
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
-        # self.recompute_fwd_gate_up = True
         self.is_split_group_gemm = is_split_group_gemm
         self.tokens_per_expert = None
         self.m_indices = None
-        self.unzipped_probs = None
         self.input = None
         self.input_fp8 = None
         self.input_scale = None
         self.o1 = None
-
-    def cached_tensors(self):
-        return [
-            self.tokens_per_expert,
-            self.m_indices,
-            self.unzipped_probs,
-            self.input,
-            self.input_fp8,
-            self.input_scale,
-            self.o1,
-        ]
-
-    def set_cached_tensors(self, tensors):
-        (
-            self.tokens_per_expert,
-            self.m_indices,
-            self.unzipped_probs,
-            self.input,
-            self.input_fp8,
-            self.input_scale,
-            self.o1,
-        ) = tensors
-
-    def clear_cached_tensors(self):
-        self.set_cached_tensors([None] * len(self.cached_tensors))
+        self.all_unzipped_grad = None
+        self.fwd_subbatch = None
+        self.bwd_subbatch = None
+        self.all_do1_list = []
+        self.all_o2_s_list = []
 
     def reset_statue(self):
         self.tokens_per_expert = None
         self.m_indices = None
+        self.fwd_subbatch = None
+        self.bwd_subbatch = None
+        self.all_do1_list = None
+        self.all_o2_s_list = None
         self.clear_activation_tensors()
 
     def clear_activation_tensors(self):
-        self.unzipped_probs = None
         self.input = None
         self.input_fp8 = None
         self.input_scale = None
         self.o1 = None
+        self.all_unzipped_grad = None
 
     def gen_m_indices(self, tokens_per_expert):
         tokens = []
@@ -834,13 +816,12 @@ class FP8GroupGemmMlpFunctionNode:
         out = paddle.concat(tokens, axis=0)
         return out
 
-    def fwd_gate_up(self, x, expert_w1, num_expert, tokens_per_expert):
+    def fwd_gate_up(self, x, expert_w1, num_expert, tokens_per_expert, m_indices=None):
         """
         o1 = x * w1
         [m_sum, n] = [m_sum, k] * [num_groups, k, n] (m_sum = sum(tokens_per_expert))
         """
-        self.tokens_per_expert = tokens_per_expert
-        if not self.is_split_group_gemm:
+        if not self.is_split_group_gemm and self.m_indices is None:
             self.m_indices = self.gen_m_indices(tokens_per_expert)
         # concat w1, shape is [num_groups, n, k]
         w1_t_quant, w1_t_scale = fused_stack_quant(expert_w1, transpose=True)
@@ -868,18 +849,23 @@ class FP8GroupGemmMlpFunctionNode:
                 split_group_gemm(x_fp8, x_scale, w1_t_quant, w1_t_scale, tokens_per_expert, o1)
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
-                    (x_fp8, x_scale), (w1_t_quant, w1_t_scale), o1, m_indices=self.m_indices, num_sms=118
+                    (x_fp8, x_scale),
+                    (w1_t_quant, w1_t_scale),
+                    o1,
+                    m_indices=self.m_indices if m_indices is None else m_indices,
+                    num_sms=118,
                 )
 
-        self.input_fp8 = x_fp8
-        self.input_scale = x_scale
+        if not self.fwd_subbatch:
+            self.input_fp8 = x_fp8
+            self.input_scale = x_scale
         return o1
 
     def fwd_swiglu(self, o1):
         o2 = swiglu(o1)
         return o2
 
-    def fwd_down(self, o1, unzipped_probs, expert_w2, num_expert, o3=None, clear_o1=False):
+    def fwd_down(self, o1, unzipped_probs, expert_w2, num_expert, m_indices=None, o3=None, clear_o1=False):
         """
         o3 = o2 * w2
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
@@ -891,11 +877,11 @@ class FP8GroupGemmMlpFunctionNode:
 
         # quant o2
         with paddle.amp.auto_cast(False):
+            unzipped_probs = unzipped_probs.squeeze(-1)
             o2_fp8, o2_scale = paddle.incubate.nn.functional.fused_weighted_swiglu_act_quant(
                 o1, unzipped_probs, using_pow2_scaling=True
             )
         o2_scale = paddle.transpose(paddle.transpose(o2_scale, [1, 0]).contiguous(), [1, 0])
-        unzipped_probs = unzipped_probs.unsqueeze(-1)
 
         if clear_o1:
             o1._clear_to_zero_allocation()
@@ -911,11 +897,16 @@ class FP8GroupGemmMlpFunctionNode:
                 split_group_gemm(o2_fp8, o2_scale, w2_quant, w2_scale, self.tokens_per_expert, o3)
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
-                    (o2_fp8, o2_scale), (w2_quant, w2_scale), o3, m_indices=self.m_indices, num_sms=118
+                    (o2_fp8, o2_scale),
+                    (w2_quant, w2_scale),
+                    o3,
+                    m_indices=m_indices if self.fwd_subbatch else self.m_indices,
+                    num_sms=118,
                 )
-        return o3, unzipped_probs
 
-    def bwd_dowm_input(self, expert_w2, unzipped_grad, o1, inplace_swiglu_prob=False):
+        return o3
+
+    def bwd_dowm_input(self, expert_w2, unzipped_grad, o1, m_indices=None, unzipped_probs=None):
         """
         do2 = do3 * w2_t
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
@@ -946,14 +937,12 @@ class FP8GroupGemmMlpFunctionNode:
                     (unzipped_grad_fp8, unzipped_grad_scale),
                     (bw_w2_quant, bw_w2_scale),
                     do2_s,
-                    m_indices=self.m_indices,
+                    m_indices=m_indices if self.bwd_subbatch else self.m_indices,
                     num_sms=118,
                 )
 
         with paddle.amp.auto_cast(False):
-            do1, probs_grad, o2_s = paddle.incubate.nn.functional.fused_swiglu_weighted_bwd(
-                o1, do2_s, self.unzipped_probs
-            )
+            do1, probs_grad, o2_s = paddle.incubate.nn.functional.fused_swiglu_weighted_bwd(o1, do2_s, unzipped_probs)
 
         return do1, o2_s, probs_grad
 
@@ -961,7 +950,7 @@ class FP8GroupGemmMlpFunctionNode:
         do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
         return do1
 
-    def bwd_gate_up_input(self, do1, expert_w1, dx=None):
+    def bwd_gate_up_input(self, do1, expert_w1, m_indices=None, dx=None):
         """
         dx = do1 * w1_t
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
@@ -987,7 +976,11 @@ class FP8GroupGemmMlpFunctionNode:
                 split_group_gemm(do1_fp8, do1_scale, bw_w1_quant, bw_w1_scale, self.tokens_per_expert, dx)
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
-                    (do1_fp8, do1_scale), (bw_w1_quant, bw_w1_scale), dx, m_indices=self.m_indices, num_sms=118
+                    (do1_fp8, do1_scale),
+                    (bw_w1_quant, bw_w1_scale),
+                    dx,
+                    m_indices=m_indices if self.bwd_subbatch else self.m_indices,
+                    num_sms=118,
                 )
 
         return dx
@@ -1032,14 +1025,17 @@ class FP8GroupGemmMlpFunctionNode:
         else:
             cal_weight_fn(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, expert_w2)
 
-    def bwd_gate_up_weight(self, do1, input_x, expert_w1, clear_input=False):
+    def bwd_gate_up_weight(
+        self, do1, input_x, expert_w1, input_fp8_slice=None, input_scale_slice=None, clear_input=False
+    ):
         """
         dw1 = dx_t * do1
         [k, n] = [k, m_sum] * [m_sum, n] (m_sum = sum(tokens_per_expert))
         """
         if input_x is None:
+            inp = (self.input_fp8, self.input_scale) if self.is_subbatch else (input_fp8_slice, input_scale_slice)
             input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(
-                self.input_fp8, self.input_scale, self.tokens_per_expert, True
+                inp[0], inp[1], self.tokens_per_expert, True
             )
 
         else:
@@ -1076,8 +1072,10 @@ class FP8GroupGemmMlpFunctionNode:
             cal_weight_fn(input_x_t_fp8, input_x_t_scale, do1_t_fp8, do1_t_scale, expert_w1)
 
     @paddle.no_grad()
-    def forward(self, hs_out, unzipped_probs, tokens_per_expert, origin_token_per_experts, output=None):
-        self.origin_token_per_experts = origin_token_per_experts
+    def forward(self, hs_out, unzipped_probs, tokens_per_expert, m_indices=None):
+        # check subbatch
+        if self.fwd_subbatch:
+            assert m_indices is not None
         # deal 0 size
         dtype = paddle.bfloat16
         if hs_out is None:
@@ -1092,7 +1090,6 @@ class FP8GroupGemmMlpFunctionNode:
 
         if shape[0] == 0:
             o3 = paddle.zeros(shape, dtype=dtype)
-            self.unzipped_probs = unzipped_probs.unsqueeze(-1)
             return o3
 
         # get w1/w2
@@ -1102,7 +1099,7 @@ class FP8GroupGemmMlpFunctionNode:
         num_expert = len(expert_w1)
 
         # o1
-        o1 = self.fwd_gate_up(hs_out, expert_w1, num_expert, tokens_per_expert)
+        o1 = self.fwd_gate_up(hs_out, expert_w1, num_expert, tokens_per_expert, m_indices)
         if not self.recompute_fwd_gate_up:
             self.o1 = o1
             clear_o1 = False
@@ -1110,43 +1107,62 @@ class FP8GroupGemmMlpFunctionNode:
             clear_o1 = True
 
         # o3
-        o3, unzipped_probs = self.fwd_down(o1, unzipped_probs, expert_w2, num_expert, clear_o1=clear_o1)
+        o3 = self.fwd_down(o1, unzipped_probs, expert_w2, num_expert, clear_o1=clear_o1, m_indices=m_indices)
 
         # save for bwd
-        self.unzipped_probs = unzipped_probs
         return o3
 
     @paddle.no_grad()
-    def backward(self, out_grad):
+    def backward(
+        self,
+        out_grad,
+        unzipped_probs,
+        input_fp8_slice=None,
+        input_scale_slice=None,
+        tokens_per_expert=None,
+        m_indices=None,
+        reset_status=False,
+    ):
+        # check subbatch
+        if self.bwd_subbatch:
+            assert m_indices is not None and input_fp8_slice is not None and input_scale_slice is not None
         # deal 0 size
         dtype = paddle.bfloat16
         shape = out_grad[0].shape if isinstance(out_grad, tuple) else out_grad.shape
         if shape[0] == 0:
-            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(self.unzipped_probs, dtype=dtype)
+            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(unzipped_probs, dtype=dtype)
 
         # recompute expert_w2 and expert_w1
         expert_w1 = [x.w1 for x in self.experts if x is not None]
         expert_w2 = [x.w2 for x in self.experts if x is not None]
 
         if self.recompute_fwd_gate_up:
-            o1 = self.fwd_gate_up(None, expert_w1, len(expert_w1), self.tokens_per_expert)
+            inp = (
+                None if input_fp8_slice is None and input_scale_slice is None else (input_fp8_slice, input_scale_slice)
+            )
+            o1 = self.fwd_gate_up(inp, expert_w1, len(expert_w1), tokens_per_expert, m_indices=m_indices)
         else:
             o1 = self.o1
 
         # do2
-        do1, o2_s, probs_grad = self.bwd_dowm_input(expert_w2, out_grad, o1, inplace_swiglu_prob=True)
+        do1, o2_s, probs_grad = self.bwd_dowm_input(
+            expert_w2, out_grad, o1, unzipped_probs=unzipped_probs, m_indices=m_indices
+        )
         del o1
         self.o1 = None
-        self.unzipped_probs = None
 
         # dw1
-        self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
-        self.input_fp8 = None
-        self.input_scale = None
-        self.input = None
+        self.bwd_gate_up_weight(do1, None, expert_w1, input_fp8_slice, input_scale_slice, clear_input=reset_status)
+
+        if reset_status:
+            self.input_fp8 = None
+            self.input_scale = None
+            self.input = None
 
         # dx
-        dx = self.bwd_gate_up_input(do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad)
+        dx = self.bwd_gate_up_input(
+            do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad, m_indices=m_indices
+        )
         del do1
 
         # dw2
@@ -1160,42 +1176,53 @@ class FP8GroupGemmMlpFunctionNode:
         else:
             self.bwd_down_weight(out_grad, o2_s, expert_w2)
 
-        self.reset_statue()
+        if reset_status:
+            self.reset_statue()
         return dx, probs_grad
 
     @paddle.no_grad()
-    def backward_dx(self, out_grad):
+    def backward_dx(self, out_grad, unzipped_probs, input_fp8_slice=None, input_scale_slice=None, m_indices=None):
+        if self.bwd_subbatch:
+            assert m_indices is not None and input_fp8_slice is not None and input_scale_slice is not None
         # deal 0 size
         dtype = paddle.bfloat16
         shape = out_grad[0].shape if isinstance(out_grad, tuple) else out_grad.shape
         if shape[0] == 0:
-            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(self.unzipped_probs, dtype=dtype)
+            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(unzipped_probs, dtype=dtype)
 
         # recompute expert_w2 and expert_w1
         expert_w1 = [x.w1 for x in self.experts if x is not None]
         expert_w2 = [x.w2 for x in self.experts if x is not None]
 
         if self.recompute_fwd_gate_up:
-            o1 = self.fwd_gate_up(None, expert_w1, len(expert_w1), self.tokens_per_expert)
+            inp = (
+                None if input_fp8_slice is None and input_scale_slice is None else (input_fp8_slice, input_scale_slice)
+            )
+            o1 = self.fwd_gate_up(inp, expert_w1, len(expert_w1), self.tokens_per_expert, m_indices=m_indices)
         else:
             o1 = self.o1
 
         # do2
-        do1, o2_s, probs_grad = self.bwd_dowm_input(expert_w2, out_grad, o1, inplace_swiglu_prob=True)
+        do1, o2_s, probs_grad = self.bwd_dowm_input(
+            expert_w2, out_grad, o1, unzipped_probs=unzipped_probs, m_indices=m_indices
+        )
         del o1
         self.o1 = None
 
-        self.do1 = do1
-        self.o2_s = o2_s
+        self.all_do1_list.append(do1)
+        self.all_o2_s_list.append(o2_s)
 
-        self.out_grad = out_grad
+        if self.all_unzipped_grad is None:
+            self.out_grad = out_grad
 
         # clear status for save memory
         self.unzipped_probs = None
         self.input = None
 
         # dx
-        dx = self.bwd_gate_up_input(do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad)
+        dx = self.bwd_gate_up_input(
+            do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad, m_indices=m_indices
+        )
 
         self.m_indices = None
 
@@ -1210,24 +1237,27 @@ class FP8GroupGemmMlpFunctionNode:
         expert_w1 = [x.w1 for x in self.experts if x is not None]
         expert_w2 = [x.w2 for x in self.experts if x is not None]
 
+        do1 = paddle.concat(self.all_do1_list, axis=0) if len(self.all_do1_list) > 1 else self.all_do1_list[0]
+        o2_s = paddle.concat(self.all_o2_s_list, axis=0) if len(self.all_o2_s_list) > 1 else self.all_o2_s_list[0]
+
         # dw1
-        self.bwd_gate_up_weight(self.do1, None, expert_w1, clear_input=True)
+        self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
         self.input_fp8 = None
         self.input_scale = None
         self.input = None
-        self.do1 = None
+        self.all_do1_list = None
+
+        out_grad = self.out_grad if self.all_unzipped_grad is None else self.all_unzipped_grad
 
         # dw2
-        if isinstance(self.out_grad, tuple):
+        if isinstance(out_grad, tuple):
             do3_fp8, do3_scale = self.fused_transpose_split_quant(
-                self.out_grad[0], self.out_grad[1], self.tokens_per_expert, True
+                out_grad[0], out_grad[1], self.tokens_per_expert, True
             )
-            self.out_grad = None
-            self.bwd_down_weight((do3_fp8, do3_scale), self.o2_s, expert_w2)
-        else:
-            self.bwd_down_weight(self.out_grad, self.o2_s, expert_w2)
 
-        self.o2_s = None
+            self.bwd_down_weight((do3_fp8, do3_scale), o2_s, expert_w2)
+        else:
+            self.bwd_down_weight(out_grad, o2_s, expert_w2)
 
         self.reset_statue()
         return

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -49,6 +49,10 @@ __all__ = [
 ]
 
 
+def extract_first_if_tuple(x):
+    return x[0] if isinstance(x, tuple) else x
+
+
 def _get_fp8_weight_and_scale(weight, stacked=False, transpose=False):
     """_get_fp8_weight_and_scale"""
     if stacked:
@@ -1047,9 +1051,15 @@ class FP8GroupGemmMlpFunctionNode:
             input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(input_x, None, tokens_per_expert, True)
 
         if clear_input:
-            self.input = None
-            self.input_fp8 = None
-            self.input_scale = None
+            if self.input_fp8 is not None:
+                self.input_fp8._clear_to_zero_allocation()
+                self.input_fp8 = None
+            if self.input_scale is not None:
+                self.input_scale._clear_to_zero_allocation()
+                self.input_scale = None
+            if self.input is not None:
+                self.input._clear_to_zero_allocation()
+                self.input = None
 
         do1_t_fp8, do1_t_scale = self.fused_transpose_split_quant(do1, None, tokens_per_expert, True)
 
@@ -1140,7 +1150,7 @@ class FP8GroupGemmMlpFunctionNode:
         dtype = paddle.bfloat16
         shape = out_grad[0].shape if isinstance(out_grad, tuple) else out_grad.shape
         if shape[0] == 0:
-            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(unzipped_probs, dtype=dtype)
+            return paddle.zeros_like(extract_first_if_tuple(out_grad), dtype=dtype), paddle.zeros_like(unzipped_probs)
 
         # recompute expert_w2 and expert_w1
         expert_w1 = [x.w1 for x in self.experts if x is not None]
@@ -1157,6 +1167,8 @@ class FP8GroupGemmMlpFunctionNode:
             expert_w2, out_grad, o1, tokens_per_expert, unzipped_probs=unzipped_probs, m_indices=m_indices
         )
         del o1
+        if self.o1 is not None:
+            self.o1._clear_to_zero_allocation()
         self.o1 = None
 
         # dw1
@@ -1171,9 +1183,15 @@ class FP8GroupGemmMlpFunctionNode:
         )
 
         if reset_status:
-            self.input_fp8 = None
-            self.input_scale = None
-            self.input = None
+            if self.input_fp8 is not None:
+                self.input_fp8._clear_to_zero_allocation()
+                self.input_fp8 = None
+            if self.input_scale is not None:
+                self.input_scale._clear_to_zero_allocation()
+                self.input_scale = None
+            if self.input is not None:
+                self.input._clear_to_zero_allocation()
+                self.input = None
 
         # dx
         dx = self.bwd_gate_up_input(

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -781,7 +781,6 @@ class FP8GroupGemmMlpFunctionNode:
         self.experts = custom_map.experts
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.is_split_group_gemm = is_split_group_gemm
-        self.tokens_per_expert = None
         self.m_indices = None
         self.input = None
         self.input_fp8 = None
@@ -790,16 +789,11 @@ class FP8GroupGemmMlpFunctionNode:
         self.all_unzipped_grad = None
         self.fwd_subbatch = None
         self.bwd_subbatch = None
-        self.all_do1_list = []
-        self.all_o2_s_list = []
 
     def reset_statue(self):
-        self.tokens_per_expert = None
         self.m_indices = None
         self.fwd_subbatch = None
         self.bwd_subbatch = None
-        self.all_do1_list = None
-        self.all_o2_s_list = None
         self.clear_activation_tensors()
 
     def clear_activation_tensors(self):
@@ -856,7 +850,7 @@ class FP8GroupGemmMlpFunctionNode:
                     num_sms=118,
                 )
 
-        if not self.fwd_subbatch:
+        if m_indices is None:
             self.input_fp8 = x_fp8
             self.input_scale = x_scale
         return o1
@@ -865,7 +859,9 @@ class FP8GroupGemmMlpFunctionNode:
         o2 = swiglu(o1)
         return o2
 
-    def fwd_down(self, o1, unzipped_probs, expert_w2, num_expert, m_indices=None, o3=None, clear_o1=False):
+    def fwd_down(
+        self, o1, unzipped_probs, expert_w2, num_expert, tokens_per_expert, m_indices=None, o3=None, clear_o1=False
+    ):
         """
         o3 = o2 * w2
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
@@ -894,7 +890,7 @@ class FP8GroupGemmMlpFunctionNode:
             o3 = paddle.empty(o3_shape, dtype=o1.dtype)
         if numpy.prod(o2_fp8.shape) != 0:
             if self.is_split_group_gemm:
-                split_group_gemm(o2_fp8, o2_scale, w2_quant, w2_scale, self.tokens_per_expert, o3)
+                split_group_gemm(o2_fp8, o2_scale, w2_quant, w2_scale, tokens_per_expert, o3)
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
                     (o2_fp8, o2_scale),
@@ -906,7 +902,7 @@ class FP8GroupGemmMlpFunctionNode:
 
         return o3
 
-    def bwd_dowm_input(self, expert_w2, unzipped_grad, o1, m_indices=None, unzipped_probs=None):
+    def bwd_dowm_input(self, expert_w2, unzipped_grad, o1, tokens_per_expert, m_indices=None, unzipped_probs=None):
         """
         do2 = do3 * w2_t
         [m_sum, n] = [m_sum, k] * [num_groups, k, n]
@@ -930,7 +926,7 @@ class FP8GroupGemmMlpFunctionNode:
         if numpy.prod(unzipped_grad_fp8.shape) != 0:
             if self.is_split_group_gemm:
                 split_group_gemm(
-                    unzipped_grad_fp8, unzipped_grad_scale, bw_w2_quant, bw_w2_scale, self.tokens_per_expert, do2_s
+                    unzipped_grad_fp8, unzipped_grad_scale, bw_w2_quant, bw_w2_scale, tokens_per_expert, do2_s
                 )
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
@@ -950,7 +946,7 @@ class FP8GroupGemmMlpFunctionNode:
         do1, _ = paddle._C_ops.swiglu_grad(o1, None, do2)
         return do1
 
-    def bwd_gate_up_input(self, do1, expert_w1, m_indices=None, dx=None):
+    def bwd_gate_up_input(self, do1, expert_w1, tokens_per_expert, m_indices=None, dx=None):
         """
         dx = do1 * w1_t
         [m_sum, k] = [m_sum, n] * [num_groups, n, k]
@@ -973,7 +969,7 @@ class FP8GroupGemmMlpFunctionNode:
             assert dx.shape == dx_shape, f"{dx.shape} vs {dx_shape}"
         if numpy.prod(do1_fp8.shape) != 0:
             if self.is_split_group_gemm:
-                split_group_gemm(do1_fp8, do1_scale, bw_w1_quant, bw_w1_scale, self.tokens_per_expert, dx)
+                split_group_gemm(do1_fp8, do1_scale, bw_w1_quant, bw_w1_scale, tokens_per_expert, dx)
             else:
                 deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
                     (do1_fp8, do1_scale),
@@ -991,7 +987,7 @@ class FP8GroupGemmMlpFunctionNode:
         )
         return out, scale
 
-    def bwd_down_weight(self, do3, o2, expert_w2):
+    def bwd_down_weight(self, do3, o2, expert_w2, tokens_per_expert):
         """
         dw2 = do2_t * do3
         [n, k] = [n, m_sum] * [m_sum, k] (m_sum = sum(tokens_per_expert))
@@ -999,12 +995,12 @@ class FP8GroupGemmMlpFunctionNode:
         if isinstance(o2, tuple):
             o2_t_fp8, o2_t_scale = o2
         else:
-            o2_t_fp8, o2_t_scale = self.fused_transpose_split_quant(o2, None, self.tokens_per_expert, True)
+            o2_t_fp8, o2_t_scale = self.fused_transpose_split_quant(o2, None, tokens_per_expert, True)
 
         if isinstance(do3, tuple):
             do3_t_fp8, do3_t_scale = do3
         else:
-            do3_t_fp8, do3_t_scale = self.fused_transpose_split_quant(do3, None, self.tokens_per_expert, True)
+            do3_t_fp8, do3_t_scale = self.fused_transpose_split_quant(do3, None, tokens_per_expert, True)
 
         def cal_weight_fn(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, expert_w2):
             with paddle.no_grad():
@@ -1026,29 +1022,32 @@ class FP8GroupGemmMlpFunctionNode:
             cal_weight_fn(o2_t_fp8, o2_t_scale, do3_t_fp8, do3_t_scale, expert_w2)
 
     def bwd_gate_up_weight(
-        self, do1, input_x, expert_w1, input_fp8_slice=None, input_scale_slice=None, clear_input=False
+        self,
+        do1,
+        input_x,
+        expert_w1,
+        tokens_per_expert,
+        input_fp8_slice=None,
+        input_scale_slice=None,
+        clear_input=False,
     ):
         """
         dw1 = dx_t * do1
         [k, n] = [k, m_sum] * [m_sum, n] (m_sum = sum(tokens_per_expert))
         """
         if input_x is None:
-            inp = (self.input_fp8, self.input_scale) if self.is_subbatch else (input_fp8_slice, input_scale_slice)
-            input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(
-                inp[0], inp[1], self.tokens_per_expert, True
-            )
+            inp = (input_fp8_slice, input_scale_slice) if self.bwd_subbatch else (self.input_fp8, self.input_scale)
+            input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(inp[0], inp[1], tokens_per_expert, True)
 
         else:
-            input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(
-                input_x, None, self.tokens_per_expert, True
-            )
+            input_x_t_fp8, input_x_t_scale = self.fused_transpose_split_quant(input_x, None, tokens_per_expert, True)
 
         if clear_input:
             self.input = None
             self.input_fp8 = None
             self.input_scale = None
 
-        do1_t_fp8, do1_t_scale = self.fused_transpose_split_quant(do1, None, self.tokens_per_expert, True)
+        do1_t_fp8, do1_t_scale = self.fused_transpose_split_quant(do1, None, tokens_per_expert, True)
 
         def cal_weight_fn(input_x_t_fp8, input_x_t_scale, do1_t_fp8, do1_t_scale, expert_w1):
             with paddle.no_grad():
@@ -1107,7 +1106,9 @@ class FP8GroupGemmMlpFunctionNode:
             clear_o1 = True
 
         # o3
-        o3 = self.fwd_down(o1, unzipped_probs, expert_w2, num_expert, clear_o1=clear_o1, m_indices=m_indices)
+        o3 = self.fwd_down(
+            o1, unzipped_probs, expert_w2, num_expert, tokens_per_expert, clear_o1=clear_o1, m_indices=m_indices
+        )
 
         # save for bwd
         return o3
@@ -1117,15 +1118,20 @@ class FP8GroupGemmMlpFunctionNode:
         self,
         out_grad,
         unzipped_probs,
+        tokens_per_expert,
         input_fp8_slice=None,
         input_scale_slice=None,
-        tokens_per_expert=None,
         m_indices=None,
         reset_status=False,
     ):
         # check subbatch
         if self.bwd_subbatch:
-            assert m_indices is not None and input_fp8_slice is not None and input_scale_slice is not None
+            assert (
+                m_indices is not None
+                and input_fp8_slice is not None
+                and input_scale_slice is not None
+                and tokens_per_expert is not None
+            )
         # deal 0 size
         dtype = paddle.bfloat16
         shape = out_grad[0].shape if isinstance(out_grad, tuple) else out_grad.shape
@@ -1137,22 +1143,28 @@ class FP8GroupGemmMlpFunctionNode:
         expert_w2 = [x.w2 for x in self.experts if x is not None]
 
         if self.recompute_fwd_gate_up:
-            inp = (
-                None if input_fp8_slice is None and input_scale_slice is None else (input_fp8_slice, input_scale_slice)
-            )
+            inp = None if not self.bwd_subbatch else (input_fp8_slice, input_scale_slice)
             o1 = self.fwd_gate_up(inp, expert_w1, len(expert_w1), tokens_per_expert, m_indices=m_indices)
         else:
             o1 = self.o1
 
         # do2
         do1, o2_s, probs_grad = self.bwd_dowm_input(
-            expert_w2, out_grad, o1, unzipped_probs=unzipped_probs, m_indices=m_indices
+            expert_w2, out_grad, o1, tokens_per_expert, unzipped_probs=unzipped_probs, m_indices=m_indices
         )
         del o1
         self.o1 = None
 
         # dw1
-        self.bwd_gate_up_weight(do1, None, expert_w1, input_fp8_slice, input_scale_slice, clear_input=reset_status)
+        self.bwd_gate_up_weight(
+            do1,
+            None,
+            expert_w1,
+            tokens_per_expert,
+            input_fp8_slice=input_fp8_slice,
+            input_scale_slice=input_scale_slice,
+            clear_input=reset_status,
+        )
 
         if reset_status:
             self.input_fp8 = None
@@ -1161,103 +1173,23 @@ class FP8GroupGemmMlpFunctionNode:
 
         # dx
         dx = self.bwd_gate_up_input(
-            do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad, m_indices=m_indices
+            do1,
+            expert_w1,
+            tokens_per_expert,
+            dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad,
+            m_indices=m_indices,
         )
         del do1
 
         # dw2
         if isinstance(out_grad, tuple):
-            do3_fp8, do3_scale = self.fused_transpose_split_quant(
-                out_grad[0], out_grad[1], self.tokens_per_expert, True
-            )
+            do3_fp8, do3_scale = self.fused_transpose_split_quant(out_grad[0], out_grad[1], tokens_per_expert, True)
             out_grad[0]._clear_to_zero_allocation()
             out_grad[1]._clear_to_zero_allocation()
-            self.bwd_down_weight((do3_fp8, do3_scale), o2_s, expert_w2)
+            self.bwd_down_weight((do3_fp8, do3_scale), o2_s, expert_w2, tokens_per_expert)
         else:
-            self.bwd_down_weight(out_grad, o2_s, expert_w2)
+            self.bwd_down_weight(out_grad, o2_s, expert_w2, tokens_per_expert)
 
         if reset_status:
             self.reset_statue()
         return dx, probs_grad
-
-    @paddle.no_grad()
-    def backward_dx(self, out_grad, unzipped_probs, input_fp8_slice=None, input_scale_slice=None, m_indices=None):
-        if self.bwd_subbatch:
-            assert m_indices is not None and input_fp8_slice is not None and input_scale_slice is not None
-        # deal 0 size
-        dtype = paddle.bfloat16
-        shape = out_grad[0].shape if isinstance(out_grad, tuple) else out_grad.shape
-        if shape[0] == 0:
-            return paddle.zeros_like(out_grad, dtype=dtype), paddle.zeros_like(unzipped_probs, dtype=dtype)
-
-        # recompute expert_w2 and expert_w1
-        expert_w1 = [x.w1 for x in self.experts if x is not None]
-        expert_w2 = [x.w2 for x in self.experts if x is not None]
-
-        if self.recompute_fwd_gate_up:
-            inp = (
-                None if input_fp8_slice is None and input_scale_slice is None else (input_fp8_slice, input_scale_slice)
-            )
-            o1 = self.fwd_gate_up(inp, expert_w1, len(expert_w1), self.tokens_per_expert, m_indices=m_indices)
-        else:
-            o1 = self.o1
-
-        # do2
-        do1, o2_s, probs_grad = self.bwd_dowm_input(
-            expert_w2, out_grad, o1, unzipped_probs=unzipped_probs, m_indices=m_indices
-        )
-        del o1
-        self.o1 = None
-
-        self.all_do1_list.append(do1)
-        self.all_o2_s_list.append(o2_s)
-
-        if self.all_unzipped_grad is None:
-            self.out_grad = out_grad
-
-        # clear status for save memory
-        self.unzipped_probs = None
-        self.input = None
-
-        # dx
-        dx = self.bwd_gate_up_input(
-            do1, expert_w1, dx=out_grad[0] if isinstance(out_grad, tuple) else out_grad, m_indices=m_indices
-        )
-
-        self.m_indices = None
-
-        return dx, probs_grad
-
-    @paddle.no_grad()
-    def backward_dw(self):
-        # deal 0 size
-        if self.input_fp8 is None or self.input_fp8.shape[0] == 0:
-            return
-        # recompute expert_w2 and expert_w1
-        expert_w1 = [x.w1 for x in self.experts if x is not None]
-        expert_w2 = [x.w2 for x in self.experts if x is not None]
-
-        do1 = paddle.concat(self.all_do1_list, axis=0) if len(self.all_do1_list) > 1 else self.all_do1_list[0]
-        o2_s = paddle.concat(self.all_o2_s_list, axis=0) if len(self.all_o2_s_list) > 1 else self.all_o2_s_list[0]
-
-        # dw1
-        self.bwd_gate_up_weight(do1, None, expert_w1, clear_input=True)
-        self.input_fp8 = None
-        self.input_scale = None
-        self.input = None
-        self.all_do1_list = None
-
-        out_grad = self.out_grad if self.all_unzipped_grad is None else self.all_unzipped_grad
-
-        # dw2
-        if isinstance(out_grad, tuple):
-            do3_fp8, do3_scale = self.fused_transpose_split_quant(
-                out_grad[0], out_grad[1], self.tokens_per_expert, True
-            )
-
-            self.bwd_down_weight((do3_fp8, do3_scale), o2_s, expert_w2)
-        else:
-            self.bwd_down_weight(out_grad, o2_s, expert_w2)
-
-        self.reset_statue()
-        return

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -29,7 +29,7 @@ from ..utils.log import logger
 from .fp8_utils import FP8GroupGemmMlpFunctionNode
 from .fused_a2a import CombineNode, DispatchNode, get_buffer, get_hidden_bytes
 from .moe_gate import PretrainedMoEGate
-from .moe_utils import UnZipNode, ZipNode
+from .moe_utils import UnZipNode, ZipNode, tokens_zip_unique_add_with_subbatch
 from .token_dispatcher import MoEFlexTokenDispatcher, PreDispatchNode
 
 try:
@@ -42,6 +42,9 @@ DSV3_USE_FP8_GEMM = os.getenv("DSV3_USE_FP8_GEMM", "False").lower() == "true"
 DSV3_USE_FP8_GROUP_GEMM = os.getenv("DSV3_USE_FP8_GROUP_GEMM", "False").lower() == "true"
 
 DSV3_USE_FP8_DISPATCH = os.getenv("DSV3_USE_FP8_DISPATCH", "False").lower() == "true"
+
+
+import TokenDispatcherUtils as TDU
 
 
 def record_stream_for_multi_input(x):
@@ -57,6 +60,10 @@ def stop_gradient_for_multi_input(x):
         x[0].stop_gradient = False
     else:
         x.stop_gradient = False
+
+
+def extract_first_if_tuple(x):
+    return x[0] if isinstance(x, tuple) else x
 
 
 def dispatching(x, dispatch_mask, scatter_index, num_experts, capacity):
@@ -695,7 +702,16 @@ class FusionMlpNode:
     The FusedMoeLayer class includes operations for unzipping, expert computation, and zipping.
     """
 
-    def __init__(self, custom_map, max_topk, recompute_fwd_gate_up=False, is_split_group_gemm=True):
+    def __init__(
+        self,
+        custom_map,
+        max_topk,
+        recompute_fwd_gate_up=False,
+        is_split_group_gemm=True,
+        mlp_fwd_subbatch_rows=0,
+        mlp_bwd_subbatch_rows=0,
+        output_subbatch_rows=0,
+    ):
         self.token_dispatcher = custom_map.token_dispatcher
         self.experts = custom_map.experts
         self.unzip_node = UnZipNode()
@@ -715,6 +731,9 @@ class FusionMlpNode:
         self.dispatched_probs = None
         self.tokens_per_expert = None
         self.router_topk = max_topk
+        self.mlp_fwd_subbatch_rows = mlp_fwd_subbatch_rows
+        self.mlp_bwd_subbatch_rows = mlp_bwd_subbatch_rows
+        self.output_subbatch_rows = output_subbatch_rows
 
     def set_recompute_fwd_gate_up(self, recompute_fwd_gate_up):
         self.experts_group_gemm_node.recompute_fwd_gate_up = recompute_fwd_gate_up
@@ -743,6 +762,125 @@ class FusionMlpNode:
         self.experts_group_gemm_node.reset_statue()
         self.experts_group_gemm_node = None
 
+    def merge_subbatch_cast(self, x, dtype):
+        if isinstance(x, (list, tuple)):
+            if len(x) == 1:
+                x = x[0]
+                return x.cast(dtype) if x.dtype != dtype else x
+            else:
+                return TDU.merge_subbatch_cast(x, dtype)
+        else:
+            return x.cast(dtype) if x.dtype != dtype else x
+
+    def prepare_env_subbatch(self, unzipped_tokens=None, unzipped_tokens_scale=None, is_fwd=True):
+        if is_fwd:
+            assert unzipped_tokens is not None and unzipped_tokens_scale is not None
+            self.experts_group_gemm_node.input_fp8 = unzipped_tokens
+            self.experts_group_gemm_node.input_scale = unzipped_tokens_scale
+            self.m_indices = self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
+            self.experts_group_gemm_node.fwd_subbatch = True
+        else:
+            self.m_indices = (
+                self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
+                if not hasattr(self, "m_indices")
+                else self.m_indices
+            )
+            self.experts_group_gemm_node.bwd_subbatch = True
+
+    def gemm_forward_subbatch(
+        self,
+        unzipped_tokens,
+        unzipped_tokens_scale,
+        unzipped_probs,
+        map_unzipped_indices_to_zipped,
+        output,
+        total_zipped_tokens,
+        padding_token_per_experts,
+        start_idx=None,
+        end_idx=None,
+        output_subbatch_rows=None,
+    ):
+        if start_idx is None or end_idx is None:
+            start_idx = 0
+            end_idx = unzipped_tokens.shape[0]
+        start_idx = max(0, start_idx)
+        end_idx = min(unzipped_tokens.shape[0], end_idx)
+
+        expert_out = self.experts_group_gemm_node.forward(
+            (unzipped_tokens[start_idx:end_idx], unzipped_tokens_scale[start_idx:end_idx]),
+            unzipped_probs[start_idx:end_idx],
+            padding_token_per_experts,
+            m_indices=self.m_indices[start_idx:end_idx],
+        )
+
+        output = tokens_zip_unique_add_with_subbatch(
+            output,
+            expert_out,
+            map_unzipped_indices_to_zipped[start_idx:end_idx],
+            total_zipped_tokens,
+            subbatch_rows=output_subbatch_rows,
+        )
+        return output
+
+    def gemm_backward_subbatch(
+        self,
+        unzipped_grad,
+        map_unzipped_indices_to_zipped,
+        total_zipped_tokens,
+        output,
+        start_idx=None,
+        end_idx=None,
+        output_subbatch_rows=None,
+        reset_status=False,
+    ):
+        def split_list_prefix(l, start, end):
+            prefix_sum = [0] * (len(l) + 1)
+            for i in range(len(l)):
+                prefix_sum[i + 1] = prefix_sum[i] + l[i]
+
+            result = []
+            for i in range(len(l)):
+                segment_start = prefix_sum[i]
+                segment_end = prefix_sum[i + 1]
+                overlap_start = max(start, segment_start)
+                overlap_end = min(end, segment_end)
+                selected = max(0, overlap_end - overlap_start)
+                result.append(selected)
+            return result
+
+        if start_idx is None or end_idx is None:
+            start_idx = 0
+            end_idx = extract_first_if_tuple(unzipped_grad).shape[0]
+
+        start_idx = max(0, start_idx)
+        end_idx = min(extract_first_if_tuple(unzipped_grad).shape[0], end_idx)
+
+        # m_indices = self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
+        unzipped_inp_grad = (
+            (unzipped_grad[0][start_idx:end_idx], unzipped_grad[1][start_idx:end_idx])
+            if isinstance(unzipped_grad, tuple)
+            else unzipped_grad[start_idx:end_idx]
+        )
+        unzipped_grad, unzipped_probs_grad = self.experts_group_gemm_node.backward(
+            unzipped_inp_grad,
+            self.unzipped_probs[start_idx:end_idx],
+            input_fp8_slice=self.experts_group_gemm_node.input_fp8[start_idx:end_idx],
+            input_scale_slice=self.experts_group_gemm_node.input_scale[start_idx:end_idx],
+            tokens_per_expert=split_list_prefix(self.tokens_per_expert, start_idx, end_idx),
+            m_indices=self.m_indices[start_idx:end_idx],
+            reset_status=reset_status,
+        )
+
+        output = tokens_zip_unique_add_with_subbatch(
+            output,
+            unzipped_grad,
+            map_unzipped_indices_to_zipped[start_idx:end_idx],
+            zipped_rows=total_zipped_tokens,
+            subbatch_rows=output_subbatch_rows,
+        )
+
+        return output, unzipped_probs_grad
+
     @paddle.no_grad()
     def forward(self, hs_2d_dispatched, dispatched_indices, dispatched_probs):
         """
@@ -758,6 +896,7 @@ class FusionMlpNode:
 
         """
         self.tokens_per_expert = self.token_dispatcher._comm_manager.tokens_per_expert
+        self.dispatched_probs = dispatched_probs
 
         num_experts = len(self.tokens_per_expert)
         # 1 unzip
@@ -780,10 +919,14 @@ class FusionMlpNode:
             dispatched_indices._record_stream()
             dispatched_probs._record_stream()
 
+            total_unzipped_tokens = extract_first_if_tuple(unzipped_tokens).shape[0]
+            total_zipped_tokens = extract_first_if_tuple(hs_2d_dispatched).shape[0]
+            padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
+
             # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
             if self.recompute_fwd_gate_up == -1:
                 if (
-                    unzipped_tokens.shape[0]
+                    total_unzipped_tokens
                     > self.seq_length * self.num_experts_per_tok * self.adaptive_remained_O1_recompute_ratio
                 ):
                     # logger.debug(f"recompute_fwd_gate_up changed to True, Because the receives {unzipped_tokens.shape[0]} Tensors greater then {self.seq_length*self.num_experts_per_tok*self.adaptive_remained_O1_recompute_ratio}.")
@@ -792,13 +935,56 @@ class FusionMlpNode:
                     # logger.debug(f"recompute_fwd_gate_up changed to False, Because the receives {unzipped_tokens.shape[0]} Tensors less then {self.seq_length*self.num_experts_per_tok*self.adaptive_remained_O1_recompute_ratio}.")
                     self.set_recompute_fwd_gate_up(False)
 
+            self.unzipped_probs = unzipped_probs.unsqueeze(-1)
+
+            # if use_mlp_subbatch is enabled, then split the unzipped_tokens into subbatches
+            if self.mlp_fwd_subbatch_rows != 0 and total_unzipped_tokens > self.mlp_fwd_subbatch_rows * 2:
+                assert (
+                    self.experts_group_gemm_node.recompute_fwd_gate_up
+                ), "recompute_fwd_gate_up must be true when use_mlp_subbatch = True"
+                map_unzipped_indices_to_zipped = TDU.tokens_unzip_slice(
+                    extract_first_if_tuple(hs_2d_dispatched),
+                    zipped_expertwise_rowmap,
+                    len(self.tokens_per_expert),
+                    total_unzipped_tokens,
+                    0,
+                    total_unzipped_tokens + 1,
+                )
+                if isinstance(hs_2d_dispatched, tuple):
+                    hs_2d_dispatched[0]._clear_to_zero_allocation()
+                    hs_2d_dispatched[1]._clear_to_zero_allocation()
+                else:
+                    hs_2d_dispatched._clear_to_zero_allocation()
+
+                subbatch_rows = min(total_unzipped_tokens // num_experts, self.mlp_fwd_subbatch_rows)
+                nparts = (total_unzipped_tokens + subbatch_rows - 1) // subbatch_rows
+                output = paddle.empty([0, extract_first_if_tuple(hs_2d_dispatched).shape[-1]], dtype=paddle.float32)
+                self.prepare_env_subbatch(unzipped_tokens, unzipped_tokens_scale, True)
+                logger.info(
+                    f"Enable subbatch_forward!! total_zipped_tokens:{total_zipped_tokens}, total_unzipped_tokens:{total_unzipped_tokens}, nparts:{nparts}, subbatch_rows:{subbatch_rows}, output_sub_rows:{self.output_subbatch_rows}"
+                )
+                for i in range(nparts):
+                    start_idx = i * subbatch_rows
+                    end_idx = min(start_idx + subbatch_rows, total_unzipped_tokens)
+                    output = self.gemm_forward_subbatch(
+                        unzipped_tokens,
+                        unzipped_tokens_scale,
+                        unzipped_probs,
+                        map_unzipped_indices_to_zipped,
+                        output,
+                        total_zipped_tokens,
+                        padding_token_per_experts,
+                        start_idx=start_idx,
+                        end_idx=end_idx,
+                        output_subbatch_rows=self.output_subbatch_rows,
+                    )
+
+                output = self.merge_subbatch_cast(output, paddle.bfloat16)
+                return output
+
             # 2 experts
-            padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
             expert_out = self.experts_group_gemm_node.forward(
-                (unzipped_tokens, unzipped_tokens_scale),
-                unzipped_probs,
-                padding_token_per_experts,
-                self.tokens_per_expert,
+                (unzipped_tokens, unzipped_tokens_scale), unzipped_probs, padding_token_per_experts
             )
         else:
             (unzipped_tokens, zipped_expertwise_rowmap, unzipped_probs, _,) = self.unzip_node.forward(
@@ -826,10 +1012,15 @@ class FusionMlpNode:
             # 2 experts
             padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
             expert_out = self.experts_group_gemm_node.forward(
-                unzipped_tokens, unzipped_probs, padding_token_per_experts, self.tokens_per_expert
+                unzipped_tokens, unzipped_probs, padding_token_per_experts
             )
 
         # 3 zip
+        if isinstance(hs_2d_dispatched, tuple):
+            hs_2d_dispatched[0]._clear_to_zero_allocation()
+            hs_2d_dispatched[1]._clear_to_zero_allocation()
+        else:
+            hs_2d_dispatched._clear_to_zero_allocation()
         expert_out_tmp = expert_out.reshape([-1, expert_out.shape[-1]])
 
         expert_out_zipped = self.zip_node.forward(
@@ -837,13 +1028,10 @@ class FusionMlpNode:
             zipped_expertwise_rowmap,
             self.dispatched_indices,
             unzipped_probs,
-            total_zipped_tokens=hs_2d_dispatched.shape[0]
-            if not isinstance(hs_2d_dispatched, tuple)
-            else hs_2d_dispatched[0].shape[0],
+            total_zipped_tokens=total_zipped_tokens,
             num_experts=num_experts,
         )
 
-        self.dispatched_probs = dispatched_probs
         expert_out_zipped.stop_gradient = False
         return expert_out_zipped
 
@@ -872,12 +1060,69 @@ class FusionMlpNode:
         )
         record_stream_for_multi_input(hidden_states_out_grad)
 
+        total_zipped_tokens = extract_first_if_tuple(hidden_states_out_grad).shape[0]
+        total_unzipped_tokens = extract_first_if_tuple(unzipped_grad).shape[0]
+        hidden_states_size = extract_first_if_tuple(hidden_states_out_grad).shape[-1]
+
+        if self.mlp_bwd_subbatch_rows != 0 and total_unzipped_tokens > self.mlp_bwd_subbatch_rows * 2:
+            map_unzipped_indices_to_zipped = TDU.tokens_unzip_slice(
+                extract_first_if_tuple(hidden_states_out_grad),
+                self.unzip_node.zipped_expertwise_rowmap,
+                len(self.tokens_per_expert),
+                total_unzipped_tokens,
+                0,
+                total_unzipped_tokens + 1,
+            )
+            if isinstance(hidden_states_out_grad, tuple):
+                hidden_states_out_grad[0]._clear_to_zero_allocation()
+                hidden_states_out_grad[1]._clear_to_zero_allocation()
+            else:
+                hidden_states_out_grad._clear_to_zero_allocation()
+
+            subbatch_rows = min(total_unzipped_tokens // len(self.tokens_per_expert), self.mlp_bwd_subbatch_rows)
+            nparts = (total_unzipped_tokens + subbatch_rows - 1) // subbatch_rows
+            output = paddle.empty([0, hidden_states_size], dtype=paddle.float32)
+            probs_grad_list = []
+            self.prepare_env_subbatch(is_fwd=False)
+            logger.info(
+                f"Enable subbatch_backward!! total_zipped_tokens:{total_zipped_tokens}, total_unzipped_tokens:{total_unzipped_tokens}, nparts:{nparts}, subbatch_rows:{subbatch_rows}, output_sub_rows:{self.output_subbatch_rows}"
+            )
+            for i in range(nparts):
+                reset_status = True if i == nparts - 1 else False  # release saved status in the last part.
+                start_idx = i * subbatch_rows
+                end_idx = min(start_idx + subbatch_rows, total_unzipped_tokens)
+                output, probs_grad = self.gemm_backward_subbatch(
+                    unzipped_grad,
+                    map_unzipped_indices_to_zipped,
+                    total_zipped_tokens,
+                    output,
+                    start_idx=start_idx,
+                    end_idx=end_idx,
+                    output_subbatch_rows=self.output_subbatch_rows,
+                    reset_status=reset_status,
+                )
+                probs_grad_list.append(probs_grad)
+            hs_dispatched_grad = self.merge_subbatch_cast(output, paddle.bfloat16)
+            dispatched_probs_grad = TDU.tokens_zip_prob_seq_subbatch(
+                probs_grad_list, self.unzip_node.zipped_expertwise_rowmap, self.dispatched_indices, subbatch_rows
+            )
+            self.reset_statue()
+            return hs_dispatched_grad, dispatched_probs_grad
+
+        if isinstance(hidden_states_out_grad, tuple):
+            hidden_states_out_grad[0]._clear_to_zero_allocation()
+            hidden_states_out_grad[1]._clear_to_zero_allocation()
+        else:
+            hidden_states_out_grad._clear_to_zero_allocation()
+
         # expert_grad
-        expert_out, probs_grad = self.experts_group_gemm_node.backward(unzipped_grad)
+        expert_out, probs_grad = self.experts_group_gemm_node.backward(
+            unzipped_grad, self.unzipped_probs, tokens_per_expert=self.tokens_per_expert
+        )
 
         hs_dispatched_grad, dispatched_probs_grad = self.unzip_node.backward(
             expert_out,
-            hidden_states_out_grad,
+            total_zipped_tokens,
             probs_grad,
             self.dispatched_indices,
             num_experts=len(self.tokens_per_expert),
@@ -889,7 +1134,7 @@ class FusionMlpNode:
     @paddle.no_grad()
     def backward_dw(self):
         self.experts_group_gemm_node.backward_dw()
-        self.reset_statue(True)
+        self.reset_statue()
 
 
 class FusionMoeNode:
@@ -898,6 +1143,9 @@ class FusionMoeNode:
         custom_map,
         recompute_fwd_gate_up=False,
         is_split_group_gemm=True,
+        mlp_fwd_subbatch_rows=0,
+        mlp_bwd_subbatch_rows=0,
+        output_subbatch_rows=0,
         name="fusion_moe_node",
     ):
         self.token_dispatcher = custom_map.token_dispatcher
@@ -909,6 +1157,9 @@ class FusionMoeNode:
             self.moe_router_topk,
             recompute_fwd_gate_up=recompute_fwd_gate_up,
             is_split_group_gemm=is_split_group_gemm,
+            mlp_fwd_subbatch_rows=mlp_fwd_subbatch_rows,
+            mlp_bwd_subbatch_rows=mlp_bwd_subbatch_rows,
+            output_subbatch_rows=output_subbatch_rows,
         )
         self.combine_node = Fp8CombineNode(self.token_dispatcher)
         self.combine_quant_node = Fp8CombineQuantNode(self.token_dispatcher, custom_map.moe_group)

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -897,8 +897,9 @@ class FusionMlpNode:
         """
         self.tokens_per_expert = self.token_dispatcher._comm_manager.tokens_per_expert
         self.dispatched_probs = dispatched_probs
-
         num_experts = len(self.tokens_per_expert)
+        padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
+
         # 1 unzip
         self.dispatched_indices = dispatched_indices.to(paddle.int32)
         if DSV3_USE_FP8_DISPATCH:
@@ -921,7 +922,6 @@ class FusionMlpNode:
 
             total_unzipped_tokens = extract_first_if_tuple(unzipped_tokens).shape[0]
             total_zipped_tokens = extract_first_if_tuple(hs_2d_dispatched).shape[0]
-            padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
 
             # If adaptive O1 recompute is enabled, determine whether to enable recompute O1 based on the degree of imbalance
             if self.recompute_fwd_gate_up == -1:
@@ -945,7 +945,7 @@ class FusionMlpNode:
                 map_unzipped_indices_to_zipped = TDU.tokens_unzip_slice(
                     extract_first_if_tuple(hs_2d_dispatched),
                     zipped_expertwise_rowmap,
-                    len(self.tokens_per_expert),
+                    num_experts,
                     total_unzipped_tokens,
                     0,
                     total_unzipped_tokens + 1,
@@ -980,6 +980,7 @@ class FusionMlpNode:
                     )
 
                 output = self.merge_subbatch_cast(output, paddle.bfloat16)
+                output.stop_gradient = False
                 return output
 
             # 2 experts
@@ -1010,7 +1011,6 @@ class FusionMlpNode:
                     self.set_recompute_fwd_gate_up(False)
 
             # 2 experts
-            padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
             expert_out = self.experts_group_gemm_node.forward(
                 unzipped_tokens, unzipped_probs, padding_token_per_experts
             )
@@ -1063,12 +1063,14 @@ class FusionMlpNode:
         total_zipped_tokens = extract_first_if_tuple(hidden_states_out_grad).shape[0]
         total_unzipped_tokens = extract_first_if_tuple(unzipped_grad).shape[0]
         hidden_states_size = extract_first_if_tuple(hidden_states_out_grad).shape[-1]
+        num_experts = len(self.tokens_per_expert)
+        padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
 
         if self.mlp_bwd_subbatch_rows != 0 and total_unzipped_tokens > self.mlp_bwd_subbatch_rows * 2:
             map_unzipped_indices_to_zipped = TDU.tokens_unzip_slice(
                 extract_first_if_tuple(hidden_states_out_grad),
                 self.unzip_node.zipped_expertwise_rowmap,
-                len(self.tokens_per_expert),
+                num_experts,
                 total_unzipped_tokens,
                 0,
                 total_unzipped_tokens + 1,
@@ -1079,7 +1081,7 @@ class FusionMlpNode:
             else:
                 hidden_states_out_grad._clear_to_zero_allocation()
 
-            subbatch_rows = min(total_unzipped_tokens // len(self.tokens_per_expert), self.mlp_bwd_subbatch_rows)
+            subbatch_rows = min(total_unzipped_tokens // num_experts, self.mlp_bwd_subbatch_rows)
             nparts = (total_unzipped_tokens + subbatch_rows - 1) // subbatch_rows
             output = paddle.empty([0, hidden_states_size], dtype=paddle.float32)
             probs_grad_list = []
@@ -1117,7 +1119,7 @@ class FusionMlpNode:
 
         # expert_grad
         expert_out, probs_grad = self.experts_group_gemm_node.backward(
-            unzipped_grad, self.unzipped_probs, tokens_per_expert=self.tokens_per_expert
+            unzipped_grad, self.unzipped_probs, padding_token_per_experts
         )
 
         hs_dispatched_grad, dispatched_probs_grad = self.unzip_node.backward(
@@ -1125,16 +1127,11 @@ class FusionMlpNode:
             total_zipped_tokens,
             probs_grad,
             self.dispatched_indices,
-            num_experts=len(self.tokens_per_expert),
+            num_experts=num_experts,
         )
 
         self.reset_statue()
         return hs_dispatched_grad, dispatched_probs_grad
-
-    @paddle.no_grad()
-    def backward_dw(self):
-        self.experts_group_gemm_node.backward_dw()
-        self.reset_statue()
 
 
 class FusionMoeNode:
@@ -1207,10 +1204,6 @@ class FusionMoeNode:
         else:
             hs_bf16_grad, token_probs_grad = self.dispatch_node.backward(hs_dispatched_grad, dispatched_probs_grad)
             return hs_bf16_grad, None, token_probs_grad
-
-    @paddle.no_grad()
-    def backward_dw(self):
-        self.mlp_node.backward_dw()
 
 
 class FusionMoe(paddle.autograd.PyLayer):

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -32,6 +32,7 @@ from .moe_gate import PretrainedMoEGate
 from .moe_utils import (
     UnZipNode,
     ZipNode,
+    merge_subbatch_cast,
     offload,
     reload,
     tokens_zip_unique_add_with_subbatch,
@@ -766,16 +767,6 @@ class FusionMlpNode:
         self.experts_group_gemm_node.reset_statue()
         self.experts_group_gemm_node = None
 
-    def merge_subbatch_cast(self, x, dtype):
-        if isinstance(x, (list, tuple)):
-            if len(x) == 1:
-                x = x[0]
-                return x.cast(dtype) if x.dtype != dtype else x
-            else:
-                return TDU.merge_subbatch_cast(x, dtype)
-        else:
-            return x.cast(dtype) if x.dtype != dtype else x
-
     def prepare_env_subbatch(self, unzipped_tokens=None, unzipped_tokens_scale=None, is_fwd=True):
         if is_fwd:
             assert unzipped_tokens is not None and unzipped_tokens_scale is not None
@@ -986,7 +977,7 @@ class FusionMlpNode:
                         output_subbatch_rows=self.output_subbatch_rows,
                     )
 
-                output = self.merge_subbatch_cast(output, paddle.bfloat16)
+                output = merge_subbatch_cast(output, paddle.bfloat16)
                 output.stop_gradient = False
                 offload(self.experts_group_gemm_node.input_fp8)
                 offload(self.experts_group_gemm_node.input_scale)
@@ -1119,7 +1110,7 @@ class FusionMlpNode:
                 unzipped_grad[1]._clear_to_zero_allocation()
             else:
                 unzipped_grad._clear_to_zero_allocation()
-            hs_dispatched_grad = self.merge_subbatch_cast(output, paddle.bfloat16)
+            hs_dispatched_grad = merge_subbatch_cast(output, paddle.bfloat16)
             dispatched_probs_grad = TDU.tokens_zip_prob_seq_subbatch(
                 probs_grad_list, self.unzip_node.zipped_expertwise_rowmap, self.dispatched_indices, subbatch_rows
             )

--- a/paddlenlp/transformers/moe_layer.py
+++ b/paddlenlp/transformers/moe_layer.py
@@ -26,10 +26,16 @@ from paddle import Tensor, nn
 from paddle.distributed.communication.group import Group
 
 from ..utils.log import logger
-from .fp8_utils import FP8GroupGemmMlpFunctionNode
+from .fp8_utils import FP8GroupGemmMlpFunctionNode, extract_first_if_tuple
 from .fused_a2a import CombineNode, DispatchNode, get_buffer, get_hidden_bytes
 from .moe_gate import PretrainedMoEGate
-from .moe_utils import UnZipNode, ZipNode, tokens_zip_unique_add_with_subbatch
+from .moe_utils import (
+    UnZipNode,
+    ZipNode,
+    offload,
+    reload,
+    tokens_zip_unique_add_with_subbatch,
+)
 from .token_dispatcher import MoEFlexTokenDispatcher, PreDispatchNode
 
 try:
@@ -60,10 +66,6 @@ def stop_gradient_for_multi_input(x):
         x[0].stop_gradient = False
     else:
         x.stop_gradient = False
-
-
-def extract_first_if_tuple(x):
-    return x[0] if isinstance(x, tuple) else x
 
 
 def dispatching(x, dispatch_mask, scatter_index, num_experts, capacity):
@@ -730,6 +732,7 @@ class FusionMlpNode:
         self.dispatched_indices = None
         self.dispatched_probs = None
         self.tokens_per_expert = None
+        self.padding_token_per_experts = None
         self.router_topk = max_topk
         self.mlp_fwd_subbatch_rows = mlp_fwd_subbatch_rows
         self.mlp_bwd_subbatch_rows = mlp_bwd_subbatch_rows
@@ -752,6 +755,7 @@ class FusionMlpNode:
         self.dispatched_indices = None
         self.dispatched_probs = None
         self.tokens_per_expert = None
+        self.padding_token_per_experts = None
         self.router_topk = None
 
         del self.unzip_node
@@ -777,15 +781,17 @@ class FusionMlpNode:
             assert unzipped_tokens is not None and unzipped_tokens_scale is not None
             self.experts_group_gemm_node.input_fp8 = unzipped_tokens
             self.experts_group_gemm_node.input_scale = unzipped_tokens_scale
-            self.m_indices = self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
+            self.m_indices = self.experts_group_gemm_node.gen_m_indices(self.padding_token_per_experts)
             self.experts_group_gemm_node.fwd_subbatch = True
         else:
             self.m_indices = (
-                self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
+                self.experts_group_gemm_node.gen_m_indices(self.padding_token_per_experts)
                 if not hasattr(self, "m_indices")
                 else self.m_indices
             )
             self.experts_group_gemm_node.bwd_subbatch = True
+            reload(self.experts_group_gemm_node.input_fp8)
+            reload(self.experts_group_gemm_node.input_scale)
 
     def gemm_forward_subbatch(
         self,
@@ -828,6 +834,7 @@ class FusionMlpNode:
         map_unzipped_indices_to_zipped,
         total_zipped_tokens,
         output,
+        padding_token_per_experts,
         start_idx=None,
         end_idx=None,
         output_subbatch_rows=None,
@@ -857,17 +864,17 @@ class FusionMlpNode:
 
         # m_indices = self.experts_group_gemm_node.gen_m_indices(self.tokens_per_expert)
         unzipped_inp_grad = (
-            (unzipped_grad[0][start_idx:end_idx], unzipped_grad[1][start_idx:end_idx])
+            (unzipped_grad[0][start_idx:end_idx].contiguous(), unzipped_grad[1][start_idx:end_idx].contiguous())
             if isinstance(unzipped_grad, tuple)
-            else unzipped_grad[start_idx:end_idx]
+            else unzipped_grad[start_idx:end_idx].contiguous()
         )
         unzipped_grad, unzipped_probs_grad = self.experts_group_gemm_node.backward(
             unzipped_inp_grad,
-            self.unzipped_probs[start_idx:end_idx],
-            input_fp8_slice=self.experts_group_gemm_node.input_fp8[start_idx:end_idx],
-            input_scale_slice=self.experts_group_gemm_node.input_scale[start_idx:end_idx],
-            tokens_per_expert=split_list_prefix(self.tokens_per_expert, start_idx, end_idx),
-            m_indices=self.m_indices[start_idx:end_idx],
+            self.unzipped_probs[start_idx:end_idx].contiguous(),
+            input_fp8_slice=self.experts_group_gemm_node.input_fp8[start_idx:end_idx].contiguous(),
+            input_scale_slice=self.experts_group_gemm_node.input_scale[start_idx:end_idx].contiguous(),
+            tokens_per_expert=split_list_prefix(padding_token_per_experts, start_idx, end_idx),
+            m_indices=self.m_indices[start_idx:end_idx].contiguous(),
             reset_status=reset_status,
         )
 
@@ -899,7 +906,7 @@ class FusionMlpNode:
         self.dispatched_probs = dispatched_probs
         num_experts = len(self.tokens_per_expert)
         padding_token_per_experts = [(x + 127) // 128 * 128 for x in self.tokens_per_expert]
-
+        self.padding_token_per_experts = padding_token_per_experts
         # 1 unzip
         self.dispatched_indices = dispatched_indices.to(paddle.int32)
         if DSV3_USE_FP8_DISPATCH:
@@ -956,7 +963,7 @@ class FusionMlpNode:
                 else:
                     hs_2d_dispatched._clear_to_zero_allocation()
 
-                subbatch_rows = min(total_unzipped_tokens // num_experts, self.mlp_fwd_subbatch_rows)
+                subbatch_rows = min((total_unzipped_tokens // num_experts) // 128 * 128, self.mlp_fwd_subbatch_rows)
                 nparts = (total_unzipped_tokens + subbatch_rows - 1) // subbatch_rows
                 output = paddle.empty([0, extract_first_if_tuple(hs_2d_dispatched).shape[-1]], dtype=paddle.float32)
                 self.prepare_env_subbatch(unzipped_tokens, unzipped_tokens_scale, True)
@@ -981,6 +988,8 @@ class FusionMlpNode:
 
                 output = self.merge_subbatch_cast(output, paddle.bfloat16)
                 output.stop_gradient = False
+                offload(self.experts_group_gemm_node.input_fp8)
+                offload(self.experts_group_gemm_node.input_scale)
                 return output
 
             # 2 experts
@@ -1081,7 +1090,7 @@ class FusionMlpNode:
             else:
                 hidden_states_out_grad._clear_to_zero_allocation()
 
-            subbatch_rows = min(total_unzipped_tokens // num_experts, self.mlp_bwd_subbatch_rows)
+            subbatch_rows = min((total_unzipped_tokens // num_experts) // 128 * 128, self.mlp_bwd_subbatch_rows)
             nparts = (total_unzipped_tokens + subbatch_rows - 1) // subbatch_rows
             output = paddle.empty([0, hidden_states_size], dtype=paddle.float32)
             probs_grad_list = []
@@ -1098,12 +1107,18 @@ class FusionMlpNode:
                     map_unzipped_indices_to_zipped,
                     total_zipped_tokens,
                     output,
+                    padding_token_per_experts,
                     start_idx=start_idx,
                     end_idx=end_idx,
                     output_subbatch_rows=self.output_subbatch_rows,
                     reset_status=reset_status,
                 )
                 probs_grad_list.append(probs_grad)
+            if isinstance(unzipped_grad, tuple):
+                unzipped_grad[0]._clear_to_zero_allocation()
+                unzipped_grad[1]._clear_to_zero_allocation()
+            else:
+                unzipped_grad._clear_to_zero_allocation()
             hs_dispatched_grad = self.merge_subbatch_cast(output, paddle.bfloat16)
             dispatched_probs_grad = TDU.tokens_zip_prob_seq_subbatch(
                 probs_grad_list, self.unzip_node.zipped_expertwise_rowmap, self.dispatched_indices, subbatch_rows

--- a/paddlenlp/transformers/moe_utils.py
+++ b/paddlenlp/transformers/moe_utils.py
@@ -400,6 +400,17 @@ def tokens_zip_unique_add_with_subbatch(zipped, unzipped, index_unzipped, zipped
         return TDU.tokens_zip_unique_add_subbatch(zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows)
 
 
+def merge_subbatch_cast(x, dtype):
+    if isinstance(x, (list, tuple)):
+        if len(x) == 1:
+            x = x[0]
+            return x.cast(dtype) if x.dtype != dtype else x
+        else:
+            return TDU.merge_subbatch_cast(x, dtype)
+    else:
+        return x.cast(dtype) if x.dtype != dtype else x
+
+
 def get_env_device():
     """
     Return the device name of running environment.

--- a/paddlenlp/transformers/moe_utils.py
+++ b/paddlenlp/transformers/moe_utils.py
@@ -398,3 +398,55 @@ def tokens_zip_unique_add_with_subbatch(zipped, unzipped, index_unzipped, zipped
             else:
                 zipped = paddle.split(zipped, rows, axis=0)
         return TDU.tokens_zip_unique_add_subbatch(zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows)
+
+
+def get_env_device():
+    """
+    Return the device name of running environment.
+    """
+    if paddle.is_compiled_with_cuda():
+        return "gpu"
+    elif "npu" in paddle.device.get_all_custom_device_type():
+        return "npu"
+    elif "mlu" in paddle.device.get_all_custom_device_type():
+        return "mlu"
+    elif "gcu" in paddle.device.get_all_custom_device_type():
+        return "gcu"
+    elif "intel_hpu" in paddle.device.get_all_custom_device_type():
+        return "intel_hpu"
+    elif paddle.is_compiled_with_rocm():
+        return "rocm"
+    elif paddle.is_compiled_with_xpu():
+        return "xpu"
+    return "cpu"
+
+
+def to_device(tensor, place=None):
+    if place is None:
+        place = get_env_device()
+
+    if isinstance(place, str):
+        place = paddle.device._convert_to_place(place)
+
+    if not tensor.place._equals(place):
+        new_t = tensor._copy_to(place, True)
+        dst_tensor = tensor.value().get_tensor()
+        src_tensor = new_t.value().get_tensor()
+        dst_tensor._share_data_with(src_tensor)
+
+    return tensor
+
+
+def offload(tensor):
+    if paddle.is_compiled_with_cuda():
+        place = paddle.CUDAPinnedPlace()
+    else:
+        place = paddle.CPUPlace()
+
+    new_tensor = to_device(tensor, place)
+    assert new_tensor is tensor, "to_device must be inplace operation"
+
+
+def reload(tensor):
+    new_tensor = to_device(tensor)
+    assert new_tensor is tensor, "to_device must be inplace operation"

--- a/paddlenlp/transformers/moe_utils.py
+++ b/paddlenlp/transformers/moe_utils.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 import paddle
+import TokenDispatcherUtils as TDU
 
 from .fp8_utils import FP8LinearFunctionBase
 
@@ -181,16 +182,14 @@ class UnZipNode:
         return (unzipped_tokens, zipped_expertwise_rowmap, unzipped_probs, unzipped_scale)
 
     @paddle.no_grad()
-    def backward(self, dx, hidden_states_out_grad, probs_grad, dispatched_indices, num_experts):
+    def backward(self, dx, total_zipped_tokens, probs_grad, dispatched_indices, num_experts):
         with paddle.amp.auto_cast(False):
             weighted_zipped_tokens, probs_grad_zipped = paddle.nn.functional.moe_unpermute(
                 dx,
                 self.zipped_expertwise_rowmap,
                 dispatched_indices,
                 probs_grad,
-                total_zipped_tokens=hidden_states_out_grad[0].shape[0]
-                if isinstance(hidden_states_out_grad, tuple)
-                else hidden_states_out_grad.shape[0],
+                total_zipped_tokens=total_zipped_tokens,
                 num_experts=num_experts,
             )
         self.reset_statue()
@@ -375,3 +374,27 @@ class UnPermuteNode:
 
         self.reset_status()
         return hidden_states_grad, dispatched_probs_grad
+
+
+def tokens_zip_unique_add_with_subbatch(zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows=None):
+    """
+    tokens_zip_unique_add_with_subbatch
+    """
+    if subbatch_rows is None or subbatch_rows <= 0 or zipped_rows <= 0:
+        return TDU.tokens_zip_unique_add(zipped, unzipped, index_unzipped, zipped_rows)
+    else:
+        if isinstance(zipped, paddle.Tensor):
+            num_split = (zipped_rows + subbatch_rows - 1) // subbatch_rows
+            remainder = zipped_rows % subbatch_rows
+            if remainder == 0:
+                rows = [subbatch_rows] * num_split
+            else:
+                rows = [subbatch_rows] * (num_split - 1) + [remainder]
+
+            if zipped.shape[0] == 0:
+                dtype = zipped.dtype
+                hidden_size = zipped.shape[1]
+                zipped = [paddle.zeros([r, hidden_size], dtype=dtype) for r in rows]
+            else:
+                zipped = paddle.split(zipped, rows, axis=0)
+        return TDU.tokens_zip_unique_add_subbatch(zipped, unzipped, index_unzipped, zipped_rows, subbatch_rows)

--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
@@ -14,8 +14,21 @@
 # limitations under the License.
 */
 #include "paddle/common/array.h"
+#include "paddle/common/flags.h"
+#include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "utils.h"
+
+COMMON_DECLARE_bool(enable_pir_api);
+
+
+static paddle::DataType TransToDataType(int64_t dtype) {
+  if (FLAGS_enable_pir_api) {
+    return static_cast<paddle::DataType>(dtype);
+  } else {
+    return phi::TransToPhiDataType(dtype);
+  }
+}
 
 #define CUMSUM_BLOCK_SIZE 48  // cumsum开销和并行度之间的tradeoff的结果，勿动
 #define CUMSUM_INVALID_TAG -1  // 用于标记无效的cumsum，尝试过-114514但失败了
@@ -566,16 +579,19 @@ std::vector<paddle::Tensor> tokens_unzip_gather(
   return {x_unzipped, x_scale_unzipped, index_unzipped};
 }
 
-template <typename ZipT, typename UnzipT, int VecSize>
+template <typename ZipT, typename UnzipT, typename ZipPtrsT, int VecSize>
 __global__ void tokens_zip_unique_add_kernel(
-    ZipT *__restrict__ zipped,
+    ZipPtrsT zipped_ptrs,
     const UnzipT *__restrict__ unzipped,
     const int64_t *__restrict__ index_unzipped,
     const int64_t unzipped_rows,
+    const int64_t subbatch_rows,
     const int hidden_size) {
   for (int64_t unzipped_row = blockIdx.x; unzipped_row < unzipped_rows;
        unzipped_row += gridDim.x) {
-    auto *zipped_ptr = zipped + index_unzipped[unzipped_row] * hidden_size;
+    int64_t zipped_row = index_unzipped[unzipped_row];
+    auto *zipped_ptr = zipped_ptrs[zipped_row / subbatch_rows] +
+                       (zipped_row % subbatch_rows) * hidden_size;
     const auto *unzipped_ptr = unzipped + unzipped_row * hidden_size;
     for (int i = threadIdx.x * VecSize; i < hidden_size;
          i += blockDim.x * VecSize) {
@@ -592,12 +608,42 @@ __global__ void tokens_zip_unique_add_kernel(
   }
 }
 
-std::vector<paddle::Tensor> tokens_zip_unique_add(
-    const paddle::Tensor &zipped_origin,
+
+template <typename T>
+T **GetTensorDevicePtrs(const std::vector<paddle::Tensor> &tensors,
+                        paddle::Tensor *ptr_tensor,
+                        cudaStream_t stream,
+                        phi::Place place) {
+  auto nbytes = tensors.size() * sizeof(T *);
+  std::vector<const T *> cpu_ptrs(tensors.size());
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    cpu_ptrs[i] = tensors[i].data<T>();
+  }
+  *ptr_tensor = paddle::empty(
+      {static_cast<int64_t>(nbytes)}, paddle::DataType::UINT8, place);
+  auto *device_ptrs = reinterpret_cast<T **>(ptr_tensor->data());
+  auto err = cudaMemcpyAsync(
+      device_ptrs, cpu_ptrs.data(), nbytes, cudaMemcpyHostToDevice, stream);
+  PD_CHECK(
+      err == cudaSuccess, "cudaMemcpyAsync error", cudaGetErrorString(err));
+  err = cudaStreamSynchronize(stream);
+  PD_CHECK(err == cudaSuccess,
+           "cudaStreamSynchronize error",
+           cudaGetErrorString(err));
+  return device_ptrs;
+}
+
+
+std::vector<paddle::Tensor> tokens_zip_unique_add_impl(
+    const std::vector<paddle::Tensor> &zipped_origin,
     const paddle::Tensor &unzipped,
     const paddle::Tensor &index_unzipped,
-    int64_t zipped_rows) {
-  auto zipped_shape = zipped_origin.shape();
+    int64_t zipped_rows,
+    int64_t subbatch_rows) {
+  int64_t num_split = static_cast<int64_t>(zipped_origin.size());
+  PD_CHECK(num_split >= 1, "num_split should be larger than or equal to 1");
+
+  auto zipped_shape = zipped_origin[0].shape();
   auto unzipped_shape = unzipped.shape();
   PD_CHECK(zipped_shape.size() == 2);
   PD_CHECK(unzipped_shape.size() == 2);
@@ -605,16 +651,50 @@ std::vector<paddle::Tensor> tokens_zip_unique_add(
 
   auto hidden_size = zipped_shape[1];
 
-  auto out_dtype = zipped_origin.dtype();
+  auto out_dtype = zipped_origin[0].dtype();
   auto in_dtype = unzipped.dtype();
-  auto place = zipped_origin.place();
+  auto place = zipped_origin[0].place();
 
-  paddle::Tensor zipped;
+  if (zipped_rows <= 0) {
+    return zipped_origin;
+  }
+
+  if (subbatch_rows <= 0) {
+    subbatch_rows = zipped_rows;
+  }
+  subbatch_rows = std::min(zipped_rows, subbatch_rows);
+  auto desired_num_split = (zipped_rows + subbatch_rows - 1) / subbatch_rows;
+  auto remainder_rows = zipped_rows - (desired_num_split - 1) * subbatch_rows;
+
+  std::vector<paddle::Tensor> zipped;
+  zipped.reserve(desired_num_split);
   if (zipped_shape[0] == 0) {
-    zipped = paddle::zeros({zipped_rows, hidden_size}, out_dtype, place);
+    PD_CHECK(num_split == 1,
+             "When input is 0-size tensor, it should be a single tensor "
+             "instead of a tensor list");
+    for (int64_t i = 0; i < desired_num_split; ++i) {
+      auto tmp_rows =
+          (i + 1 == desired_num_split ? remainder_rows : subbatch_rows);
+      zipped.emplace_back(
+          paddle::zeros({tmp_rows, hidden_size}, out_dtype, place));
+    }
+    num_split = desired_num_split;
   } else {
-    PD_CHECK(zipped_shape[0] == zipped_rows);
-    zipped = zipped_origin;
+    PD_CHECK(num_split == desired_num_split);
+    for (int64_t i = 0; i < desired_num_split; ++i) {
+      auto tmp_shape = zipped_origin[i].shape();
+      auto tmp_dtype = zipped_origin[i].dtype();
+      PD_CHECK(tmp_shape.size() == 2);
+      if (i + 1 == desired_num_split) {
+        PD_CHECK(tmp_shape[0] == remainder_rows);
+      } else {
+        PD_CHECK(tmp_shape[0] == subbatch_rows);
+      }
+      PD_CHECK(tmp_shape[1] == hidden_size);
+      PD_CHECK(tmp_dtype == out_dtype);
+
+      zipped.emplace_back(zipped_origin[i]);
+    }
   }
 
   auto index_shape = index_unzipped.shape();
@@ -629,16 +709,54 @@ std::vector<paddle::Tensor> tokens_zip_unique_add(
   int block = 1024;
   int grid = LimitGridDim(unzipped_rows);
 
-#define LAUNCH_TOKENS_ZIP_UNIQUE_ADD(__ZipT, __UnzipT)       \
-  do {                                                       \
-    tokens_zip_unique_add_kernel<__ZipT, __UnzipT, kVecSize> \
-        <<<grid, block, 0, unzipped.stream()>>>(             \
-            zipped.data<__ZipT>(),                           \
-            unzipped.data<__UnzipT>(),                       \
-            index_unzipped.data<int64_t>(),                  \
-            unzipped_rows,                                   \
-            hidden_size);                                    \
+  auto stream = unzipped.stream();
+  paddle::Tensor ptr_tensor;
+
+#define LAUNCH_TOKENS_ZIP_UNIQUE_ADD_CASE_IMPL(__ZipT, __UnzipT, __out_ptrs)  \
+  do {                                                                        \
+    auto stream = unzipped.stream();                                          \
+    tokens_zip_unique_add_kernel<                                             \
+        __ZipT,                                                               \
+        __UnzipT,                                                             \
+        typename std::remove_reference<decltype(__out_ptrs)>::type,           \
+        kVecSize><<<grid, block, 0, stream>>>(__out_ptrs,                     \
+                                              unzipped.data<__UnzipT>(),      \
+                                              index_unzipped.data<int64_t>(), \
+                                              unzipped_rows,                  \
+                                              subbatch_rows,                  \
+                                              hidden_size);                   \
   } while (0)
+
+
+#define LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, __num_split) \
+  if (num_split <= __num_split) {                                            \
+    phi::Array<__ZipT *, __num_split> array;                                 \
+    for (int64_t i = 0; i < num_split; ++i) {                                \
+      array[i] = zipped[i].data<__ZipT>();                                   \
+    }                                                                        \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_CASE_IMPL(__ZipT, __UnzipT, array);         \
+    break;                                                                   \
+  }
+
+
+#define LAUNCH_TOKENS_ZIP_UNIQUE_ADD_DYNAMIC_CASE(__ZipT, __UnzipT)      \
+  paddle::Tensor ptr_tensor;                                             \
+  auto device_ptrs =                                                     \
+      GetTensorDevicePtrs<__ZipT>(zipped, &ptr_tensor, stream, place);   \
+  LAUNCH_TOKENS_ZIP_UNIQUE_ADD_CASE_IMPL(__ZipT, __UnzipT, device_ptrs); \
+  break
+
+
+#define LAUNCH_TOKENS_ZIP_UNIQUE_ADD(__ZipT, __UnzipT)           \
+  do {                                                           \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, 1);  \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, 2);  \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, 4);  \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, 8);  \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_FIX_CASE(__ZipT, __UnzipT, 16); \
+    LAUNCH_TOKENS_ZIP_UNIQUE_ADD_DYNAMIC_CASE(__ZipT, __UnzipT); \
+  } while (0)
+
 
   if (grid > 0) {
     if (out_dtype == paddle::DataType::FLOAT32 &&
@@ -654,10 +772,27 @@ std::vector<paddle::Tensor> tokens_zip_unique_add(
       PD_THROW("Unsupported data type");
     }
   }
-
-  return {zipped};
+  return zipped;
 }
 
+std::vector<paddle::Tensor> tokens_zip_unique_add(
+    const paddle::Tensor &zipped_origin,
+    const paddle::Tensor &unzipped,
+    const paddle::Tensor &index_unzipped,
+    int64_t zipped_rows) {
+  return tokens_zip_unique_add_impl(
+      {zipped_origin}, unzipped, index_unzipped, zipped_rows, 0);
+}
+
+void tokens_zip_unique_add_subbatch(
+    const std::vector<paddle::Tensor> &zipped_origin,
+    const paddle::Tensor &unzipped,
+    const paddle::Tensor &index_unzipped,
+    int64_t zipped_rows,
+    int64_t subbatch_rows) {
+  tokens_zip_unique_add_impl(
+      zipped_origin, unzipped, index_unzipped, zipped_rows, subbatch_rows);
+}
 
 template <typename T>
 struct UnzippedProbInfo {
@@ -766,6 +901,327 @@ std::vector<paddle::Tensor> tokens_zip_prob(
 }
 
 
+template <typename T, int MAX_NUM_EXPERTS_C>
+__global__ void tokens_zip_prob_seq_subbatch_kernel(
+    phi::Array<const T *, MAX_NUM_EXPERTS_C> unzipped_probs,
+    const int *__restrict__ zipped_expertwise_rowmap,
+    const int *__restrict__ dispatched_indices,
+    T *zipped_probs,
+    int64_t zipped_rows,
+    int topk,
+    int num_expert,
+    int64_t subbatch_rows) {
+  int64_t idx = threadIdx.x + static_cast<int64_t>(blockDim.x) * blockIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  int64_t limit = zipped_rows * topk;
+  while (idx < limit) {
+    auto zipped_row = idx / topk;
+    auto topk_idx = idx % topk;
+    auto expert_id = dispatched_indices[idx];
+    T value = static_cast<T>(0);
+    if (expert_id >= 0) {
+      auto unzipped_row =
+          zipped_expertwise_rowmap[zipped_row * num_expert + expert_id];
+      auto i = unzipped_row / subbatch_rows;
+      auto j = unzipped_row % subbatch_rows;
+      if (unzipped_row >= 0) {
+        value = unzipped_probs[i][j];
+      }
+    }
+    zipped_probs[idx] = value;
+    idx += stride;
+  }
+}
+
+template <typename T>
+std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
+    const std::vector<paddle::Tensor> &unzipped_probs,
+    const paddle::Tensor &zipped_expertwise_rowmap,
+    const paddle::Tensor &dispatched_indices,
+    int64_t subbatch_rows,
+    paddle::DataType dtype) {
+  auto zipped_expertwise_rowmap_shape = zipped_expertwise_rowmap.shape();
+  auto dispatched_indices_shape = dispatched_indices.shape();
+  PD_CHECK(zipped_expertwise_rowmap_shape.size() == 2);
+  PD_CHECK(dispatched_indices_shape.size() == 2);
+  PD_CHECK(zipped_expertwise_rowmap_shape[0] == dispatched_indices_shape[0]);
+
+  int64_t zipped_rows = zipped_expertwise_rowmap_shape[0];
+  int num_expert = zipped_expertwise_rowmap_shape[1];
+  int topk = dispatched_indices_shape[1];
+
+  auto zipped_probs =
+      paddle::empty({zipped_rows, topk}, dtype, unzipped_probs[0].place());
+
+  PD_SWITCH_NUM_EXPERTS(
+      num_expert, ([&] {
+        phi::Array<const T *, MAX_NUM_EXPERTS_C> unzipped_probs_info;
+        int64_t offset = 0;
+        for (int i = 0; i < num_expert; ++i) {
+          unzipped_probs_info[i] = unzipped_probs[i].data<T>();
+        }
+
+        int thread = 1024;
+        int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
+
+        if (grid > 0) {
+          tokens_zip_prob_seq_subbatch_kernel<T, MAX_NUM_EXPERTS_C>
+              <<<grid, thread, 0, zipped_probs.stream()>>>(
+                  unzipped_probs_info,
+                  zipped_expertwise_rowmap.data<int>(),
+                  dispatched_indices.data<int>(),
+                  zipped_probs.data<T>(),
+                  zipped_rows,
+                  topk,
+                  num_expert,
+                  subbatch_rows);
+        }
+      }));
+  return {zipped_probs};
+}
+
+
+std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch(
+    const std::vector<paddle::Tensor> &unzipped_probs,
+    const paddle::Tensor &zipped_expertwise_rowmap,
+    const paddle::Tensor &dispatched_indices,
+    int64_t subbatch_rows) {
+  PD_CHECK(zipped_expertwise_rowmap.dtype() == paddle::DataType::INT32);
+  PD_CHECK(dispatched_indices.dtype() == paddle::DataType::INT32);
+
+  auto dtype = unzipped_probs[0].dtype();
+  if (dtype == paddle::DataType::FLOAT32) {
+    return tokens_zip_prob_seq_subbatch_impl<float>(unzipped_probs,
+                                                    zipped_expertwise_rowmap,
+                                                    dispatched_indices,
+                                                    subbatch_rows,
+                                                    dtype);
+  } else if (dtype == paddle::DataType::BFLOAT16) {
+    return tokens_zip_prob_seq_subbatch_impl<phi::bfloat16>(
+        unzipped_probs,
+        zipped_expertwise_rowmap,
+        dispatched_indices,
+        subbatch_rows,
+        dtype);
+  } else {
+    PD_THROW("Unsupported data type: %s", dtype);
+  }
+}
+
+
+template <typename InT, typename OutT, typename InPtrsT, int VecSize>
+__global__ void merge_subbatch_cast_kernel(const InPtrsT in_ptrs,
+                                           OutT *__restrict__ out,
+                                           int64_t total_num,
+                                           int64_t subbatch_num) {
+  int64_t idx =
+      (threadIdx.x + static_cast<int64_t>(blockDim.x) * blockIdx.x) * VecSize;
+  int64_t stride = (static_cast<int64_t>(blockDim.x) * gridDim.x) * VecSize;
+
+  while (idx < total_num) {
+    const InT *x_ptr = in_ptrs[idx / subbatch_num] + idx % subbatch_num;
+    phi::AlignedVector<InT, VecSize> in_data;
+    phi::Load(x_ptr, &in_data);
+    if constexpr (std::is_same<InT, OutT>::value) {
+      phi::Store(in_data, out + idx);
+    } else {
+      phi::AlignedVector<OutT, VecSize> out_data;
+#pragma unroll
+      for (int i = 0; i < VecSize; ++i) {
+        out_data[i] = static_cast<OutT>(in_data[i]);
+      }
+      phi::Store(out_data, out + idx);
+    }
+    idx += stride;
+  }
+}
+
+
+std::vector<paddle::Tensor> merge_subbatch_cast(
+    const std::vector<paddle::Tensor> &x, int64_t int_dtype) {
+  if (x.empty()) return {};
+
+  auto in_dtype = x[0].dtype();
+  auto merged_dtype = TransToDataType(int_dtype);
+
+  auto place = x[0].place();
+  auto merged_shape = x[0].shape();
+  int64_t subbatch_rows = merged_shape[0];
+  for (size_t i = 1; i < x.size(); ++i) {
+    auto tmp_shape = x[i].shape();
+    PD_CHECK(tmp_shape.size() == merged_shape.size());
+    for (size_t j = 1; j < tmp_shape.size(); ++j) {
+      PD_CHECK(tmp_shape[j] == merged_shape[j]);
+    }
+    if (i + 1 != x.size()) {
+      PD_CHECK(tmp_shape[0] == subbatch_rows);
+    } else {
+      PD_CHECK(tmp_shape[0] <= subbatch_rows);
+    }
+    merged_shape[0] += tmp_shape[0];
+
+    PD_CHECK(x[i].dtype() == in_dtype);
+  }
+
+  auto output = paddle::empty(merged_shape, merged_dtype, place);
+  int64_t hidden_size = 1;
+  for (size_t i = 1; i < merged_shape.size(); ++i) {
+    hidden_size *= merged_shape[i];
+  }
+
+  int64_t total_num = merged_shape[0] * hidden_size;
+  int64_t subbatch_num = subbatch_rows * hidden_size;
+
+  constexpr int kVecSize = 4;
+  PD_CHECK(total_num % kVecSize == 0);
+  PD_CHECK(subbatch_num % kVecSize == 0);
+  auto stream = output.stream();
+
+  int thread = 1024;
+  int grid = LimitGridDim((total_num / kVecSize + thread - 1) / thread);
+  auto num_split = static_cast<int64_t>(x.size());
+
+#define LAUNCH_MERGE_SUBBATCH_CAST_CASE_IMPL(__InT, __OutT, __in_ptrs) \
+  do {                                                                 \
+    merge_subbatch_cast_kernel<                                        \
+        __InT,                                                         \
+        __OutT,                                                        \
+        typename std::remove_reference<decltype(__in_ptrs)>::type,     \
+        kVecSize><<<grid, thread, 0, stream>>>(                        \
+        __in_ptrs, output.data<__OutT>(), total_num, subbatch_num);    \
+  } while (0)
+
+#define LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, __num_split) \
+  if (num_split <= __num_split) {                                       \
+    phi::Array<const __InT *, __num_split> array;                       \
+    for (int64_t i = 0; i < num_split; ++i) {                           \
+      array[i] = x[i].data<__InT>();                                    \
+    }                                                                   \
+    LAUNCH_MERGE_SUBBATCH_CAST_CASE_IMPL(__InT, __OutT, array);         \
+    break;                                                              \
+  }
+
+#define LAUNCH_MERGE_SUBBATCH_CAST_DYNAMIC_CASE(__InT, __OutT)      \
+  paddle::Tensor ptr_tensor;                                        \
+  auto device_ptrs =                                                \
+      GetTensorDevicePtrs<__InT>(x, &ptr_tensor, stream, place);    \
+  LAUNCH_MERGE_SUBBATCH_CAST_CASE_IMPL(__InT, __OutT, device_ptrs); \
+  break
+
+
+#define LAUNCH_MERGE_SUBBATCH_CAST(__InT, __OutT)           \
+  do {                                                      \
+    LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, 1);  \
+    LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, 2);  \
+    LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, 4);  \
+    LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, 8);  \
+    LAUNCH_MERGE_SUBBATCH_CAST_FIX_CASE(__InT, __OutT, 16); \
+    LAUNCH_MERGE_SUBBATCH_CAST_DYNAMIC_CASE(__InT, __OutT); \
+  } while (0)
+
+
+  if (grid > 0) {
+    if (in_dtype == paddle::DataType::FLOAT32 &&
+        merged_dtype == paddle::DataType::BFLOAT16) {
+      LAUNCH_MERGE_SUBBATCH_CAST(float, paddle::bfloat16);
+    } else if (in_dtype == paddle::DataType::BFLOAT16 &&
+               merged_dtype == paddle::DataType::FLOAT32) {
+      LAUNCH_MERGE_SUBBATCH_CAST(paddle::bfloat16, float);
+    } else if (in_dtype == paddle::DataType::FLOAT32 &&
+               merged_dtype == paddle::DataType::FLOAT32) {
+      LAUNCH_MERGE_SUBBATCH_CAST(float, float);
+    } else if (in_dtype == paddle::DataType::BFLOAT16 &&
+               merged_dtype == paddle::DataType::BFLOAT16) {
+      LAUNCH_MERGE_SUBBATCH_CAST(paddle::bfloat16, paddle::bfloat16);
+    } else {
+      PD_THROW("Unsupported data type");
+    }
+  }
+
+  return {output};
+}
+
+
+template <typename T>
+__global__ void tokens_unzip_slice_kernel(
+    const T *__restrict__ x,
+    const int *__restrict__ zipped_expertwise_rowmap,
+    int64_t *__restrict__ index_out,
+    int64_t total_zipped_rows,
+    int num_experts,
+    int start_idx,
+    int end_idx) {
+  const int64_t slice_len = end_idx - start_idx;
+  if (slice_len <= 0) return;
+
+  const int64_t total = total_zipped_rows * static_cast<int64_t>(num_experts);
+
+  for (int64_t elem = blockIdx.x * blockDim.x + threadIdx.x; elem < total;
+       elem += blockDim.x * gridDim.x) {
+    int64_t row = elem / num_experts;
+    int64_t u = zipped_expertwise_rowmap[elem];
+    if (u < 0) continue;
+    if (u < start_idx || u >= end_idx) continue;
+    int64_t out = static_cast<int64_t>(u) - start_idx;
+    index_out[out] = row;
+  }
+  // TODO: thread_level memcpy elements
+}
+
+std::vector<paddle::Tensor> tokens_unzip_slice(
+    const paddle::Tensor &x,
+    const paddle::Tensor &zipped_expertwise_rowmap,
+    const int num_experts,
+    const int total_unzipped_rows,
+    const int start_idx,
+    const int end_idx) {
+  auto dtype = x.dtype();
+  auto place = x.place();
+  auto stream = x.stream();
+  auto x_shape = x.shape();
+  PD_CHECK(x_shape.size() == 2);
+  int64_t total_zipped_rows = x_shape[0];
+
+  auto index_unzipped =
+      paddle::empty({total_unzipped_rows}, paddle::DataType::INT64, place);
+
+  int block = 1024;
+  int grid = LimitGridDim(total_zipped_rows);
+
+#define LAUNCH_TOKENS_UNZIP_SLICE_KERNEL_IMPL(__cpp_dtype)                 \
+  do {                                                                     \
+    tokens_unzip_slice_kernel<__cpp_dtype>                                 \
+        <<<grid, block, 0, stream>>>(x.data<__cpp_dtype>(),                \
+                                     zipped_expertwise_rowmap.data<int>(), \
+                                     index_unzipped.data<int64_t>(),       \
+                                     total_zipped_rows,                    \
+                                     num_experts,                          \
+                                     start_idx,                            \
+                                     end_idx);                             \
+  } while (0)
+
+#define LAUNCH_TOKENS_UNZIP_SLICE_KERNEL(__cpp_dtype)   \
+  do {                                                  \
+    LAUNCH_TOKENS_UNZIP_SLICE_KERNEL_IMPL(__cpp_dtype); \
+  } while (0)
+
+  if (grid > 0) {
+    LAUNCH_TOKENS_UNZIP_SLICE_KERNEL(phi::float8_e4m3fn);
+  }
+
+  return {index_unzipped};
+}
+
+PD_BUILD_OP(tokens_unzip_slice)
+    .Inputs({"x", "zipped_expertwise_rowmap"})
+    .Outputs({"idx_unzipped"})
+    .Attrs({"num_experts: int",
+            "total_unzipped_rows: int",
+            "start_idx: int",
+            "end_idx: int"})
+    .SetKernelFn(PD_KERNEL(tokens_unzip_slice));
+
+
 PD_BUILD_OP(tokens_unzip_gather)
     .Inputs({"x", paddle::Optional("x_scale"), "zipped_expertwise_rowmap"})
     .Outputs({"x_unzipped",
@@ -783,6 +1239,13 @@ PD_BUILD_OP(tokens_zip_unique_add)
     .Attrs({"zipped_rows: int64_t"})
     .SetKernelFn(PD_KERNEL(tokens_zip_unique_add));
 
+PD_BUILD_OP(tokens_zip_unique_add_subbatch)
+    .Inputs({paddle::Vec("x_zipped"), "x_unzipped", "idx_unzipped"})
+    .Outputs({paddle::Vec("y_zipped")})
+    .SetInplaceMap({{paddle::Vec("x_zipped"), paddle::Vec("y_zipped")}})
+    .Attrs({"zipped_rows: int64_t", "subbatch_rows: int64_t"})
+    .SetKernelFn(PD_KERNEL(tokens_zip_unique_add_subbatch));
+
 
 PD_BUILD_OP(tokens_zip_prob)
     .Inputs({paddle::Vec("unzipped_prob"),
@@ -790,3 +1253,17 @@ PD_BUILD_OP(tokens_zip_prob)
              "dispatched_indices"})
     .Outputs({"zipped_prob"})
     .SetKernelFn(PD_KERNEL(tokens_zip_prob));
+
+PD_BUILD_OP(tokens_zip_prob_seq_subbatch)
+    .Inputs({paddle::Vec("unzipped_prob"),
+             "zipped_expertwise_rowmap",
+             "dispatched_indices"})
+    .Outputs({"zipped_prob"})
+    .Attrs({"subbatch_rows: int64_t"})
+    .SetKernelFn(PD_KERNEL(tokens_zip_prob_seq_subbatch));
+
+PD_BUILD_OP(merge_subbatch_cast)
+    .Inputs({paddle::Vec("x")})
+    .Outputs({"y"})
+    .Attrs({"dtype: int64_t"})
+    .SetKernelFn(PD_KERNEL(merge_subbatch_cast));

--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
@@ -590,6 +590,7 @@ __global__ void tokens_zip_unique_add_kernel(
   for (int64_t unzipped_row = blockIdx.x; unzipped_row < unzipped_rows;
        unzipped_row += gridDim.x) {
     int64_t zipped_row = index_unzipped[unzipped_row];
+    if (zipped_row < 0) continue;
     auto *zipped_ptr = zipped_ptrs[zipped_row / subbatch_rows] +
                        (zipped_row % subbatch_rows) * hidden_size;
     const auto *unzipped_ptr = unzipped + unzipped_row * hidden_size;
@@ -957,7 +958,7 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
       num_expert, ([&] {
         phi::Array<const T *, MAX_NUM_EXPERTS_C> unzipped_probs_info;
         int64_t offset = 0;
-        for (int i = 0; i < num_expert; ++i) {
+        for (size_t i = 0; i < unzipped_probs.size(); ++i) {
           unzipped_probs_info[i] = unzipped_probs[i].data<T>();
         }
 
@@ -1183,8 +1184,7 @@ std::vector<paddle::Tensor> tokens_unzip_slice(
   int64_t total_zipped_rows = x_shape[0];
 
   auto index_unzipped =
-      paddle::empty({total_unzipped_rows}, paddle::DataType::INT64, place);
-
+      paddle::full({total_unzipped_rows}, -1, paddle::DataType::INT64, place);
   int block = 1024;
   int grid = LimitGridDim(total_zipped_rows);
 

--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
@@ -902,9 +902,9 @@ std::vector<paddle::Tensor> tokens_zip_prob(
 }
 
 
-template <typename T, int MAX_NUM_EXPERTS_C>
+template <typename T, int SPLIT_NUMS>
 __global__ void tokens_zip_prob_seq_subbatch_kernel(
-    phi::Array<const T *, MAX_NUM_EXPERTS_C> unzipped_probs,
+    phi::Array<const T *, SPLIT_NUMS> unzipped_probs,
     const int *__restrict__ zipped_expertwise_rowmap,
     const int *__restrict__ dispatched_indices,
     T *zipped_probs,
@@ -954,30 +954,73 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
   auto zipped_probs =
       paddle::empty({zipped_rows, topk}, dtype, unzipped_probs[0].place());
 
-  PD_SWITCH_NUM_EXPERTS(
-      num_expert, ([&] {
-        phi::Array<const T *, MAX_NUM_EXPERTS_C> unzipped_probs_info;
-        int64_t offset = 0;
-        for (size_t i = 0; i < unzipped_probs.size(); ++i) {
-          unzipped_probs_info[i] = unzipped_probs[i].data<T>();
-        }
+  int thread = 1024;
+  int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
 
-        int thread = 1024;
-        int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
+#define LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, __num_split)       \
+  if (unzipped_probs.size() <= __num_split) {                                \
+    phi::Array<const __T *, __num_split> unzipped_probs_info;                \
+    for (size_t i = 0; i < unzipped_probs.size(); ++i) {                     \
+      unzipped_probs_info[i] = unzipped_probs[i].data<__T>();                \
+    }                                                                        \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_CASE_IMPL(__T, unzipped_probs_info); \
+    break;                                                                   \
+  }
 
-        if (grid > 0) {
-          tokens_zip_prob_seq_subbatch_kernel<T, MAX_NUM_EXPERTS_C>
-              <<<grid, thread, 0, zipped_probs.stream()>>>(
-                  unzipped_probs_info,
-                  zipped_expertwise_rowmap.data<int>(),
-                  dispatched_indices.data<int>(),
-                  zipped_probs.data<T>(),
-                  zipped_rows,
-                  topk,
-                  num_expert,
-                  subbatch_rows);
-        }
-      }));
+#define LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_DYNAMIC_CASE(__T)              \
+  paddle::Tensor ptr_tensor;                                               \
+  auto unzipped_probs_info =                                               \
+      GetTensorDevicePtrs<const __T>(unzipped_probs,                       \
+                                     &ptr_tensor,                          \
+                                     zipped_probs.stream(),                \
+                                     zipped_probs.place());                \
+  LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_CASE_IMPL(__T, unzipped_probs_info); \
+  break
+
+#define LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_CASE_IMPL(__T,                   \
+                                                      __unzipped_probs_info) \
+  do {                                                                       \
+    if (grid > 0) {                                                          \
+      tokens_zip_prob_seq_subbatch_kernel<                                   \
+          __T,                                                               \
+          std::remove_reference_t<decltype(__unzipped_probs_info)>::size()>  \
+          <<<grid, thread, 0, zipped_probs.stream()>>>(                      \
+              __unzipped_probs_info,                                         \
+              zipped_expertwise_rowmap.data<int>(),                          \
+              dispatched_indices.data<int>(),                                \
+              zipped_probs.data<__T>(),                                      \
+              zipped_rows,                                                   \
+              topk,                                                          \
+              num_expert,                                                    \
+              subbatch_rows);                                                \
+    }                                                                        \
+  } while (0)
+
+#define LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH(__T)           \
+  do {                                                     \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 1);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 2);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 3);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 4);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 5);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 6);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 7);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 8);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 9);  \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 10); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 11); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 12); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 13); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 14); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 15); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 16); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 17); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 18); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 19); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_FIX_CASE(__T, 20); \
+    LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_DYNAMIC_CASE(__T); \
+  } while (0)
+
   return {zipped_probs};
 }
 

--- a/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
+++ b/slm/model_zoo/gpt-3/external_ops/token_dispatcher_utils/tokens_stable_unzip.cu
@@ -902,9 +902,9 @@ std::vector<paddle::Tensor> tokens_zip_prob(
 }
 
 
-template <typename T, int SPLIT_NUMS>
+template <typename T, typename UnZipProbPtrsT>
 __global__ void tokens_zip_prob_seq_subbatch_kernel(
-    phi::Array<const T *, SPLIT_NUMS> unzipped_probs,
+    UnZipProbPtrsT unzipped_probs,
     const int *__restrict__ zipped_expertwise_rowmap,
     const int *__restrict__ dispatched_indices,
     T *zipped_probs,
@@ -916,15 +916,15 @@ __global__ void tokens_zip_prob_seq_subbatch_kernel(
   int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   int64_t limit = zipped_rows * topk;
   while (idx < limit) {
-    auto zipped_row = idx / topk;
-    auto topk_idx = idx % topk;
-    auto expert_id = dispatched_indices[idx];
+    int64_t zipped_row = idx / topk;
+    int64_t topk_idx = idx % topk;
+    int64_t expert_id = dispatched_indices[idx];
     T value = static_cast<T>(0);
     if (expert_id >= 0) {
-      auto unzipped_row =
+      int64_t unzipped_row =
           zipped_expertwise_rowmap[zipped_row * num_expert + expert_id];
-      auto i = unzipped_row / subbatch_rows;
-      auto j = unzipped_row % subbatch_rows;
+      int64_t i = unzipped_row / subbatch_rows;
+      int64_t j = unzipped_row % subbatch_rows;
       if (unzipped_row >= 0) {
         value = unzipped_probs[i][j];
       }
@@ -953,7 +953,6 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
 
   auto zipped_probs =
       paddle::empty({zipped_rows, topk}, dtype, unzipped_probs[0].place());
-
   int thread = 1024;
   int grid = LimitGridDim((zipped_rows * topk + thread - 1) / thread);
 
@@ -983,7 +982,8 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
     if (grid > 0) {                                                          \
       tokens_zip_prob_seq_subbatch_kernel<                                   \
           __T,                                                               \
-          std::remove_reference_t<decltype(__unzipped_probs_info)>::size()>  \
+          typename std::remove_reference<                                    \
+              decltype(__unzipped_probs_info)>::type>                        \
           <<<grid, thread, 0, zipped_probs.stream()>>>(                      \
               __unzipped_probs_info,                                         \
               zipped_expertwise_rowmap.data<int>(),                          \
@@ -1021,6 +1021,7 @@ std::vector<paddle::Tensor> tokens_zip_prob_seq_subbatch_impl(
     LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH_DYNAMIC_CASE(__T); \
   } while (0)
 
+  LAUNCH_TOKENS_ZIP_PROB_SEQ_SUBBATCH(T);
   return {zipped_probs};
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
本PR主要有以下几部分工作：
1. 添加mlp_sub_batch功能解决，解决负载不均衡情况，两大种subbatch策略：
    a. 输入维度切片策略（减少mlp流程，中间变量（o1,o2_s...）显存大小）
    b. 输出维度切片策略（不均衡情况下，对于较大输出（dx...）使用小块显存拼接，避免一次性申请显存过大显存）
2. 以上两种策略通过3个flag进行控制，可灵活进行组合「前向、反向、输出维度」三种场景：
    ```
    "mlp_fwd_subbatch_rows": 32768,    // 控制是否开启前向输入subbatch，0代表关闭
    "mlp_bwd_subbatch_rows": 32768,   // 控制是否开启反向输入subbatch，0代表关闭
    "output_subbatch_rows": 8192,       // 控制输出切片大小，0代表关闭
    ```
    输入subbatch策略在不均衡程度大于2倍flag阈值时开启，输出subbatch需配合输入subbatch策略开启场景下生效

1. 实现offload和reload逻辑，触发条件是进入subbatch分支，会offload fwd中input_fp8

3. 实现部分subbatch算子，暂时以自定义算子方式实现，可能需迁移至Paddle repo
4. 处理部分原代码中 0size bug
5. 进行fp8_util代码prune，移除backward_dx，backward_dw旧版策略
---
注：本PR代码升级改动遵守以下原则：尽量不修改接口，必须修改接口场景下，**必选新增输入**为args形式，**可选新增输入**为kwargs形式
       
