### PR TITLE
Quant weight of FP8 parameter except MoE expert

### DIFF
--- a/paddlenlp/trainer/trainer_callback.py
+++ b/paddlenlp/trainer/trainer_callback.py
@@ -27,6 +27,7 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 from tqdm.auto import tqdm
 
+from paddlenlp.transformers.moe_utils import offload, reload
 from paddlenlp.utils.log import logger
 
 from .trainer_utils import IntervalStrategy, has_length
@@ -646,5 +647,23 @@ class FP8QuantWeightCallback(TrainerCallback):
         if not g_shard_bypass_dygraph_optimizer or skip_count == 0:
             model.fp8_quant_weight(True)
             optimizer.clear_param_storage("moe_expert")
+            optimizer.clear_param_storage("rms_linear")
+            optimizer.clear_param_storage("memory_attn")
+            optimizer.clear_param_storage("attn_out_project")
+            optimizer.clear_param_storage("shared_expert")
+
+            self.moe_weights_name = []
+            for param in optimizer._inner_opt._parameter_list:
+                color = getattr(param, "color", -1)
+                if isinstance(color, dict) and color["color"] == "moe_expert":
+                    self.moe_weights_name.append(param.name)
+
+            for name in self.moe_weights_name:
+                offload(optimizer._master_weights[name])
 
         skip_count += 1
+
+    def on_optimizer_begin(self, args, state, control, **kwargs):
+        optimizer = kwargs["optimizer"]
+        for name in self.moe_weights_name:
+            reload(optimizer._master_weights[name])

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -88,6 +88,7 @@ from ..fp8_utils import (
     FP8LinearFunctionBase,
     FP8Mlp,
     cache_fp8_weight,
+    set_parameter_color,
 )
 from .fp8_linear import Linear
 
@@ -105,6 +106,7 @@ except ImportError:
         if y is None:
             x, y = paddle.chunk(x, chunks=2, axis=-1)
         return F.silu(x) * y
+
 
 try:
     from paddle.incubate.nn.functional import fused_partial_rope
@@ -752,6 +754,7 @@ class DeepseekV2MLP(nn.Layer):
 
 class FusedNormGateFunc(paddle.autograd.PyLayer):
     """recompute of postnorm and gate"""
+
     _current_norm_output = None
     _current_invar = None
 
@@ -799,6 +802,7 @@ class FusedNormGateFunc(paddle.autograd.PyLayer):
 
         return dx, d_rms_norm_weight, d_moe_gate_weight
 
+
 class TemporaryVarContext:
     def __init__(self, norm_output, invar):
         self.norm_output = norm_output
@@ -809,6 +813,7 @@ class TemporaryVarContext:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         FusedNormGateFunc.clear_temporary_vars()
+
 
 def balance_expert_assignment(n, m, k):
     assert k * n % m == 0
@@ -999,7 +1004,11 @@ class DeepseekV2MoE(MoELayer):
 
         if config.offline_quant_expert_weight and config.clear_origin_weight_when_offline_quant:
             moe_grad_group = fleet.get_hybrid_communicate_group().expert_grad_comm_group
-            for p in self.experts.parameters():
+            expert_w1_list = [expert.w1 for expert in self.experts if expert is not None]
+            expert_w2_list = [expert.w2 for expert in self.experts if expert is not None]
+            for p in expert_w1_list:
+                setattr(p, "color", {"color": "moe_expert", "group": moe_grad_group})
+            for p in expert_w2_list:
                 setattr(p, "color", {"color": "moe_expert", "group": moe_grad_group})
 
         self.alpha = config.aux_loss_alpha
@@ -1019,6 +1028,7 @@ class DeepseekV2MoE(MoELayer):
                 self.shared_experts = DeepseekV2MLPClass(
                     config=config, intermediate_size=intermediate_size, is_moe=False
                 )
