### PR TITLE
Make pp_stream wait on attn_backward_dx

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1077,7 +1077,7 @@ class OverlapedFUsionScheduleNode:
         # get dispatch backward event
         dispatch_backward_event = deep_ep.get_event_from_comm_stream(self.backward_node.moe_group.id)
 
-        paddle.base.core.nvprof_nvtx_push("dispatch_backward_dw")
+        paddle.base.core.nvprof_nvtx_push("mlp_backward_dw")
         WeightGradStore.pop()
         assert WeightGradStore.funcs_queue.empty()
         paddle.base.core.nvprof_nvtx_pop()
@@ -1108,11 +1108,7 @@ class OverlapedFUsionScheduleNode:
 
         if pp_stream is not None:
             send_recv_stream = paddle.device.Stream(stream_base=pp_stream)
-
-            # combine_forward_event.custom_stream_wait( pp_stream)
-            # final_out_event.custom_stream_wait(pp_stream)
-
-            paddle.base.core.nvprof_nvtx_push("pp stream add")
+            paddle.base.core.nvprof_nvtx_push("pp_stream_add")
 
             with paddle.device.stream_guard(send_recv_stream):
                 combine_forward_event.current_stream_wait()
@@ -1127,20 +1123,27 @@ class OverlapedFUsionScheduleNode:
 
         dispatch_backward_event.calc_stream_wait(self.backward_node.moe_group.id)
 
-        paddle.base.core.nvprof_nvtx_push("attn_backward")
+        paddle.base.core.nvprof_nvtx_push("attn_backward_dx")
         assert WeightGradStore.funcs_queue.empty()
         WeightGradStore.enabled = True
         output_grad = self.backward_node.attn_backward(output_grad)
         event_to_wait = deep_ep.get_event_from_calc_stream(self.backward_node.moe_group.id)
+        paddle.base.core.nvprof_nvtx_pop()
 
         if EventStore is not None:
             EventStore.set(event_to_wait)
 
+        if pp_stream is not None:
+            # TODO(liangshuhao): this wait seems unnecessary, but there will be
+            # convergence issue without this.
+            with paddle.device.stream_guard(send_recv_stream):
+                event_to_wait.current_stream_wait()
+
+        paddle.base.core.nvprof_nvtx_push("attn_backward_dw")
         WeightGradStore.enabled = False
         WeightGradStore.flush()
         WeightGradStore.pop()
         assert WeightGradStore.funcs_queue.empty()
-
         paddle.base.core.nvprof_nvtx_pop()
 
         # residual add
@@ -1218,6 +1221,8 @@ class OverlapedDenseFusionScheduleNode:
             paddle.base.core.nvprof_nvtx_pop()  # moe_attn
 
             paddle.base.core.nvprof_nvtx_push("dense_mlp_moe_dispatch")
+            if combine_bw_event_to_wait is not None:
+                combine_bw_event_to_wait.calc_stream_wait(self.forward_node.moe_group.id)
             output_grad = self.backward_node.mlp_node.backward(output_grad)
             inputs = self.forward_node.dispatch_forward(
                 inputs, previous_event=attn_fw_event, async_finish=True, allocate_on_comm_stream=True


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
让 pp_stream 等待 attn_backward_dx，解决开启 overlap_p2p_comm 时遇到的 loss 下降速度慢的问题

下图显示了修复前和修复后的等待关系
<img width="1608" height="722" alt="图片 1" src="https://github.com/user-attachments/assets/1d94655f-1668-4928-9824-091dc25ff853" />

其实我也不知道为什么加这条等待就行，我只是通过二分法定位到是 PP(F) 的问题，然后试着加了等待，然后 loss 就正常了，估计跟跨 stream 分配显存有关，我通过单测发现 Paddle 的跨 stream 分配显存有一些不安全的情况，虽然模型里看起来没有不安全的用法，但也不好说，所以还是保守一点

<b>对性能有一定影响</b>，因为把 PP(F) 推后了，该 PR 还需要改进

正常情况下，单机配置（29 Decoder + 1 MTP），跑200个step，loss应该下降到7.3；在本PR之前开启 overlap_p2p_comm，loss 只能降到8.7；现在开不开都能降到7.3