### PR TITLE
Add stepped O1 recompute

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/configuration.py
+++ b/paddlenlp/transformers/deepseek_v2/configuration.py
@@ -182,6 +182,7 @@ class DeepseekV2Config(PretrainedConfig):
         use_dualpipev=False,
         send_mtp_embed=False,
         using_post_norm_recompute=False,
+        stepped_recompute_fwd_gate_up=False,
         recompute_fwd_gate_up=0,
         recompute_fa3=0,
         is_split_group_gemm=False,
@@ -245,6 +246,7 @@ class DeepseekV2Config(PretrainedConfig):
         self.using_post_norm_recompute = using_post_norm_recompute
         self.recompute_fwd_gate_up = recompute_fwd_gate_up
         self.recompute_fa3 = recompute_fa3
+        self.stepped_recompute_fwd_gate_up = stepped_recompute_fwd_gate_up
         self.is_split_group_gemm = is_split_group_gemm
         self.fakse_gate_restrict_balance = fakse_gate_restrict_balance
         self.adaptive_remained_O1_recompute_ratio = adaptive_remained_O1_recompute_ratio

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -34,11 +34,6 @@ try:
 except ImportError:
     EventStore = None
 
-try:
-    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import StepEvent
-except ImportError:
-    StepEvent = None
-
 from paddle.distributed.fleet.recompute.recompute import recompute
 from paddle.distributed.fleet.utils.sequence_parallel_utils import ScatterOp
 
@@ -590,6 +585,7 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         mlp_layer,
         send_mtp_embed,
         using_post_norm_recompute=False,
+        stepped_recompute_fwd_gate_up=False,
         name="",
     ):
         self.attn_and_gate_node = attn_and_gate_node
@@ -598,6 +594,7 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         self.send_mtp_embed = send_mtp_embed
 
         self.using_post_norm_recompute = using_post_norm_recompute
+        self.stepped_recompute_fwd_gate_up = stepped_recompute_fwd_gate_up
         self.name = name
 
         self.moe_group = mlp_layer.moe_group
@@ -979,7 +976,7 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         return output_grad
 
     def forward(self, inputs):
-        if StepEvent is not None and StepEvent.need_rc_o1:
+        if self.stepped_recompute_fwd_gate_up:
             self.fp8_fusion_moe_node.mlp_node.set_recompute_fwd_gate_up(True)
         inputs = self.attn_forward(inputs)
         inputs = self.dispatch_forward(inputs)
@@ -1710,6 +1707,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                         mlp_layer=self.mlp,
                         send_mtp_embed=self.config.send_mtp_embed,
                         using_post_norm_recompute=self.config.using_post_norm_recompute,
+                        stepped_recompute_fwd_gate_up=self.config.stepped_recompute_fwd_gate_up
                         name="FusionFp8DecoderLayerNode",
                     )
                 else:

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -30,7 +30,7 @@ from paddle.distributed.fleet.meta_parallel import (
 from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import WeightGradStore
 
 try:
-    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import EventStore
+    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import EventStore, StepEvent
 except ImportError:
     EventStore = None
 from paddle.distributed.fleet.recompute.recompute import recompute
@@ -973,6 +973,8 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         return output_grad
 
     def forward(self, inputs):
+        if StepEvent.need_rc_o1:
+            self.fp8_fusion_moe_node.mlp_node.set_recompute_fwd_gate_up(True)
         inputs = self.attn_forward(inputs)
         inputs = self.dispatch_forward(inputs)
         inputs = self.mlp_forward(inputs)

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -30,9 +30,15 @@ from paddle.distributed.fleet.meta_parallel import (
 from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import WeightGradStore
 
 try:
-    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import EventStore, StepEvent
+    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import EventStore
 except ImportError:
     EventStore = None
+
+try:
+    from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import StepEvent
+except ImportError:
+    StepEvent = None
+
 from paddle.distributed.fleet.recompute.recompute import recompute
 from paddle.distributed.fleet.utils.sequence_parallel_utils import ScatterOp
 
@@ -973,7 +979,7 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         return output_grad
 
     def forward(self, inputs):
-        if StepEvent.need_rc_o1:
+        if StepEvent is not None and StepEvent.need_rc_o1:
             self.fp8_fusion_moe_node.mlp_node.set_recompute_fwd_gate_up(True)
         inputs = self.attn_forward(inputs)
         inputs = self.dispatch_forward(inputs)

--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -1707,7 +1707,7 @@ class DeepseekV2DecoderLayerPipe(DeepseekV2DecoderLayer):
                         mlp_layer=self.mlp,
                         send_mtp_embed=self.config.send_mtp_embed,
                         using_post_norm_recompute=self.config.using_post_norm_recompute,
-                        stepped_recompute_fwd_gate_up=self.config.stepped_recompute_fwd_gate_up
+                        stepped_recompute_fwd_gate_up=self.config.stepped_recompute_fwd_gate_up,
                         name="FusionFp8DecoderLayerNode",
                     )
                 else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
需要配合升级Paddle使用：https://github.com/PaddlePaddle/Paddle/pull/74905
当前策略为：开启flag（FLAGS_stepped_recompute_o1）后，dualpipev中step0、step1进行o1 rc，其余step交由原本fwd_gate_up_recompute控制