### PR TITLE
Fix post_process_backward calc stream wait

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling_pp.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_pp.py
@@ -766,6 +766,9 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         return inputs
 
     def post_process_backward(self, output_grad, event_to_wait=None):
+        if event_to_wait is not None:
+            event_to_wait.calc_stream_wait(self.moe_group.id)
+
         grad = self.post_process_node.backward(output_grad)
 
         if self.using_post_norm_recompute:


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
在 post_process_backward 中让计算流也等待 event_to_wait，避免计算流先于 backward send/recv 执行

问题的根源如下面的红色箭头所示，从 PP(B) 到 POST(B) 的这条数据依赖居然没有任何 event wait 来约束
<img width="2047" height="306" alt="图片 3" src="https://github.com/user-attachments/assets/544db812-6b4c-41e0-a7fe-85e6301c3e12" />
之前能跑过实属神奇，可能是之前 PP(B) 都比 ATTN(F) 短，避免了 POST(B) 先于 PP(B) 执行；最近不知道改了什么，导致每个 step 总会出现一次 PP(B) 比较长的情况，导致开启 overlap_p2p_comm 时收敛又出问题了

#### 副作用分析
event_to_wait 有两种来源：（1) 如果前面有 send/recv，则它是 PP(B) 结束的 event；(2) 如果前面没有 send/recv，则它是前一个chunk 的 ATTN(B) 结束的 event。
对于情况 (1)，显然我们必须等待，所以不存在副作用一说；
对于情况 (2)，由于当前 chunk 的 ATTN(F) 一定晚于前一个 chunk 的 ATTN(B)，因此这个 event_to_wait 不会产生作用；
另外，dense overlap 节点用的是取自计算流的 event_to_wait，backward 阶段没有 event_to_wait，因此都不影响；
总之，本 PR 的修改不会对性能产生副作用

#### 收敛实验
下面用 PP4 EP2 做了收敛实验，可以发现本 PR 修复后开启 overlap_p2p_comm 与不开启的 loss 下降曲线基本重合，而不修的话 loss 就会下降得较慢，且始终无法下降到 7.3
<img width="1356" height="570" alt="图片 1" src="https://github.com/user-attachments/assets/b9dfa103-a92a-4527-b9e2-1ed04db5c64d" />