+            set_parameter_color([self.shared_experts.w1, self.shared_experts.w2], "shared_expert")
 
     def fp8_quant_weight(self, batch_mode=False):
         """Quantize weights in FP8 format.
@@ -1171,7 +1181,16 @@ def qkv_pre_process(
 ):
     if (fused_partial_rope is None) or (position_ids is not None):
         return qkv_pre_process_no_fuse(
-            q, kv, k_pe, rotary_emb, num_heads, q_head_dim, qk_nope_head_dim, v_head_dim, qk_rope_head_dim, position_ids
+            q,
+            kv,
+            k_pe,
+            rotary_emb,
+            num_heads,
+            q_head_dim,
+            qk_nope_head_dim,
+            v_head_dim,
+            qk_rope_head_dim,
+            position_ids,
         )
 
     bsz, q_len, _ = q.shape
@@ -1712,6 +1731,7 @@ class MemroyRecomputeAttn(paddle.nn.Layer):
             kv_lora_rank,
             softmax_scale,
         )
+        set_parameter_color([self.q_up_weight, self.kv_up_weight], "memory_attn")
 
     def fp8_quant_weight(self):
         cache_fp8_weight(self.q_up_weight)
@@ -1839,6 +1859,7 @@ class FusedRMSLinear(paddle.nn.Layer):
             is_bias=False,
         )
         self.eps = eps
+        set_parameter_color([self.q_down_weight], "rms_linear")
 
     def fp8_quant_weight(self):
         cache_fp8_weight(self.q_down_weight)
@@ -2236,6 +2257,8 @@ class DeepseekV2DecoderLayer(nn.Layer):
         if isinstance(self.mlp, DeepseekV2MoE):
             # logger.info(f"fp8 quant weight for mlp {type(self.mlp)}")
             self.mlp.fp8_quant_weight(batch_mode)
+            self.self_attn.fp8_quant_weight()
+        elif isinstance(self.mlp, FP8Mlp):
             self.self_attn.fp8_quant_weight()
 
     def forward(

--- a/paddlenlp/transformers/fp8_utils.py
+++ b/paddlenlp/transformers/fp8_utils.py
@@ -50,6 +50,22 @@ __all__ = [
 ]
 
 
+def set_parameter_color(
+    parameters, color, group=None, offline_quant_expert_weight=True, clear_origin_weight_when_offline_quant=True
+):
+    if offline_quant_expert_weight and clear_origin_weight_when_offline_quant:
+        if group is None:
+            for p in parameters:
+                if hasattr(p, "color") and p.color is not None:
+                    continue
+                setattr(p, "color", {"color": color})
+        else:
+            for p in parameters:
+                if hasattr(p, "color") and p.color is not None:
+                    continue
+                setattr(p, "color", {"color": color, "group": group})
+
+
 def _get_fp8_weight_and_scale(weight, stacked=False, transpose=False):
     """_get_fp8_weight_and_scale"""
     if stacked:
@@ -593,6 +609,7 @@ class FP8KeepXLinear(paddle.nn.Layer):
             dtype="bfloat16",
             is_bias=False,
         )
+        set_parameter_color([self.weight], "attn_out_project")
 
     def fp8_quant_weight(self):
         cache_fp8_weight(self.weight)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
该PR升级 quant weight cache 机制，主要工作如下：
1. 支持 MoE expert 之外 fp weight 设置 color，在quant之后根据color删除bf16副本，（新增Master Weight会被SD）
3. MoE expert 新增 Master Weight 不会被SD组切分，由于其较大，因此采用offload和reload逻辑
4. 对Dense层支持 quant weight
5. 本PR需要升级Paddle&PaddleNLP使用，

    - Paddle pr：https://github.com/PaddlePaddle/Paddle/pull/74724 升级 color 机制
  
    - PaddleNLP pr：https://github.com/PaddlePaddle/PaddleNLP/pull/10947 新增 reload 和 offload 方法