### PR TITLE
Implement Decoder backward self-overlapping

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -540,6 +540,20 @@ class OverlapedScheduleChunk:
         return inputs, output_grad, None
 
 
+class DecoderBackwardScheduleChunk:
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def backward(self, output_grad, combine_bw_event_to_wait=None, pp_stream=None):
+        event_to_wait = combine_bw_event_to_wait
+        for i, n in enumerate(self.nodes):
+            pp_stream_t = pp_stream if i + 1 == len(self.nodes) else None
+            output_grad, event_to_wait = n.backward_for_fusion(
+                output_grad, combine_bw_event_to_wait=event_to_wait, pp_stream=pp_stream_t
+            )
+        return output_grad
+
+
 class OverlapedScheduleNode:
     def __init__(self, forward_node, backward_node, name=""):
         assert isinstance(forward_node, DecoderLayerNode) and isinstance(backward_node, DecoderLayerNode)
@@ -972,6 +986,77 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
             output_grad = self.attn_and_gate_node.backward(output_grad)
         return output_grad
 
+    def backward_for_fusion(self, output_grad, combine_bw_event_to_wait=None, pp_stream=None):
+        paddle.base.core.nvprof_nvtx_push("backward")
+        if combine_bw_event_to_wait is None:
+            combine_bw_event_to_wait = deep_ep.get_event_from_calc_stream(self.moe_group.id)
+
+        paddle.base.core.nvprof_nvtx_push("post_process_backward")
+        output_grad = self.post_process_backward(output_grad, combine_bw_event_to_wait)
+        paddle.base.core.nvprof_nvtx_pop()
+
+        paddle.base.core.nvprof_nvtx_push("combine_backward")
+        output_grad = self.combine_backward(
+            output_grad, previous_event=combine_bw_event_to_wait, async_finish=True, allocate_on_comm_stream=True
+        )
+        combine_backward_event = deep_ep.get_event_from_comm_stream(self.moe_group.id)
+        combine_backward_event.calc_stream_wait(self.moe_group.id)
+        paddle.base.core.nvprof_nvtx_pop()
+
+        if WeightGradStore.enabled:
+            paddle.base.core.nvprof_nvtx_push("mlp_backward")
+            output_grad = self.mlp_backward(output_grad)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("dispatch_backward")
+            output_grad = self.dispatch_backward(output_grad)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("attn_backward")
+            output_grad = self.attn_backward(output_grad)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            event_to_wait = None
+
+        else:
+            paddle.base.core.nvprof_nvtx_push("mlp_backward_dx")
+            assert WeightGradStore.funcs_queue.empty()
+            WeightGradStore.enabled = True
+            output_grad = self.mlp_backward(output_grad)
+            WeightGradStore.enabled = False
+            WeightGradStore.flush()
+            output_grad_event = deep_ep.get_event_from_calc_stream(self.moe_group.id)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("dispatch_backward")
+            output_grad = self.dispatch_backward(
+                output_grad, async_finish=True, previous_event=output_grad_event, allocate_on_comm_stream=True
+            )
+            dispatch_backward_event = deep_ep.get_event_from_comm_stream(self.moe_group.id)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("mlp_backward_dw")
+            WeightGradStore.pop()
+            assert WeightGradStore.funcs_queue.empty()
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("attn_backward_dx")
+            dispatch_backward_event.calc_stream_wait(self.moe_group.id)
+            WeightGradStore.enabled = True
+            output_grad = self.attn_backward(output_grad)
+            WeightGradStore.enabled = False
+            WeightGradStore.flush()
+            event_to_wait = deep_ep.get_event_from_calc_stream(self.moe_group.id)
+            paddle.base.core.nvprof_nvtx_pop()
+
+            paddle.base.core.nvprof_nvtx_push("attn_backward_dw")
+            WeightGradStore.pop()
+            assert WeightGradStore.funcs_queue.empty()
+            paddle.base.core.nvprof_nvtx_pop()
+
+        paddle.base.core.nvprof_nvtx_pop()
+        return output_grad, event_to_wait
+
     def forward(self, inputs):
         inputs = self.attn_forward(inputs)
         inputs = self.dispatch_forward(inputs)
@@ -1303,6 +1388,11 @@ def build_overlapped_nodes(forward_chunk, backward_chunk):
 
     backward_pre_node = ScheduleChunk(list(reversed(backward_pre_overlap_layers)))
     backward_post_node = ScheduleChunk(list(reversed(backward_post_overlap_layers)))
+
+    if not forward_chunk.nodes and all(
+        isinstance(n, FusionFp8DecoderLayerNode) for n in backward_chunk.nodes
+    ):
+        backward_post_node = DecoderBackwardScheduleChunk(backward_post_overlap_layers)
 
     overlap_node = OverlapedScheduleChunk(forward_overlap_layers, backward_overlap_layers, use_fuion=DSV3_USE_FP8_GEMM)
     return forward_pre_node, backward_pre_node, overlap_node, forward_post_node, backward_post_node


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Models

### Description
实现 Decoder backward 的<b>【自Overlap】</b>机制，即：
1. ATTN(W)+POST(B) 与 COMBINE(B) 进行 overlap
2. MLP(W) 与 DISPATCH(B) 进行 overlap

下图展示了一个 backward chunk 的原版和自Overlap的编排对比：
<img width="1835" height="460" alt="图片 1" src="https://github.com/user-attachments/assets/99c2ca2c-dd43-4463-b2d8-b91b65634b54" />

实际 timeline 看起来挺好，基本能 overlap 住：
<img width="1277" height="308" alt="图片 2" src="https://github.com/user-attachments/assets/041073e7-b666-49b5-8765-45642098549f" />

<b>性能：</b>pp4ep8，16 mini-batch
单 chunk 用时 112ms -> 96ms，提速 14%
单 batch 用时 4.834s -> 4.791s，提速 1%

该 PR 未实现 send/recv overlap，传入的 pp_stream 始终为 None，但保留了传入的接口；当然这个的提升估计会非常小，就像之前做 forward 阶段的 send/recv overlap 一样

该 PR 需要 Paddle 更新到 https://github.com/PaddlePaddle/Paddle/pull/74891 才能生效，但不更新也不会错，会跑原来无 overlap 的分支，性能不变