### PR TITLE
Implement auxiliary-loss-free load balancing

### DIFF
--- a/llm/model_config/DeepSeek-V3/config.json
+++ b/llm/model_config/DeepSeek-V3/config.json
@@ -9,7 +9,8 @@
       "AutoModel": "modeling_deepseek.DeepseekV3Model",
       "AutoModelForCausalLM": "modeling_deepseek.DeepseekV3ForCausalLM"
     },
-    "aux_loss_alpha": 0.001,
+    "aux_loss_alpha": 0.0001,
+    "aux_loss_free_gamma": 0.001,
     "bos_token_id": 0,
     "eos_token_id": 1,
     "ep_size": 1,

--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -28,6 +28,7 @@ from paddlenlp.data.causal_dataset import (
 )
 from paddlenlp.trainer import (
     FP8QuantWeightCallback,
+    MoECorrectionBiasAdjustCallback,
     PdArgumentParser,
     StepFlexToken,
     Trainer,
@@ -570,6 +571,10 @@ def main():
     )
 
     callbacks = [StepFlexToken(), FP8QuantWeightCallback()]
+
+    if getattr(config, "topk_method", None) == "noaux_tc":
+        aux_loss_free_gamma = getattr(config, "aux_loss_free_gamma", 0.001)
+        callbacks += [MoECorrectionBiasAdjustCallback(aux_loss_free_gamma)]
 
     trainer = PretrainingTrainer(
         model=model,

--- a/paddlenlp/trainer/trainer_callback.py
+++ b/paddlenlp/trainer/trainer_callback.py
@@ -27,6 +27,11 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 from tqdm.auto import tqdm
 
+import paddle
+import paddle.distributed as dist
+from paddle.distributed.fleet import fleet
+
+from paddlenlp.transformers.moe_gate import PretrainedMoEGate
 from paddlenlp.transformers.moe_utils import offload, reload
 from paddlenlp.utils.log import logger
 
@@ -44,6 +49,7 @@ __all__ = [
     "EarlyStoppingCallback",
     "StepFlexToken",
     "FP8QuantWeightCallback",
+    "MoECorrectionBiasAdjustCallback",
 ]
 
 
@@ -671,3 +677,55 @@ class FP8QuantWeightCallback(TrainerCallback):
         if (not g_shard_bypass_dygraph_optimizer) and hasattr(model, "fp8_quant_weight"):
             for name in self.moe_weights_name:
                 reload(optimizer._master_weights[name])
+
+
+class MoECorrectionBiasAdjustCallback(TrainerCallback):
+    """used for moe aux loss free balance"""
+
+    def __init__(self, lr=0.001, use_mp=False):
+        super().__init__()
+        self.update_lr = lr
+        self.use_mp = use_mp
+
+    def on_optimizer_end(self, args, state, control, **kwargs):
+        model = kwargs["model"]
+
+        biases = []
+        usages = []
+
+        def get_stat(layer):
+            if isinstance(layer, PretrainedMoEGate) and layer.topk_method == "noaux_tc":
+                biases.append(layer.e_score_correction_bias)
+                usages.append(layer.expert_usage)
+
+        model.apply(get_stat)
+
+        usages_tensor = paddle.stack(usages, 0)  # [num_layers, num_experts]
+        if not hasattr(fleet, "_hcg"):
+            dist.all_reduce(usages_tensor)
+            return
+
+        hcg = fleet.get_hybrid_communicate_group()
+        mp_group = hcg.get_model_parallel_group()
+        dp_group = hcg.get_data_parallel_group()
+        sd_group = hcg.get_sharding_parallel_group()
+
+        if self.use_mp and mp_group.nranks > 1:
+            dist.all_reduce(usages_tensor, group=mp_group)
+        if dp_group.nranks > 1:
+            dist.all_reduce(usages_tensor, group=dp_group)
+        if sd_group.nranks > 1:
+            dist.all_reduce(usages_tensor, group=sd_group)
+
+        usages_mean = usages_tensor.mean(-1, keepdim=True)
+        update = paddle.sign(usages_mean - usages_tensor) * self.update_lr
+        update_list = list(update)
+
+        def update_bias(layer):
+            if isinstance(layer, PretrainedMoEGate) and layer.topk_method == "noaux_tc":
+                with paddle.no_grad():
+                    if not layer.weight.stop_gradient:
+                        biases.pop(0).add_(update_list.pop(0))
+                    usages.pop(0).zero_()
+
+        model.apply(update_bias)

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -925,6 +925,11 @@ class MoEGate(PretrainedMoEGate):
                 default_initializer=nn.initializer.Constant(0.0),
             )
             self.e_score_correction_bias.is_distributed = True
