### PR TITLE
Fix slow convergence issue when enable overlap_p2p_comm

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1086,7 +1086,6 @@ class OverlapedFUsionScheduleNode:
         paddle.base.core.nvprof_nvtx_push("mlp_forward")
         inputs = self.forward_node.mlp_forward(inputs)
         paddle.base.core.nvprof_nvtx_pop()
-        mlp_fwd_event = deep_ep.get_event_from_calc_stream(self.forward_node.moe_group.id)
 
         if pp_stream is not None:
             paddle.base.core.nvprof_nvtx_push("post_process_forward")
@@ -1098,7 +1097,7 @@ class OverlapedFUsionScheduleNode:
 
         paddle.base.core.nvprof_nvtx_push("combine_forward")
         inputs = self.forward_node.combine_forward(
-            inputs, previous_event=mlp_fwd_event, async_finish=True, allocate_on_comm_stream=True
+            inputs, previous_event=final_out_event, async_finish=True, allocate_on_comm_stream=True
         )
         paddle.base.core.nvprof_nvtx_pop()
 
@@ -1108,9 +1107,6 @@ class OverlapedFUsionScheduleNode:
 
         if pp_stream is not None:
             send_recv_stream = paddle.device.Stream(stream_base=pp_stream)
-
-            # combine_forward_event.custom_stream_wait( pp_stream)
-            # final_out_event.custom_stream_wait(pp_stream)
 
             paddle.base.core.nvprof_nvtx_push("pp stream add")
 
@@ -1218,6 +1214,8 @@ class OverlapedDenseFusionScheduleNode:
             paddle.base.core.nvprof_nvtx_pop()  # moe_attn
 
             paddle.base.core.nvprof_nvtx_push("dense_mlp_moe_dispatch")
+            if combine_bw_event_to_wait is not None:
+                combine_bw_event_to_wait.calc_stream_wait(self.forward_node.moe_group.id)
             output_grad = self.backward_node.mlp_node.backward(output_grad)
             inputs = self.forward_node.dispatch_forward(
                 inputs, previous_event=attn_fw_event, async_finish=True, allocate_on_comm_stream=True


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Models

### Description
修复开启 overlap_p2p_comm 时出现的 loss 下降慢的问题，包括2点：
1. 让`combine_forward`等待`post_process_forward`，不允许两者 overlap，
2. 让 Dense 节点的 mlp_backward 等待 combine_bw_event_to_wait，因为 Dense 节点没有 combine_bw，直接到 mlp_backward 了，所以应该由 mlp_backward 来等待

第2点问题是明确的，但是第1点其实不知道本质原因，我只是通过二分法定位到是 forward send/recv 附近的问题，然后试着加了等待，然后 loss 就正常了，估计跟跨 stream 分配显存有关，我通过单测发现 Paddle 的跨 stream 分配显存有一些不安全的情况，虽然模型里看起来没有不安全的用法，但也不好说，所以还是保守一点

本 PR 对性能几乎无影响，因为 post_process_forward 很短，把 combine_forward 推后一点影响不大，而且推后只会发生在每个 stage 的最后一层 Decoder，影响比例很小

正常情况下，单机配置（29 Decoder + 1 MTP），跑200个step，loss应该下降到7.3；在本PR之前开启 overlap_p2p_comm，loss 只能降到8.7；现在开不开都能降到7.3