### PR TITLE
Fix FusedRMSLinear backward compute

### DIFF
--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -1922,9 +1922,10 @@ class FusedRMSLinearFunc(paddle.autograd.PyLayer):
                 quant_method="1x128",
                 input_transpose=True,
             )
-            FP8LinearFunctionBase.compute_fp8_linear(
-                (d_q_fp8, d_q_scale), q_down_weight, weight_transpose=False, out=h_grad.view([-1, h_grad.shape[-1]])
+            h_grad_0 = FP8LinearFunctionBase.compute_fp8_linear(
+                (d_q_fp8, d_q_scale), q_down_weight, weight_transpose=False
             )
+            h_grad = h_grad + h_grad_0
 
             def q_down_weight_grad(h_t_fp8, h_t_scale, d_q_t_fp8, d_q_t_scale, q_down_weight):
                 FP8LinearFunctionBase.kitchen_gemm(


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
修复 FusedRMSLinear backward 里的一处计算逻辑错误

因为 compute_fp8_linear 函数的 out 没有累加语义，是直接覆盖的，因此 h_grad 不能原地传入，应该在外面进行累加

#### 收敛性验证
使用单机冷启进行验证，统计 loss 和全局梯度方差（检验是否梯度爆炸，一般应小于10）在 200 步内的变化：

<img width="2102" height="577" alt="图片 3" src="https://github.com/user-attachments/assets/afd9a145-52ec-451a-9176-50932f652026" />

其实好像修不修没区别…… loss几乎一样，全局梯度方差则是修了之后稍微大一点，因为把之前丢掉的一部分梯度加回来了，但是并没有影响到 loss 收敛

总之，说明被覆盖的这部分 h_grad 可能不是那么重要，但是逻辑上确实应该改