+            self.expert_usage = paddle.zeros(
+                shape=[num_experts],
+                dtype=paddle.int64,
+            )
+            self.expert_usage.stop_gradient = True
 
         if self.using_post_norm_recompute:
             assert norm_weight is not None and norm_eps is not None
@@ -970,6 +975,8 @@ class MoEGate(PretrainedMoEGate):
             scores, routing_map, exp_counts, l_aux, l_zloss = self.topkgating_nodrop(
                 scores
             )  # (scores, routing_map, exp_counts, l_aux, l_zloss)
+            with paddle.no_grad():
+                self.expert_usage += exp_counts
             ret = (scores, routing_map, l_aux, l_zloss)
         else:
             ret = self.topkgating(scores)  # (capacity, combine_weights, dispatch_mask, exp_counts, l_aux, l_zloss)

--- a/paddlenlp/transformers/moe_gate.py
+++ b/paddlenlp/transformers/moe_gate.py
@@ -301,7 +301,7 @@ class PretrainedMoEGate(nn.Layer, MoEGateMixin):
         assert n_experts % n_group == 0, "n_experts must be divisible by n_groups"
 
         assert self.e_score_correction_bias is not None, "e_score_correction_bias is None"
-        scores_for_choice = scores.reshape([bsz_seq_len, -1]) + self.e_score_correction_bias.unsqueeze(0)
+        scores_for_choice = scores.reshape([bsz_seq_len, -1]) + self.e_score_correction_bias.detach().unsqueeze(0)
         reshape_tmp_rst = scores_for_choice.reshape([bsz_seq_len, self.n_group, -1])
         top_k = min(reshape_tmp_rst.shape[2], 2)
         group_scores = reshape_tmp_rst.topk(top_k, axis=-1)[0].sum(axis=-1)  # fmt:skip [n, n_group]


### PR DESCRIPTION
### PR types
New features

### PR changes
Models

### Description
实现了 DeepseekV3 论文所述的 <b>Auxiliary-Loss-Free Load Balancing</b> 机制

该机制在 MoE gating score 上增加了一个统计性的 expert-wise bias，对于一个 expert，若它在上个 batch 中访问量高于平均，则减少它的 bias，反之增加它的 bias，以此实现负载均衡

<img width="1127" height="529" alt="截屏2025-09-17 09 26 28" src="https://github.com/user-attachments/assets/92fc3901-6151-4ae6-a68a-5a12efcac76f" />
由于该 bias 是统计性的，不需要梯度，因此我在代码中添加了必要的 no_grad 和 detach 进行修饰

参数 alpha 和 gamma 已根据论文设置如下：

<img width="1127" height="135" alt="截屏2025-09-17 15 36 50" src="https://github.com/user-attachments/assets/993b1f75-af02-45ab-82ce-3771c627d684" />


### 实验效果

通过 log 确认，bias 确实按预期在更新，高于平均的 expert 会减小 bias，低于平均的 expert 会增加 bias

使用<b>【PP4EP8 29层32专家】</b>配置进行冷启的访问量热力图：
<img width="2879" height="512" alt="图片 3" src="https://github.com/user-attachments/assets/0df6c5c8-88ed-44e0-a9b6-8af0c4434037" />
可以看到，Aux-Free-Loss 在 300 step 开始就进入了一种非常均衡的状态，而默认 loss 一直有比较严重的均衡问题

使用<b>【PP4EP8 29层64专家】</b>配置进行热启的访问量热力图：

<img width="3752" height="804" alt="output" src="https://github.com/user-attachments/assets/81429620-09e1-4f11-b6d5-1072acfc575a" />

由于热启的权重已经经过训练，因此不均衡阶段应当比较短，Aux-Free-Loss 基本 100 step 就进入了均衡状态，而默认 loss 的均衡性则越来越差，然后很快因为 OOM 而终止
<br>

### 代码规范

由于 bias 不是通过梯度更新的，不能走 optimizer，因此我使用了 Callback 的方式来实现更新

我新增的 MoECorrectionBiasAdjustCallback 考虑了通用性，并不局限于 DSV3 模型，任何 MoE 模型只要用了 topk_method == "noaux_tc" 的方式都可以用

根据 DSV3 论文，bias 的 lr 在前 14.3T 个 token 为 0.001，之后则为 0.0，这里我不那么严谨地将其固定为 0.001，如果用户真的需要训练超过 14.3T 个 token，再由用户自己来调整