### PR TITLE
Feat: support chatglm v2 faster infer in p800

### DIFF
--- a/paddlenlp/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/transformers/chatglm_v2/modeling.py
@@ -405,23 +405,13 @@ class SelfAttention(nn.Layer):
 
         multiplier = self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition
 
-        key_layer = key_layer.unsqueeze(-2).tile([1, 1, 1, multiplier, 1])
-        key_layer = key_layer.reshape(
-            key_layer.shape[:2] + [self.num_attention_heads_per_partition, self.hidden_size_per_attention_head]
-        )
-        value_layer = value_layer.unsqueeze(-2).tile([1, 1, 1, multiplier, 1])
-        value_layer = value_layer.reshape(
-            value_layer.shape[:2] + [self.num_attention_heads_per_partition, self.hidden_size_per_attention_head]
-        )
-
-        B, S, G, D = key_layer.shape
+        S, B, G, D = key_layer.shape
         key_layer = key_layer.unsqueeze(-2)
-        key_layer = key_layer.expand(B, S, G, multiplier, D)
-        key_layer = key_layer.reshape(B, S, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        key_layer = key_layer.expand(S, B, G, multiplier, D)
+        key_layer = key_layer.reshape( S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
         value_layer = value_layer.unsqueeze(-2)
-        value_layer = value_layer.expand(B, S, G, multiplier, D)
-        value_layer = value_layer.reshape(B, S, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
-
+        value_layer = value_layer.expand(S, B, G, multiplier, D)
+        value_layer = value_layer.reshape(S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
 
         # ==================================
         # core attention computation

--- a/paddlenlp/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/transformers/chatglm_v2/modeling.py
@@ -414,6 +414,15 @@ class SelfAttention(nn.Layer):
             value_layer.shape[:2] + [self.num_attention_heads_per_partition, self.hidden_size_per_attention_head]
         )
 
+        B, S, G, D = key_layer.shape
+        key_layer = key_layer.unsqueeze(-2)
+        key_layer = key_layer.expand(B, S, G, multiplier, D)
+        key_layer = key_layer.reshape(B, S, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        value_layer = value_layer.unsqueeze(-2)
+        value_layer = value_layer.expand(B, S, G, multiplier, D)
+        value_layer = value_layer.reshape(B, S, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+
+
         # ==================================
         # core attention computation
         # ==================================

--- a/paddlenlp/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/transformers/chatglm_v2/modeling.py
@@ -408,10 +408,14 @@ class SelfAttention(nn.Layer):
         S, B, G, D = key_layer.shape
         key_layer = key_layer.unsqueeze(-2)
         key_layer = key_layer.expand(S, B, G, multiplier, D)
-        key_layer = key_layer.reshape( S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        key_layer = key_layer.reshape(
+            S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head
+        )
         value_layer = value_layer.unsqueeze(-2)
         value_layer = value_layer.expand(S, B, G, multiplier, D)
-        value_layer = value_layer.reshape(S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        value_layer = value_layer.reshape(
+            S, B, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head
+        )
 
         # ==================================
         # core attention computation


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
在昆仑芯P800运行过程中，float16的tile操作会使得昆仑芯P800运行效率低下，将其更改为expand操作解决该问题

<img width="1290" height="36" alt="截屏2025-09-25 23 55 01" src="https://github.com/user-attachments/assets/c265ee38-144f-4923-bd58-1a91f56acf60" />

#### 运行单元效率对比
```
import paddle
import time

paddle.set_device('xpu')
num_attention_heads_per_partition = 32
num_multi_query_groups_per_partition = 2
hidden_size_per_attention_head = 128
multiplier = num_attention_heads_per_partition // num_multi_query_groups_per_partition

B, S, G, D = 27, 1, num_multi_query_groups_per_partition, hidden_size_per_attention_head
key_layer_in = paddle.randn(B, S, G, D, dtype='float16')
value_layer_in = paddle.randn(B, S, G, D, dtype='float16')
# -------- type1 (tile+reshape) --------
key_layer = key_layer_in.clone()
value_layer = value_layer_in.clone()

start = time.time()
key_layer = key_layer.unsqueeze(-2).tile([1, 1, 1, multiplier, 1])
key_layer = key_layer.reshape(
    key_layer.shape[:2] + [num_attention_heads_per_partition, hidden_size_per_attention_head]
)
value_layer = value_layer.unsqueeze(-2).tile([1, 1, 1, multiplier, 1])
value_layer = value_layer.reshape(
    value_layer.shape[:2] + [num_attention_heads_per_partition, hidden_size_per_attention_head]
)
end = time.time()
print(f"type1 cost time: {end - start:.6f}s")
print("type1 key_layer shape:", key_layer.shape)

# -------- type2 (expand+reshape) --------
key_layer = key_layer_in.clone()
value_layer = value_layer_in.clone()

start = time.time()
key_layer = key_layer.unsqueeze(-2).expand(B, S, G, multiplier, D)
key_layer = key_layer.reshape(B, S, num_attention_heads_per_partition, hidden_size_per_attention_head)
value_layer = value_layer.unsqueeze(-2).expand(B, S, G, multiplier, D)
value_layer = value_layer.reshape(B, S, num_attention_heads_per_partition, hidden_size_per_attention_head)
end = time.time()
print(f"type2 cost time: {end - start:.6f}s")
```
<img width="1491" height="129" alt="截屏2025-09-25 23 58 45" src="https://github.com/user-attachments/assets/aeaef9e1-de63-49ee-8b18-a577877339d3" />
