### PR TITLE
Fix empty usage error of aux-loss-free

### DIFF
--- a/paddlenlp/trainer/trainer_callback.py
+++ b/paddlenlp/trainer/trainer_callback.py
@@ -700,6 +700,9 @@ class MoECorrectionBiasAdjustCallback(TrainerCallback):
 
         model.apply(get_stat)
 
+        if not usages:
+            return
+
         usages_tensor = paddle.stack(usages, 0)  # [num_layers, num_experts]
         if not hasattr(fleet, "_hcg"):
             dist.all_reduce(usages_tensor)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
修复 AuxLossFree 在 usage 为空时报错的问题

这个错误发生在每个 pp stage 只放1或2层 decoder 的情况下，例如 PP=4 layers=13，这样某些 pp stage 就会完全没有 MoE 层，导致 usage 为空
