### PR TITLE
fix: replace 207 bare except clauses with except Exception

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -127,7 +127,7 @@ def extract_tar(app, config):
 
         with tarfile.open(fileobj=file_stream, mode="r") as tar:
             tar.extractall("_static/")
-    except:
+    except Exception:
         pass
 
 

--- a/llm/alignment/rl/run_rl.py
+++ b/llm/alignment/rl/run_rl.py
@@ -374,7 +374,7 @@ def main():
 
     try:
         generation_config = GenerationConfig.from_pretrained(model_args.actor_model_name_or_path)
-    except:
+    except Exception:
         logger.warning("Can't find generation config, so it will not use generation_config field in the model config")
         generation_config = None
 

--- a/llm/alignment/rm/reward_model.py
+++ b/llm/alignment/rm/reward_model.py
@@ -22,7 +22,7 @@ from paddle import nn
 
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import GatherOp
-except:
+except Exception:
     pass
 
 import paddlenlp

--- a/llm/application/distill/grader.py
+++ b/llm/application/distill/grader.py
@@ -55,14 +55,14 @@ def parse_digits(num):
     num = regex.sub(",", "", str(num))
     try:
         return float(num)
-    except:
+    except Exception:
         if num.endswith("%"):
             num = num[:-1]
             if num.endswith("\\"):
                 num = num[:-1]
             try:
                 return float(num) / 100
-            except:
+            except Exception:
                 pass
     return None
 
@@ -125,7 +125,7 @@ def math_equal(
                 except Exception:
                     continue
             return False
-    except:
+    except Exception:
         pass
 
     if not prediction and prediction not in [0, False]:
@@ -252,10 +252,10 @@ def symbolic_equal(a, b):
         for f in [parse_latex, parse_expr, latex2sympy]:
             try:
                 return f(s.replace("\\\\", "\\"))
-            except:
+            except Exception:
                 try:
                     return f(s)
-                except:
+                except Exception:
                     pass
         return s
 
@@ -266,27 +266,27 @@ def symbolic_equal(a, b):
     try:
         if str(a) == str(b) or a == b:
             return True
-    except:
+    except Exception:
         pass
 
     # simplify equal
     try:
         if a.equals(b) or simplify(a - b) == 0:
             return True
-    except:
+    except Exception:
         pass
 
     # equation equal
     try:
         if (abs(a.lhs - a.rhs)).equals(abs(b.lhs - b.rhs)):
             return True
-    except:
+    except Exception:
         pass
 
     try:
         if numeric_equal(float(N(a)), float(N(b))):
             return True
-    except:
+    except Exception:
         pass
 
     # matrix
@@ -297,7 +297,7 @@ def symbolic_equal(a, b):
             _b = b.applyfunc(lambda x: round(x, 3))
             if _a.equals(_b):
                 return True
-    except:
+    except Exception:
         pass
 
     return False

--- a/llm/benchmark/serving/benchmark_client.py
+++ b/llm/benchmark/serving/benchmark_client.py
@@ -27,7 +27,7 @@ def infer(
     while not req_que.empty():
         try:
             prompt, input_seqlen, output_seqlen = req_que.get(timeout=10.0)
-        except:
+        except Exception:
             continue
 
         start = time.time()
@@ -102,7 +102,7 @@ def infer(
                 token_num = eval(
                     res_text.split("previous_num_tokens:")[-1].split("data: [DONE]")[0]
                 )
-            except:
+            except Exception:
                 token_num = len(chunks)
         elif backend == "paddle":
             token_num = 0

--- a/llm/experimental/ernie-3.5-se/data.py
+++ b/llm/experimental/ernie-3.5-se/data.py
@@ -54,7 +54,7 @@ def convert_example(example, tokenizer, data_args, is_test=False):
         question = example["question"]
         try:
             answer = example["answers"][0]
-        except:
+        except Exception:
             print(example["context"])
             print(example["question"])
             print(example["answers"])

--- a/llm/experimental/ernie-3.5-se/ernie_dataset.py
+++ b/llm/experimental/ernie-3.5-se/ernie_dataset.py
@@ -177,7 +177,7 @@ class BlendableDataset(paddle.io.Dataset):
 
             try:
                 hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
-            except:
+            except Exception:
                 hcg = FakeHCG()
 
             counts = paddle.to_tensor([cache_success], dtype="int64")
@@ -816,7 +816,7 @@ def _build_index_mappings(
 
     try:
         hcg = fleet.get_hybrid_communicate_group()
-    except:
+    except Exception:
         hcg = FakeHCG()
 
     counts = paddle.to_tensor([data_cache_success], dtype="int64")

--- a/llm/experimental/ernie-3.5-se/modeling.py
+++ b/llm/experimental/ernie-3.5-se/modeling.py
@@ -47,7 +47,7 @@ try:
     from paddle.nn.functional.flash_attention import flash_attention
 
     logger.warning("Use flash attention in scaled-dot-product. Attention mask is deprecated")
-except:
+except Exception:
     flash_attention = None
 
 try:

--- a/llm/predict/predictor.py
+++ b/llm/predict/predictor.py
@@ -36,7 +36,7 @@ try:
         InferenceWithReferenceProposer,
         SpeculateArgument,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.generation import GenerationConfig, TextIteratorStreamer
@@ -268,7 +268,7 @@ class BasePredictor:
 
         try:
             self.generation_config = GenerationConfig.from_pretrained(config.model_name_or_path)
-        except:
+        except Exception:
             logger.warning(
                 "Can't find generation config, so it will not use generation_config field in the model config"
             )

--- a/llm/run_pretrain.py
+++ b/llm/run_pretrain.py
@@ -485,7 +485,7 @@ def main():
                 from utils.register_reshard import register_pp_reshard_information
 
                 register_pp_reshard_information(config.num_hidden_layers)
-            except:
+            except Exception:
                 print("Not register llama pp reshard information.")
 
     architectures_to_check = {"Qwen2Moe", "DeepseekV2", "DeepseekV3"}

--- a/llm/server/server/server/engine/config.py
+++ b/llm/server/server/server/engine/config.py
@@ -127,7 +127,7 @@ class Config:
         # Generation config
         try:
             self.generation_config = GenerationConfig.from_pretrained(self.model_dir)
-        except:
+        except Exception:
             model_server_logger.warning(
                 "Can't find generation config, so it will not use generation_config field in the model config"
             )

--- a/llm/server/server/server/engine/engine.py
+++ b/llm/server/server/server/engine/engine.py
@@ -279,7 +279,7 @@ class Engine(object):
             self.shm_flag_ready.unlink()
             self.shm_flag_has_block_step.close()
             self.shm_flag_has_block_step.unlink()
-        except:
+        except Exception:
             pass
 
     def _init_engine_flags(self):
@@ -293,7 +293,7 @@ class Engine(object):
             )
             tmp.close()
             tmp.unlink()
-        except:
+        except Exception:
             pass
         self.shm_flag_ready = shared_memory.SharedMemory(
             create=True, size=flag_array.nbytes, name=self.cfg.get_unique_name("shm_flag_infer_ready")
@@ -311,7 +311,7 @@ class Engine(object):
             )
             tmp.close()
             tmp.unlink()
-        except:
+        except Exception:
             pass
         self.shm_flag_broadcast = shared_memory.SharedMemory(
             create=True, size=broadcast_flag_array.nbytes, name=self.cfg.get_unique_name("shm_pd_infer_flag_broadcast")
@@ -332,7 +332,7 @@ class Engine(object):
             )
             tmp.close()
             tmp.unlink()
-        except:
+        except Exception:
             pass
         self.shm_flag_has_block_step = shared_memory.SharedMemory(
             create=True,

--- a/llm/server/server/server/triton_server.py
+++ b/llm/server/server/server/triton_server.py
@@ -34,7 +34,7 @@ import server
 
 try:
     import triton_python_backend_utils as pb_utils
-except:
+except Exception:
     model_server_logger.warning(
         "TritonPythonModel is only available under triton inference server framework."
     )

--- a/llm/tools/merge_lora_params.py
+++ b/llm/tools/merge_lora_params.py
@@ -25,7 +25,7 @@ try:
     from paddlenlp.quantization.qlora import qlora_weight_quantize_dequantize
     from paddlenlp.quantization.quantization_config import QuantizationConfig
     from paddlenlp.quantization.quantization_linear import QuantizationLinear
-except:
+except Exception:
     pass
 
 from paddlenlp.trainer.argparser import strtobool
@@ -159,7 +159,7 @@ def merge_old_lora(lora_config, args):
     try:
         model.merge()
         model.eval()
-    except:
+    except Exception:
         model.eval()
     model_state_dict = model.model.state_dict()
     for key in list(model_state_dict):
@@ -172,7 +172,7 @@ def read_file(file_name):
     if file_name.endswith("safetensors"):
         try:
             from paddlenlp.utils.safetensors import fast_load_file as load_file
-        except:
+        except Exception:
             from safetensors.numpy import load_file
 
         read_tensors = load_file(file_name)

--- a/ops/csrc/fp8/setup.py
+++ b/ops/csrc/fp8/setup.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     try:
         cmd = ["git", "rev-parse", "--short", "HEAD"]
         revision = "+" + subprocess.check_output(cmd).decode("ascii").rstrip()
-    except:
+    except Exception:
         revision = ""
 
     setuptools.setup(

--- a/paddlenlp/data/causal_dataset.py
+++ b/paddlenlp/data/causal_dataset.py
@@ -588,7 +588,7 @@ def _build_index_mappings(
                     time.sleep(3)
     # try:
     #     hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
-    # except:
+    # except Exception:
     #     hcg = FakeHCG()
 
     # counts = paddle.to_tensor([data_cache_success], dtype="int64")

--- a/paddlenlp/experimental/model_utils.py
+++ b/paddlenlp/experimental/model_utils.py
@@ -479,7 +479,7 @@ def get_dequant_weight(w, w_s=None, dtype=None, weight_block_size=[128, 128]):
         from paddlenlp_ops import (
             cutlass_fp8_fp8_half_block_gemm_fused as fp8_block_gemm_fused,
         )
-    except:
+    except Exception:
         assert False, "fp8_block_gemm_fused only supported on sm90"
 
     eye = paddle.eye(w.shape[0], dtype=paddle.float32)

--- a/paddlenlp/experimental/transformers/bloom/modeling.py
+++ b/paddlenlp/experimental/transformers/bloom/modeling.py
@@ -56,7 +56,7 @@ def parallel_matmul(x: Tensor, y: Tensor, parallel_output=True):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         world_size = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
     if is_fleet_init and world_size > 1:
         # if not running under distributed.launch, it will raise AttributeError: 'Fleet' object has no attribute '_hcg'
@@ -116,7 +116,7 @@ class BloomModelInferenceModel(BloomPreTrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         # Transformer blocks

--- a/paddlenlp/experimental/transformers/chatglm/modeling.py
+++ b/paddlenlp/experimental/transformers/chatglm/modeling.py
@@ -168,7 +168,7 @@ class ChatGLMStackDyBatch(nn.Layer):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         self.input_layernorm = nn.LayerNorm(config.hidden_size, epsilon=config.layernorm_epsilon)

--- a/paddlenlp/experimental/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/experimental/transformers/deepseek_v2/modeling.py
@@ -331,7 +331,7 @@ class DeepseekV2BlockInferenceModel(DeepseekV2PretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         ln_scale_attrs = [
@@ -1382,7 +1382,7 @@ class DeepseekV2BlockInferenceModelXPU(DeepseekV2BlockInferenceModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         ln_scale_attrs = [

--- a/paddlenlp/experimental/transformers/fused_transformer_layers.py
+++ b/paddlenlp/experimental/transformers/fused_transformer_layers.py
@@ -73,7 +73,7 @@ if paddle.is_compiled_with_cuda():
             transpose_remove_padding,
             write_cache_kv,
         )
-    except:
+    except Exception:
         pass
 
 __all__ = [
@@ -666,7 +666,7 @@ class FusedMultiTransformerBase(Layer):
         if use_custom_allreduce():
             try:
                 from paddlenlp.ops.custom_all_reduce import custom_all_reduce
-            except:
+            except Exception:
                 assert False, "please install paddlenlp.ops"
             self.custom_all_reduce_max_bytes = 1024 * self.embed_dim
             from paddle.distributed import fleet
@@ -6090,7 +6090,7 @@ class FusedBlockMultiTransformerFP8DynamicQuant(FusedBlockMultiTransformer):
                 from paddlenlp_ops import (
                     cutlass_fp8_fp8_half_gemm_ptr_scale_fused as fp8_gemm_fused_ptr_scale,
                 )
-            except:
+            except Exception:
                 assert False, "fp8_gemm_fused_ptr_scale only supported on sm90"
             if ffn1:
                 n, k = y.shape
@@ -6137,7 +6137,7 @@ class FusedBlockMultiTransformerFP8DynamicQuant(FusedBlockMultiTransformer):
                 from paddlenlp_ops import (
                     cutlass_fp8_fp8_half_block_gemm_fused as fp8_block_gemm_fused,
                 )
-            except:
+            except Exception:
                 assert False, "fp8_block_gemm_fused only supported on sm90"
             out = fp8_block_gemm_fused(
                 x,

--- a/paddlenlp/experimental/transformers/gpt/modeling.py
+++ b/paddlenlp/experimental/transformers/gpt/modeling.py
@@ -82,7 +82,7 @@ class GPTInferenceModel(GPTPretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         ln_scale_attrs = [

--- a/paddlenlp/experimental/transformers/llama/modeling.py
+++ b/paddlenlp/experimental/transformers/llama/modeling.py
@@ -450,7 +450,7 @@ class LlamaInferenceModel(LlamaPretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         qkv_weight_scale_attrs = None

--- a/paddlenlp/experimental/transformers/mistral/modeling.py
+++ b/paddlenlp/experimental/transformers/mistral/modeling.py
@@ -153,7 +153,7 @@ class MistralInferenceModel(MistralPreTrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         qkv_weight_scale_attrs = None

--- a/paddlenlp/experimental/transformers/mixtral/modeling.py
+++ b/paddlenlp/experimental/transformers/mixtral/modeling.py
@@ -150,7 +150,7 @@ class MixtralInferenceModel(MixtralPretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         ln_scale_attrs = [paddle.ParamAttr(name="fusemixtral.{}.ln_scale".format(i)) for i in range(self.num_layers)]

--- a/paddlenlp/experimental/transformers/qwen2/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen2/modeling.py
@@ -148,7 +148,7 @@ class Qwen2InferenceModel(Qwen2PretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         qkv_weight_scale_attrs = None

--- a/paddlenlp/experimental/transformers/qwen2_moe/modeling.py
+++ b/paddlenlp/experimental/transformers/qwen2_moe/modeling.py
@@ -125,7 +125,7 @@ class Qwen2MoeInferenceModel(Qwen2MoePretrainedModel):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
 
         ln_scale_attrs = [paddle.ParamAttr(name="fuseqwen2_moe.{}.ln_scale".format(i)) for i in range(self.num_layers)]

--- a/paddlenlp/generation/utils.py
+++ b/paddlenlp/generation/utils.py
@@ -1230,7 +1230,7 @@ class GenerationMixin(object):
                     hcg = fleet.get_hybrid_communicate_group()
                     group = hcg.get_model_parallel_group()
                     src = hcg.get_model_parallel_group_src_rank()
-                except:
+                except Exception:
                     group, src = None, 0
                 paddle.distributed.broadcast(next_tokens, src=src, group=group)
             # config does not include pipeline_parallel_degree, and pipeline parallel

--- a/paddlenlp/ops/triton_ops/__init__.py
+++ b/paddlenlp/ops/triton_ops/__init__.py
@@ -20,5 +20,5 @@ try:
     from .segment_mean import segment_mean
 
     __all__ = +["per_token_group_quant_fp8_api_masked", "per_token_group_quant_fp8_api"]
-except:
+except Exception:
     pass

--- a/paddlenlp/peft/lora/lora_layers.py
+++ b/paddlenlp/peft/lora/lora_layers.py
@@ -35,7 +35,7 @@ try:
         ReduceScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     AllGatherOp = None
     ReduceScatterOp = None
     mark_as_sequence_parallel_parameter = None

--- a/paddlenlp/peft/lora/loraga_utils.py
+++ b/paddlenlp/peft/lora/loraga_utils.py
@@ -20,7 +20,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         register_sequence_parallel_allreduce_hooks,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.peft import LoRAModel
@@ -175,7 +175,7 @@ def get_module_gradient(
         model_parallel_group = hcg.get_model_parallel_group()
         sharding_parallel_group = hcg.get_sharding_parallel_group()
         data_parallel_group = hcg.get_data_parallel_group()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if tp_degree > 1:

--- a/paddlenlp/quantization/quantization_linear.py
+++ b/paddlenlp/quantization/quantization_linear.py
@@ -30,7 +30,7 @@ from .qat_utils import QATFunc
 
 try:
     from .qlora import qlora_weight_dequantize, qlora_weight_linear
-except:
+except Exception:
     qlora_weight_linear = None
     qlora_weight_dequantize = None
 

--- a/paddlenlp/quantization/quantization_utils.py
+++ b/paddlenlp/quantization/quantization_utils.py
@@ -29,7 +29,7 @@ from paddle.nn.quant import weight_quantize
 
 try:
     from .qlora import qlora_weight_linear, qlora_weight_quantize
-except:
+except Exception:
     qlora_weight_linear = None
     qlora_weight_quantize = None
 

--- a/paddlenlp/rl/models/ppo_model_utils.py
+++ b/paddlenlp/rl/models/ppo_model_utils.py
@@ -32,7 +32,7 @@ from paddle.distributed.fleet.meta_parallel import ParallelCrossEntropy
 
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import GatherOp
-except:
+except Exception:
     pass
 
 
@@ -330,7 +330,7 @@ class VocabParallelEntropy(paddle.autograd.PyLayer):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             tensor_parallel_degree = hcg.get_model_parallel_world_size()
-        except:
+        except Exception:
             tensor_parallel_degree = 1
         logits_max = vocab_parallel_logits.max(axis=-1, keepdim=True)
 

--- a/paddlenlp/rl/models/score_model_utils.py
+++ b/paddlenlp/rl/models/score_model_utils.py
@@ -162,7 +162,7 @@ class ScoreModelMixin:
                     hcg = dist.fleet.get_hybrid_communicate_group()
                     group = hcg.get_sharding_parallel_group()
                     dist.all_gather(gathered_end_score_list, end_score, group)
-                except:
+                except Exception:
                     dist.all_gather(gathered_end_score_list, end_score)
                 gathered_end_score = paddle.concat(gathered_end_score_list, axis=0)
                 self.normalizer.update(gathered_end_score)

--- a/paddlenlp/rl/trainer/ppo_trainer.py
+++ b/paddlenlp/rl/trainer/ppo_trainer.py
@@ -1221,7 +1221,7 @@ class PPOTrainer(RLTrainerBase):
             hcg = fleet.get_hybrid_communicate_group()
             sharding_parallel_group = hcg.get_sharding_parallel_group()
             data_parallel_group = hcg.get_data_parallel_group()
-        except:
+        except Exception:
             sharding_parallel_group = None
             data_parallel_group = None
 
@@ -1335,7 +1335,7 @@ class PPOTrainer(RLTrainerBase):
             hcg = fleet.get_hybrid_communicate_group()
             sharding_parallel_group = hcg.get_sharding_parallel_group()
             data_parallel_group = hcg.get_data_parallel_group()
-        except:
+        except Exception:
             is_fleet_init = False
             sharding_parallel_group = None
             data_parallel_group = None

--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -61,7 +61,7 @@ from .utils.helper import distributed_file, distributed_isfile  # nested_truncat
 
 try:
     from ..quantization.quantization_linear import QuantizationLinear
-except:
+except Exception:
     QuantizationLinear = None
 
 MODEL_NAME = "model"

--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -46,12 +46,12 @@ from paddle.distributed.fleet.meta_parallel import PipelineLayer
 
 try:
     from paddle.distributed.fleet.meta_parallel import PipelineDatasetPreprocessor
-except:
+except Exception:
     PipelineDatasetPreprocessor = None
 
 try:
     from paddle.base import core
-except:
+except Exception:
     core = None
 from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
@@ -67,12 +67,12 @@ try:
     )
 
     _obtain_optimizer_parameters_list = obtain_optimizer_parameters_list
-except:
+except Exception:
     try:
         from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
             _obtain_optimizer_parameters_list,
         )
-    except:
+    except Exception:
         _obtain_optimizer_parameters_list = None
 
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
@@ -106,7 +106,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         register_sequence_parallel_allreduce_hooks,
     )
-except:
+except Exception:
     pass
 
 from ..transformers.context_parallel_utils import split_inputs_sequence_dim_load_balance
@@ -227,17 +227,17 @@ if is_datasets_available():
 
 try:
     from paddle.distributed.fleet.utils import mix_precision_utils
-except:
+except Exception:
     mix_precision_utils = None
 
 try:
     from paddle.io.dataloader.dataloader_iter import _DataLoaderIterBase
-except:
+except Exception:
     from paddle.fluid.dataloader.dataloader_iter import _DataLoaderIterBase
 
 try:
     from paddle.distributed import in_auto_parallel_align_mode
-except:
+except Exception:
 
     def in_auto_parallel_align_mode():
         """
@@ -2461,7 +2461,7 @@ class Trainer:
                     fleet.meta_parallel.get_rng_state_tracker().set_states_tracker(
                         checkpoint_rng_state["hybrid_parallel_rng_state_tracker"]
                     )
-                except:
+                except Exception:
                     logger.warning(
                         "Hybrid parallel rng states change when training environment differs, so we dot not set state tracker here."
                     )

--- a/paddlenlp/trainer/training_args.py
+++ b/paddlenlp/trainer/training_args.py
@@ -1494,7 +1494,7 @@ class TrainingArguments:
                             logger.info("setting sync_moment")
                             strategy.hybrid_configs["mp_configs"].sync_moment = True
 
-                    except:
+                    except Exception:
                         warnings.warn(
                             "The enable_mp_async_allreduce, enable_mp_skip_c_identity and enable_mp_fused_linear_param_grad_add are not supported "
                             "by current version of Paddle. Please try latest develop Paddle."
@@ -1618,7 +1618,7 @@ class TrainingArguments:
                         ], "Only sharding stage1 supports to disable reduce_avg strategy."
                         try:
                             strategy.hybrid_configs["sharding_configs"].use_reduce_avg = False
-                        except:
+                        except Exception:
                             warnings.warn(
                                 "The reduce_avg strategy is not supported by current version of Paddle so you don't need to disable it. The nccl comm in sharding still use reduce_sum and scale of gradients."
                             )
@@ -1838,7 +1838,7 @@ class TrainingArguments:
                         mp_optimization.allreduce_matmul_grad_overlapping = True
                     if "replace_with_c_embedding" in mp_config:
                         mp_optimization.replace_with_c_embedding = True
-                except:
+                except Exception:
                     warnings.warn(
                         "The enable_mp_async_allreduce, replace_with_c_embedding, enable_mp_skip_c_identity and enable_mp_fused_linear_param_grad_add are not supported "
                         "by current version of Paddle. Please try latest develop Paddle."

--- a/paddlenlp/trainer/utils/helper.py
+++ b/paddlenlp/trainer/utils/helper.py
@@ -198,7 +198,7 @@ def broadcast_dp_optimizer(state_dict):
         # Don't broadcast optimizer for dp rank is 1.
         if dp_group.nranks <= 1:
             return state_dict
-    except:
+    except Exception:
         dp_group = None
         src_rank = 0
         process_rank = paddle.distributed.get_rank()
@@ -239,7 +239,7 @@ def broadcast_moe_optimizer(state_dict, model_state_dict=None, broadcast_dp=True
         # Don't broadcast optimizer for dp rank is 1.
         if dp_group.nranks <= 1:
             return state_dict
-    except:
+    except Exception:
         dp_group = None
         src_rank = 0
         data_parallel_rank = dist.get_rank()

--- a/paddlenlp/trainer/utils/reshard/common.py
+++ b/paddlenlp/trainer/utils/reshard/common.py
@@ -28,7 +28,7 @@ try:
     from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
         DygraphShardingOptimizerV2,
     )
-except:
+except Exception:
     DygraphShardingOptimizerV2 = None
 
 

--- a/paddlenlp/trainer/utils/reshard/sharding_v2.py
+++ b/paddlenlp/trainer/utils/reshard/sharding_v2.py
@@ -28,7 +28,7 @@ try:
     from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
         DygraphShardingOptimizerV2,
     )
-except:
+except Exception:
     DygraphShardingOptimizerV2 = None
 
 

--- a/paddlenlp/trainer/utils/sharding_io.py
+++ b/paddlenlp/trainer/utils/sharding_io.py
@@ -29,7 +29,7 @@ try:
     from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
         DygraphShardingOptimizerV2,
     )
-except:
+except Exception:
     DygraphShardingOptimizerV2 = None
 
 from paddlenlp.transformers.model_utils import (

--- a/paddlenlp/trainer/utils/zero_cost_checkpoint.py
+++ b/paddlenlp/trainer/utils/zero_cost_checkpoint.py
@@ -66,7 +66,7 @@ try:
     from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
         DygraphShardingOptimizerV2,
     )
-except:
+except Exception:
     DygraphShardingOptimizerV2 = None
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer import (
     DygraphShardingOptimizer,

--- a/paddlenlp/transformers/__init__.py
+++ b/paddlenlp/transformers/__init__.py
@@ -46,7 +46,7 @@ try:
         mark_as_sequence_parallel_parameter,
         register_sequence_parallel_allreduce_hooks,
     )
-except:
+except Exception:
     pass
 from .export import export_model
 

--- a/paddlenlp/transformers/auto/tokenizer.py
+++ b/paddlenlp/transformers/auto/tokenizer.py
@@ -367,7 +367,7 @@ class AutoTokenizer:
                 try:
                     if tokenizer_class is None:
                         tokenizer_class = getattr(import_class, init_class)
-                except:
+                except Exception:
                     raise ValueError(f"Tokenizer class {init_class} is not currently imported.")
                 return tokenizer_class
             else:

--- a/paddlenlp/transformers/bloom/modeling.py
+++ b/paddlenlp/transformers/bloom/modeling.py
@@ -63,7 +63,7 @@ def parallel_matmul(x: Tensor, y: Tensor, parallel_output=True):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         world_size = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
     if is_fleet_init and world_size > 1:
         # if not running under distributed.launch, it will raise AttributeError: 'Fleet' object has no attribute '_hcg'

--- a/paddlenlp/transformers/bloom/tokenizer.py
+++ b/paddlenlp/transformers/bloom/tokenizer.py
@@ -243,7 +243,7 @@ class BloomTokenizer(PretrainedTokenizer):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/paddlenlp/transformers/chatglm_v2/modeling.py
+++ b/paddlenlp/transformers/chatglm_v2/modeling.py
@@ -44,12 +44,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 
 __all__ = [
@@ -81,7 +81,7 @@ def parallel_matmul(x: Tensor, y: Tensor, tensor_parallel_output):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/chatglm_v2/modeling_pp.py
+++ b/paddlenlp/transformers/chatglm_v2/modeling_pp.py
@@ -17,7 +17,7 @@ from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
 
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import ScatterOp
-except:
+except Exception:
     pass
 
 from paddlenlp.transformers.model_utils import PipelinePretrainedModel

--- a/paddlenlp/transformers/deberta/tokenizer.py
+++ b/paddlenlp/transformers/deberta/tokenizer.py
@@ -214,7 +214,7 @@ class DebertaTokenizer(PretrainedTokenizer):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/paddlenlp/transformers/deepseek_v2/fp8_linear.py
+++ b/paddlenlp/transformers/deepseek_v2/fp8_linear.py
@@ -29,7 +29,7 @@ from ..linear_utils import RowSequenceParallelLinear as PD_RowSequenceParallelLi
 
 try:
     from .kernel import act_quant, fp8_gemm, weight_dequant
-except:
+except Exception:
     pass
 
 

--- a/paddlenlp/transformers/deepseek_v2/modeling.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling.py
@@ -48,12 +48,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 

--- a/paddlenlp/transformers/deepseek_v2/modeling_auto.py
+++ b/paddlenlp/transformers/deepseek_v2/modeling_auto.py
@@ -38,7 +38,7 @@ except ImportError:
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 from ...utils.log import logger

--- a/paddlenlp/transformers/deepseek_v3/modeling_auto.py
+++ b/paddlenlp/transformers/deepseek_v3/modeling_auto.py
@@ -33,7 +33,7 @@ except ImportError:
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 from ...utils.log import logger

--- a/paddlenlp/transformers/gemma/modeling.py
+++ b/paddlenlp/transformers/gemma/modeling.py
@@ -39,7 +39,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.transformers.conversion_utils import (
@@ -64,7 +64,7 @@ from .configuration import (
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 
@@ -164,7 +164,7 @@ def parallel_matmul(x: Tensor, y, tensor_parallel_output=True, transpose_y=False
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/gpt/modeling.py
+++ b/paddlenlp/transformers/gpt/modeling.py
@@ -37,7 +37,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 from paddle.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from paddle.utils import try_import
@@ -62,11 +62,11 @@ from .configuration import (
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 
 OriginLayerNorm = paddle.nn.LayerNorm
@@ -108,7 +108,7 @@ def parallel_matmul(x: paddle.Tensor, y: paddle.Tensor, transpose_y=True, tensor
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if is_fleet_init and tensor_parallel_degree > 1 and y.is_distributed:

--- a/paddlenlp/transformers/gpt/modeling_auto.py
+++ b/paddlenlp/transformers/gpt/modeling_auto.py
@@ -39,11 +39,11 @@ from .configuration import GPT_PRETRAINED_INIT_CONFIGURATION, GPTConfig
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 
 __all__ = [

--- a/paddlenlp/transformers/gpt/modeling_auto_pp.py
+++ b/paddlenlp/transformers/gpt/modeling_auto_pp.py
@@ -39,7 +39,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 __all__ = [

--- a/paddlenlp/transformers/gpt/modeling_network.py
+++ b/paddlenlp/transformers/gpt/modeling_network.py
@@ -33,7 +33,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from .. import PretrainedModel, register_base_model
@@ -42,11 +42,11 @@ from .configuration import GPT_PRETRAINED_INIT_CONFIGURATION, GPTConfig
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 
 __all__ = [

--- a/paddlenlp/transformers/gpt/modeling_pp.py
+++ b/paddlenlp/transformers/gpt/modeling_pp.py
@@ -22,13 +22,13 @@ from paddle.distributed.fleet.utils import recompute
 
 try:
     from paddle.distributed.fleet.meta_parallel import LocalSharedLayerDesc
-except:
+except Exception:
     LocalSharedLayerDesc = None
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.transformers.model_utils import PipelinePretrainedModel

--- a/paddlenlp/transformers/gpt/tokenizer.py
+++ b/paddlenlp/transformers/gpt/tokenizer.py
@@ -470,7 +470,7 @@ class GPTTokenizer(PretrainedTokenizer):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/paddlenlp/transformers/jamba/modeling.py
+++ b/paddlenlp/transformers/jamba/modeling.py
@@ -952,7 +952,7 @@ class JambaSparseMoeBlock(nn.Layer):
                         )
                         * routing_weights[0, 0]
                     )
-        except:
+        except Exception:
             pass
 
         # Loop over all available experts in the model and perform the computation on each expert.

--- a/paddlenlp/transformers/linear_utils.py
+++ b/paddlenlp/transformers/linear_utils.py
@@ -21,7 +21,7 @@ from paddle import nn
 
 try:
     from paddle.distributed.fleet.utils import sequence_parallel_utils
-except:
+except Exception:
     sequence_parallel_utils = None
 
 from paddlenlp.transformers.mc2_parallel_linear import (
@@ -45,7 +45,7 @@ __all__ = [
 try:
     ColumnSequenceParallelLinear = sequence_parallel_utils.ColumnSequenceParallelLinear
     RowSequenceParallelLinear = sequence_parallel_utils.RowSequenceParallelLinear
-except:
+except Exception:
 
     class ColumnSequenceParallelLinearPass(object):
         """

--- a/paddlenlp/transformers/llama/fusion_ops.py
+++ b/paddlenlp/transformers/llama/fusion_ops.py
@@ -48,7 +48,7 @@ try:
             if lib.endswith(".so"):
                 paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(lib)
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 from paddlenlp.transformers.refined_recompute import no_recompute

--- a/paddlenlp/transformers/llama/modeling.py
+++ b/paddlenlp/transformers/llama/modeling.py
@@ -64,7 +64,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.transformers.conversion_utils import (
@@ -97,7 +97,7 @@ try:
             if lib.endswith(".so"):
                 paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(lib)
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 from . import fusion_ops
 
@@ -194,7 +194,7 @@ def parallel_matmul(x: Tensor, y: Tensor, transpose_y=False, tensor_parallel_out
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/llama/modeling_auto.py
+++ b/paddlenlp/transformers/llama/modeling_auto.py
@@ -77,7 +77,7 @@ from .modeling import (
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 __all__ = [

--- a/paddlenlp/transformers/llama/modeling_auto_pp.py
+++ b/paddlenlp/transformers/llama/modeling_auto_pp.py
@@ -55,7 +55,7 @@ from .modeling_auto import LlamaDecoderLayerAuto, LlamaPretrainedModelAuto
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 __all__ = [

--- a/paddlenlp/transformers/llama/modeling_network.py
+++ b/paddlenlp/transformers/llama/modeling_network.py
@@ -69,7 +69,7 @@ from .modeling import (
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 __all__ = [

--- a/paddlenlp/transformers/long_sequence_strategies/long_sequence_strategies.py
+++ b/paddlenlp/transformers/long_sequence_strategies/long_sequence_strategies.py
@@ -56,7 +56,7 @@ class LongSequenceStrategies:
             )
         try:
             strategy_class = getattr(import_class, stratety_name)
-        except:
+        except Exception:
             all_strategy_classes = import_class.__all__
             raise LookupError(
                 f"module '{import_class.__name__}' only supports the following classes: "

--- a/paddlenlp/transformers/luke/tokenizer.py
+++ b/paddlenlp/transformers/luke/tokenizer.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Union
 
 try:
     import regex as re
-except:
+except Exception:
     import re
 
 import itertools
@@ -572,7 +572,7 @@ class LukeTokenizer(RobertaBPETokenizer):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/paddlenlp/transformers/mamba/tokenizer.py
+++ b/paddlenlp/transformers/mamba/tokenizer.py
@@ -182,7 +182,7 @@ class MambaTokenizer(PretrainedTokenizer):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/paddlenlp/transformers/mc2_parallel_linear.py
+++ b/paddlenlp/transformers/mc2_parallel_linear.py
@@ -29,7 +29,7 @@ try:
         ColumnSequenceParallelLinear,
         RowSequenceParallelLinear,
     )
-except:
+except Exception:
     pass
 from paddlenlp.utils.tools import get_env_device
 

--- a/paddlenlp/transformers/mistral/modeling.py
+++ b/paddlenlp/transformers/mistral/modeling.py
@@ -754,7 +754,7 @@ def parallel_matmul(x: paddle.Tensor, y: paddle.Tensor, tensor_parallel_output=T
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/mixtral/modeling.py
+++ b/paddlenlp/transformers/mixtral/modeling.py
@@ -39,7 +39,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from ...utils.log import logger
@@ -53,7 +53,7 @@ from .configuration import MixtralConfig
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 __all__ = [
@@ -188,7 +188,7 @@ def parallel_matmul(x: Tensor, y: Tensor, tensor_parallel_output=True):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -63,7 +63,7 @@ from safetensors.paddle import save_file
 
 try:
     from paddle.distributed.fleet.meta_parallel import LocalSharedLayerDesc
-except:
+except Exception:
     LocalSharedLayerDesc = None
 from paddle.nn import Embedding, Layer
 
@@ -124,7 +124,7 @@ __all__ = [
 def dy2st_nocheck_guard_context():
     try:
         context = paddle.framework._no_check_dy2st_diff()
-    except:
+    except Exception:
         context = contextlib.nullcontext()
     return context
 
@@ -2731,7 +2731,7 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                     subfolder=subfolder,
                     **kwargs,
                 )
-            except:
+            except Exception:
                 logger.info(
                     "Generation config file not found, using a generation config created from the model config."
                 )

--- a/paddlenlp/transformers/moe_layer_auto.py
+++ b/paddlenlp/transformers/moe_layer_auto.py
@@ -24,7 +24,7 @@ import paddle.nn.functional as F
 
 try:
     from paddle.distributed.auto_parallel.local_layer import LocalLayer
-except:
+except Exception:
 
     class LocalLayer(object):
         """

--- a/paddlenlp/transformers/qwen/modeling.py
+++ b/paddlenlp/transformers/qwen/modeling.py
@@ -68,7 +68,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 __all__ = [
@@ -86,12 +86,12 @@ MAX_NTK_SEQ_LENGTH = 32768
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.incubate.nn.functional import fused_rotary_position_embedding
-except:
+except Exception:
     fused_rotary_position_embedding = None
 
 
@@ -107,7 +107,7 @@ def parallel_matmul(x: Tensor, y: Tensor, tensor_parallel_output=True):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if is_fleet_init and tensor_parallel_degree > 1 and y.is_distributed:

--- a/paddlenlp/transformers/qwen/modeling_auto.py
+++ b/paddlenlp/transformers/qwen/modeling_auto.py
@@ -46,12 +46,12 @@ MAX_NTK_SEQ_LENGTH = 32768
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.incubate.nn.functional import fused_rotary_position_embedding
-except:
+except Exception:
     fused_rotary_position_embedding = None
 
 try:

--- a/paddlenlp/transformers/qwen/modeling_network.py
+++ b/paddlenlp/transformers/qwen/modeling_network.py
@@ -43,12 +43,12 @@ MAX_NTK_SEQ_LENGTH = 32768
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.incubate.nn.functional import fused_rotary_position_embedding
-except:
+except Exception:
     fused_rotary_position_embedding = None
 
 try:

--- a/paddlenlp/transformers/qwen2/modeling.py
+++ b/paddlenlp/transformers/qwen2/modeling.py
@@ -74,12 +74,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 
@@ -143,7 +143,7 @@ def parallel_matmul(x: Tensor, y: Tensor, transpose_y=True, tensor_parallel_outp
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/qwen2_moe/modeling.py
+++ b/paddlenlp/transformers/qwen2_moe/modeling.py
@@ -195,7 +195,7 @@ def parallel_matmul(x: Tensor, y: Tensor, tensor_parallel_output=True):
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/paddlenlp/transformers/qwen3/modeling.py
+++ b/paddlenlp/transformers/qwen3/modeling.py
@@ -73,7 +73,7 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 

--- a/paddlenlp/transformers/refined_recompute.py
+++ b/paddlenlp/transformers/refined_recompute.py
@@ -537,7 +537,7 @@ def get_skip_recompute_ops(config, layer_idx):
     try:
         hcg = fleet.get_hybrid_communicate_group()
         pp_size = max(hcg.get_pipe_parallel_world_size(), 1)
-    except:
+    except Exception:
         pp_size = 1
     layer_num = config.num_layers if hasattr(config, "num_layers") else config.num_hidden_layers
     if hasattr(config, "add_tail_layer") and config.add_tail_layer:

--- a/paddlenlp/transformers/tensor_parallel_utils.py
+++ b/paddlenlp/transformers/tensor_parallel_utils.py
@@ -16,7 +16,7 @@ import paddle.distributed.fleet as fleet
 
 try:
     from paddle.nn.layer.layers import in_declarative_mode
-except:
+except Exception:
     from paddle.fluid.dygraph.base import in_declarative_mode
 import paddle.distributed as dist
 from paddle.autograd import PyLayer
@@ -57,7 +57,7 @@ def parallel_matmul(lm_output, logit_weights, tensor_parallel_output=True, train
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     is_logit_weight_distributed = logit_weights.is_distributed
@@ -85,7 +85,7 @@ def parallel_linear(lm_output, logit_weights, bias, tensor_parallel_output=True)
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     is_logit_weight_distributed = logit_weights.is_distributed

--- a/paddlenlp/transformers/tokenizer_utils_base.py
+++ b/paddlenlp/transformers/tokenizer_utils_base.py
@@ -1220,10 +1220,10 @@ class SpecialTokensMixin:
         for attr in self.SPECIAL_TOKENS_ATTRIBUTES:
             try:
                 attr_value = getattr(self, "_" + attr)
-            except:
+            except Exception:
                 try:
                     attr_value = getattr(self, attr)
-                except:
+                except Exception:
                     continue
             if attr_value:
                 set_attr[attr] = (
@@ -1246,10 +1246,10 @@ class SpecialTokensMixin:
         for attr in self.SPECIAL_TOKENS_ATTRIBUTES:
             try:
                 attr_value = getattr(self, "_" + attr)
-            except:
+            except Exception:
                 try:
                     attr_value = getattr(self, attr)
-                except:
+                except Exception:
                     continue
             if attr_value:
                 set_attr[attr] = attr_value

--- a/paddlenlp/transformers/utils.py
+++ b/paddlenlp/transformers/utils.py
@@ -60,7 +60,7 @@ from ..utils.download import resolve_file_path
 # TODO(@zewu): upgrade aistudio to the newest version
 try:
     from .aistudio_utils import aistudio_download
-except:
+except Exception:
     aistudio_download = None
 
 HUGGINGFACE_CO_RESOLVE_ENDPOINT = "https://huggingface.co"
@@ -183,7 +183,7 @@ def adapt_stale_fwd_patch(self, name, value):
 
             if is_inference_mode(value):
                 return value
-        except:
+        except Exception:
             pass
 
         if hasattr(inspect, "getfullargspec"):
@@ -563,7 +563,7 @@ def cached_file(
             resolved_file = aistudio_download(
                 repo_id=path_or_repo_id, filename=filename, subfolder=subfolder, cache_dir=cache_dir
             )
-        except:
+        except Exception:
             resolved_file = None
     else:
         # if cache_dir is None:
@@ -809,7 +809,7 @@ def use_hybrid_parallel():
 
         hcg = fleet.get_hybrid_communicate_group()
         return hcg
-    except:
+    except Exception:
         return None
 
 

--- a/paddlenlp/transformers/yuan/modeling.py
+++ b/paddlenlp/transformers/yuan/modeling.py
@@ -44,7 +44,7 @@ try:
         ColumnSequenceParallelLinear,
         RowSequenceParallelLinear,
     )
-except:
+except Exception:
     pass
 
 __all__ = [

--- a/paddlenlp/trl/kto_trainer.py
+++ b/paddlenlp/trl/kto_trainer.py
@@ -33,7 +33,7 @@ def disable_dropout_in_model(model: paddle.nn.Layer) -> None:
 
 try:
     from paddlenlp.peft.lora.lora_model import AVAILABLE_LAYERS
-except:
+except Exception:
     from paddlenlp.peft.lora.lora_model import AVALIABLE_LAYERS
 
     AVAILABLE_LAYERS = AVALIABLE_LAYERS

--- a/paddlenlp/trl/sft_auto_trainer.py
+++ b/paddlenlp/trl/sft_auto_trainer.py
@@ -56,7 +56,7 @@ from .sft_trainer import SFTTrainer
 
 try:
     from ...quantization.quantization_linear import QuantizationLinear
-except:
+except Exception:
     QuantizationLinear = None
 
 MODEL_NAME = "model"

--- a/paddlenlp/trl/trl_utils.py
+++ b/paddlenlp/trl/trl_utils.py
@@ -21,7 +21,7 @@ def calculate_effective_tokens(training_args, train_dataset, max_seq_len):
 
     try:
         data_parallel_degree = training_args.data_parallel_degree
-    except:
+    except Exception:
         data_parallel_degree = 1
     if training_args.sharding_parallel_degree > 1:
         sharding_parallel_degree = training_args.sharding_parallel_degree

--- a/paddlenlp/utils/__init__.py
+++ b/paddlenlp/utils/__init__.py
@@ -26,7 +26,7 @@ from .memory_utils import empty_device_cache
 
 try:
     from .optimizer import *
-except:
+except Exception:
     logger.info("Not support custom optimizer")
 
 from .paddle_patch import *

--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -180,7 +180,7 @@ class MetricsDumper(object):
                     break
                 with open(self.filename, "a") as writer:
                     writer.write(json.dumps(metrics) + "\n")
-            except:
+            except Exception:
                 continue
 
     def _signal_handler(self, sig, frame):

--- a/paddlenlp/utils/optimizer.py
+++ b/paddlenlp/utils/optimizer.py
@@ -28,7 +28,7 @@ from paddlenlp.utils.log import logger
 
 try:
     from .adamw_triton import adamw_triton
-except:
+except Exception:
     adamw_triton = None
 
 
@@ -482,7 +482,7 @@ class AdamWCustom(AdamW):
         self._add_accumulator(self._moment2_acc_str, p, dtype=moment_dtype)
         try:
             type = core.VarDesc.VarType.DENSE_TENSOR
-        except:
+        except Exception:
             type = core.VarDesc.VarType.LOD_TENSOR
         self._add_accumulator(
             name=self._beta1_pow_acc_str,

--- a/scripts/codestyle/convert/example/qwen2/modeling.py
+++ b/scripts/codestyle/convert/example/qwen2/modeling.py
@@ -74,12 +74,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 
@@ -143,7 +143,7 @@ def parallel_matmul(x: Tensor, y: Tensor, transpose_y=True, tensor_parallel_outp
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/scripts/codestyle/convert/example/qwen2/modeling_qwen2.py
+++ b/scripts/codestyle/convert/example/qwen2/modeling_qwen2.py
@@ -76,12 +76,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 __all__ = [
     "Qwen2Model",
@@ -241,7 +241,7 @@ def parallel_matmul(x: Tensor, y: Tensor, transpose_y=False, tensor_parallel_out
         hcg = fleet.get_hybrid_communicate_group()
         model_parallel_group = hcg.get_model_parallel_group()
         tensor_parallel_degree = hcg.get_model_parallel_world_size()
-    except:
+    except Exception:
         is_fleet_init = False
 
     if paddle.in_dynamic_mode():

--- a/scripts/codestyle/convert/example/qwen2/modular_qwen2.py
+++ b/scripts/codestyle/convert/example/qwen2/modular_qwen2.py
@@ -84,12 +84,12 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 __all__ = [
     "Qwen2Model",

--- a/scripts/regression/gen_allure_report.py
+++ b/scripts/regression/gen_allure_report.py
@@ -85,19 +85,19 @@ def gen_allure_report():
             time.sleep(1)
             try:
                 os.remove("allure-2.19.0.zip")
-            except:
+            except Exception:
                 print("#### can not remove allure-2.19.0.zip")
         if os.path.exists("java_linux.tar.gz"):
             time.sleep(1)
             try:
                 os.remove("java_linux.tar.gz")
-            except:
+            except Exception:
                 print("#### can not remove java_linux.tar.gz")
         if os.path.exists("bos_new.tar.gz"):
             time.sleep(1)
             try:
                 os.remove("bos_new.tar.gz")
-            except:
+            except Exception:
                 print("#### can not remove bos_new.tar.gz")
         return ret
     else:

--- a/slm/examples/few_shot/RGL/template.py
+++ b/slm/examples/few_shot/RGL/template.py
@@ -127,7 +127,7 @@ class Template(nn.Layer):
                     if isinstance(part, set):
                         part = {k: None for k in part}
                     p.update(part)
-                except:
+                except Exception:
                     import traceback
 
                     logger.error(traceback.format_exc())

--- a/slm/examples/information_extraction/DuIE/extract_chinese_and_punct.py
+++ b/slm/examples/information_extraction/DuIE/extract_chinese_and_punct.py
@@ -89,18 +89,18 @@ class ChineseAndPunctuationExtractor(object):
                     f = chr(f)
                     t = chr(t)
                     L.append("%s-%s" % (f, t))
-                except:
+                except Exception:
                     pass  # A narrow python build, so can't use chars > 65535 without surrogate pairs!
 
             else:
                 try:
                     L.append(chr(i))
-                except:
+                except Exception:
                     pass
         for j, _ in CN_PUNCTS:
             try:
                 L.append(chr(j))
-            except:
+            except Exception:
                 pass
 
         for k in EN_PUNCTS:
@@ -109,7 +109,7 @@ class ChineseAndPunctuationExtractor(object):
                 f = chr(f)
                 t = chr(t)
                 L.append("%s-%s" % (f, t))
-            except:
+            except Exception:
                 raise ValueError()
                 pass  # A narrow python build, so can't use chars > 65535 without surrogate pairs!
 

--- a/slm/examples/information_extraction/DuIE/re_official_evaluation.py
+++ b/slm/examples/information_extraction/DuIE/re_official_evaluation.py
@@ -53,12 +53,12 @@ def check_format(line):
     json_info = {}
     try:
         line = line.strip()
-    except:
+    except Exception:
         ret_code = ENCODING_ERROR
         return ret_code, json_info
     try:
         json_info = json.loads(line)
-    except:
+    except Exception:
         ret_code = JSON_ERROR
         return ret_code, json_info
     if "text" not in json_info or "spo_list" not in json_info:
@@ -99,7 +99,7 @@ def load_predict_result(predict_filename):
         return ret_code, predict_result
     try:
         predict_file_zip = zipfile.ZipFile(predict_filename)
-    except:
+    except Exception:
         ret_code = NOT_ZIP_FILE
         return ret_code, predict_result
     for predict_file in predict_file_zip.namelist():
@@ -149,7 +149,7 @@ def load_alias_dict(alias_filename):
                 alias_dict[words[0].lower()] = set()
                 for alias_word in words[1:]:
                     alias_dict[words[0].lower()].add(alias_word.lower())
-            except:
+            except Exception:
                 ret_code = ALIAS_FORMAT_ERROR
                 return ret_code, alias_dict
     return ret_code, alias_dict

--- a/slm/examples/machine_translation/transformer/deploy/python/tls/benchmark_utils.py
+++ b/slm/examples/machine_translation/transformer/deploy/python/tls/benchmark_utils.py
@@ -80,7 +80,7 @@ class PaddleInferBenchmark(object):
             self.data_num = data_info["data_num"]
 
             self.inference_time_s = round(perf_info["inference_time_s"], 4)
-        except:
+        except Exception:
             self.print_help()
             raise ValueError("Set argument wrong, please check input argument and its type")
 

--- a/slm/examples/machine_translation/transformer/deploy/serving/transformer_web_server.py
+++ b/slm/examples/machine_translation/transformer/deploy/serving/transformer_web_server.py
@@ -21,7 +21,7 @@ from easydict import EasyDict as AttrDict
 
 try:
     from paddle_serving_server_gpu.web_service import WebService
-except:
+except Exception:
     from paddle_serving_server.web_service import WebService
 
 from transformer_reader import TransformerReader
@@ -97,7 +97,7 @@ def do_server(args):
     if args.profile:
         try:
             service.setup_profile(30)
-        except:
+        except Exception:
             pass
     service.load_model_config(args.inference_model_dir)
     if args.device == "gpu":

--- a/slm/examples/model_interpretation/evaluation/accuracy/mrc_f1_evaluate.py
+++ b/slm/examples/model_interpretation/evaluation/accuracy/mrc_f1_evaluate.py
@@ -152,7 +152,7 @@ def evaluate_ch(ref_ans, pred_ans):
         answers = sample["sent_label"]
         try:
             prediction = pred_ans[query_id]["pred_label"]
-        except:
+        except Exception:
             skip_count += 1
             continue
         if prediction == "":

--- a/slm/examples/model_interpretation/task/mrc/saliency_map/utils.py
+++ b/slm/examples/model_interpretation/task/mrc/saliency_map/utils.py
@@ -28,7 +28,7 @@ class UnpackDataLoader(paddle.io.DataLoader):
 def create_if_not_exists(dir):
     try:
         dir.mkdir(parents=True)
-    except:
+    except Exception:
         pass
     return dir
 

--- a/slm/examples/model_interpretation/task/senti/saliency_map/utils.py
+++ b/slm/examples/model_interpretation/task/senti/saliency_map/utils.py
@@ -29,7 +29,7 @@ class UnpackDataLoader(paddle.io.DataLoader):
 def create_if_not_exists(dir):
     try:
         dir.mkdir(parents=True)
-    except:
+    except Exception:
         pass
     return dir
 

--- a/slm/model_zoo/gpt-3/ppfleetx/core/engine/eager_engine.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/core/engine/eager_engine.py
@@ -467,7 +467,7 @@ class EagerEngine(BasicEngine):
                 if not hasattr(self._optimizer, "all_fused_tensors") or self._optimizer.all_fused_tensors is None:
                     try:
                         fused_allreduce_gradients(list(self._module.model.parameters()), None)
-                    except:
+                    except Exception:
                         fused_allreduce_gradients(list(self._module.model.parameters()), None)
                 else:
                     all_reduce_parameters(self._optimizer.all_fused_tensors, self._dp_group)

--- a/slm/model_zoo/gpt-3/ppfleetx/data/utils/batch_collate_fn.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/data/utils/batch_collate_fn.py
@@ -19,7 +19,7 @@ import paddle
 
 try:
     from collections.abc import Mapping, Sequence
-except:
+except Exception:
     from collections import Sequence, Mapping
 
 from ppfleetx.data.sampler import Stack, Tuple

--- a/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/auto/auto_model.py
@@ -40,18 +40,18 @@ from ..dygraph.processor import (
 
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 FusedDropoutAdd = None
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.jit.api import set_dynamic_shape
-except:
+except Exception:
     from paddle.jit.dy2static.utils_helper import set_dynamic_shape
 
 def shard_op_for_sequence_parallel_linear(tgt, mesh):

--- a/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/hybrid_model.py
@@ -56,24 +56,24 @@ try:
         ScatterOp,
         mark_as_sequence_parallel_parameter,
     )
-except:
+except Exception:
     pass
 
 from paddlenlp.transformers.segment_parallel_utils  import ReshardLayer
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.incubate.nn.layer.fused_dropout_add import FusedDropoutAdd
-except:
+except Exception:
     FusedDropoutAdd = None
 
 try:
     from paddle.jit.api import set_dynamic_shape
-except:
+except Exception:
     from paddle.jit.dy2static.utils_helper import set_dynamic_shape
 
 def get_attr(layer, name):

--- a/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/models/language_model/gpt/dygraph/single_model.py
@@ -40,12 +40,12 @@ from .processor import (
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 try:
     from paddle.jit.api import set_dynamic_shape
-except:
+except Exception:
     from paddle.jit.dy2static.utils_helper import set_dynamic_shape
 
 def get_attr(layer, name):

--- a/slm/model_zoo/gpt-3/ppfleetx/models/language_model/language_module.py
+++ b/slm/model_zoo/gpt-3/ppfleetx/models/language_model/language_module.py
@@ -28,7 +28,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         register_sequence_parallel_allreduce_hooks,
     )
-except:
+except Exception:
     pass
 from ppfleetx.utils.log import logger
 

--- a/slm/model_zoo/t5/dataset_utils.py
+++ b/slm/model_zoo/t5/dataset_utils.py
@@ -1,1 +1,842 @@
-../ernie-1.0/data_tools/dataset_utils.py
+# coding=utf-8
+
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# Copyright 2018 The Google AI Language Team Authors, and NVIDIA.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import math
+import os
+import re
+import time
+
+import numpy as np
+import paddle
+
+from paddlenlp.data.indexed_dataset import get_indexed_dataset_
+
+# Most of the code here has been copied from:
+#   https://github.com/google-research/albert/blob/master/create_pretraining_data.py
+# with some modifications.
+
+
+def get_local_rank():
+    return int(os.getenv("PADDLE_RANK_IN_NODE", 0))
+
+
+print_rank_0 = print
+COMPILED = False
+DSET_TYPE_BERT = "standard_bert"
+DSET_TYPE_T5 = "t5"
+DSET_TYPE_ERNIE = "ernie"
+DSET_TYPES = [DSET_TYPE_BERT, DSET_TYPE_T5, DSET_TYPE_ERNIE]
+
+
+def compile_helper():
+    """Compile helper function ar runtime. Make sure this
+    is invoked on a single process."""
+    import os
+    import subprocess
+
+    path = os.path.abspath(os.path.dirname(__file__))
+    ret = subprocess.run(["make", "-C", path])
+    if ret.returncode != 0:
+        print("Making C++ dataset helpers module failed, exiting.")
+        import sys
+
+        sys.exit(1)
+
+
+class BlendableDataset(paddle.io.Dataset):
+    """
+    The BlendableDataset is a wrapper which used to mix different dataset.
+
+    The input is a list of dataset and corresponding weights for each dataset.
+    """
+
+    def __init__(self, datasets, weights):
+
+        self.datasets = datasets
+        num_datasets = len(datasets)
+        assert num_datasets == len(weights)
+
+        self.size = 0
+        for dataset in self.datasets:
+            self.size += len(dataset)
+
+        # Normalize weights.
+        weights = np.array(weights, dtype=np.float64)
+        sum_weights = np.sum(weights)
+        assert sum_weights > 0.0
+        weights /= sum_weights
+
+        # Build indecies.
+        start_time = time.time()
+        assert num_datasets < 255
+        self.dataset_index = np.zeros(self.size, dtype=np.uint8)
+        self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
+
+        # local_rank = 0 if fleet.local_rank() is None else int(fleet.local_rank(
+        # ))
+        local_rank = get_local_rank()
+
+        while True:
+            try:
+                try:
+                    from fast_dataindex import helpers
+                except Exception:
+                    print_rank_0(
+                        " > missing fast_dataindex, pip install fast_dataindex please, try to compile locally."
+                    )
+                    import data_tools.helpers as helpers
+                break
+            except Exception:
+                if local_rank == 0:
+                    compile_helper()
+                print_rank_0("> wait for hepers to be compiled!")
+                time.sleep(1)
+
+        helpers.build_blending_indices(
+            self.dataset_index, self.dataset_sample_index, weights, num_datasets, self.size, local_rank == 0
+        )
+        print_rank_0(
+            "> elapsed time for building blendable dataset indices: " "{:.2f} (sec)".format(time.time() - start_time)
+        )
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        dataset_idx = self.dataset_index[idx]
+        sample_idx = self.dataset_sample_index[idx]
+        return self.datasets[dataset_idx][sample_idx]
+
+
+def get_datasets_weights_and_num_samples(data_prefix, train_valid_test_num_samples):
+
+    # The data prefix should be in the format of:
+    #   weight-1, data-prefix-1, weight-2, data-prefix-2, ..
+    assert len(data_prefix) % 2 == 0
+    num_datasets = len(data_prefix) // 2
+    weights = [0] * num_datasets
+    prefixes = [0] * num_datasets
+    for i in range(num_datasets):
+        weights[i] = float(data_prefix[2 * i])
+        prefixes[i] = (data_prefix[2 * i + 1]).strip()
+    # Normalize weights
+    weight_sum = 0.0
+    for weight in weights:
+        weight_sum += weight
+    assert weight_sum > 0.0
+    weights = [weight / weight_sum for weight in weights]
+
+    # Add 0.5% (the 1.005 factor) so in case the bleding dataset does
+    # not uniformly distribute the number of samples, we still have
+    # samples left to feed to the network.
+    datasets_train_valid_test_num_samples = []
+    for weight in weights:
+        datasets_train_valid_test_num_samples.append(
+            [int(math.ceil(val * weight * 1.005)) for val in train_valid_test_num_samples]
+        )
+
+    return prefixes, weights, datasets_train_valid_test_num_samples
+
+
+def get_a_and_b_segments(sample, np_rng):
+    """Divide sample into a and b segments."""
+
+    # Number of sentences in the sample.
+    n_sentences = len(sample)
+    # Make sure we always have two sentences.
+    assert n_sentences > 1, "make sure each sample has at least two sentences."
+
+    # First part:
+    # `a_end` is how many sentences go into the `A`.
+    a_end = 1
+    if n_sentences >= 3:
+        # Note that randin in numpy is exclusive.
+        a_end = np_rng.randint(1, n_sentences)
+    tokens_a = []
+    for j in range(a_end):
+        tokens_a.extend(sample[j])
+
+    # Second part:
+    tokens_b = []
+    for j in range(a_end, n_sentences):
+        tokens_b.extend(sample[j])
+
+    # Random next:
+    is_next_random = False
+    if np_rng.random() < 0.5:
+        is_next_random = True
+        tokens_a, tokens_b = tokens_b, tokens_a
+
+    return tokens_a, tokens_b, is_next_random
+
+
+def truncate_segments(tokens_a, tokens_b, len_a, len_b, max_num_tokens, np_rng):
+    """Truncates a pair of sequences to a maximum sequence length."""
+    # print(len_a, len_b, max_num_tokens)
+    assert len_a > 0
+    if len_a + len_b <= max_num_tokens:
+        return False
+    while len_a + len_b > max_num_tokens:
+        if len_a > len_b:
+            len_a -= 1
+            tokens = tokens_a
+        else:
+            len_b -= 1
+            tokens = tokens_b
+        if np_rng.random() < 0.5:
+            del tokens[0]
+        else:
+            tokens.pop()
+    return True
+
+
+def create_tokens_and_tokentypes(tokens_a, tokens_b, cls_id, sep_id):
+    """Merge segments A and B, add [CLS] and [SEP] and build tokentypes."""
+
+    tokens = []
+    tokentypes = []
+    # [CLS].
+    tokens.append(cls_id)
+    tokentypes.append(0)
+    # Segment A.
+    for token in tokens_a:
+        tokens.append(token)
+        tokentypes.append(0)
+    # [SEP].
+    tokens.append(sep_id)
+    tokentypes.append(0)
+    # Segment B.
+    for token in tokens_b:
+        tokens.append(token)
+        tokentypes.append(1)
+    if tokens_b:
+        # [SEP].
+        tokens.append(sep_id)
+        tokentypes.append(1)
+
+    return tokens, tokentypes
+
+
+MaskedLmInstance = collections.namedtuple("MaskedLmInstance", ["index", "label"])
+
+
+def is_start_piece(piece):
+    """Check if the current word piece is the starting piece (BERT)."""
+    # When a word has been split into
+    # WordPieces, the first token does not have any marker and any subsequence
+    # tokens are prefixed with ##. So whenever we see the ## token, we
+    # append it to the previous set of word indexes.
+    return not piece.startswith("##")
+
+
+def create_masked_lm_predictions(
+    tokens,
+    vocab_id_list,
+    vocab_id_to_token_dict,
+    masked_lm_prob,
+    cls_id,
+    sep_id,
+    mask_id,
+    max_predictions_per_seq,
+    np_rng,
+    max_ngrams=3,
+    vocab_token_to_id_dict=None,
+    do_whole_word_mask=True,
+    favor_longer_ngram=False,
+    do_permutation=False,
+    geometric_dist=False,
+    to_chinese_char=False,
+    inplace_random_mask=False,
+    masking_style="bert",
+):
+    """Creates the predictions for the masked LM objective.
+    Note: Tokens here are vocab ids and not text tokens."""
+
+    cand_indexes = []
+    # Note(mingdachen): We create a list for recording if the piece is
+    # the starting piece of current token, where 1 means true, so that
+    # on-the-fly whole word masking is possible.
+    token_boundary = [0] * len(tokens)
+
+    for (i, token) in enumerate(tokens):
+        if token == cls_id or token == sep_id:
+            token_boundary[i] = 1
+            continue
+        # Whole Word Masking means that if we mask all of the wordpieces
+        # corresponding to an original word.
+        #
+        # Note that Whole Word Masking does *not* change the training code
+        # at all -- we still predict each WordPiece independently, softmaxed
+        # over the entire vocabulary.
+        vocab_id = vocab_id_to_token_dict[token]
+        if do_whole_word_mask and len(cand_indexes) >= 1 and not is_start_piece(vocab_id):
+            cand_indexes[-1].append(i)
+        else:
+            cand_indexes.append([i])
+            if is_start_piece(vocab_id_to_token_dict[token]):
+                token_boundary[i] = 1
+
+    if to_chinese_char:
+        # set ## chinse char to original chinese char
+        char_tokens = []
+        assert vocab_token_to_id_dict is not None
+        for i, b in enumerate(token_boundary):
+            if b == 0:
+                vocab_id = vocab_id_to_token_dict[tokens[i]]
+                new_vocab_id = vocab_id[2:] if len(re.findall("##[\u4E00-\u9FA5]", vocab_id)) > 0 else vocab_id
+                char_tokens.append(
+                    vocab_token_to_id_dict[new_vocab_id] if new_vocab_id in vocab_token_to_id_dict else token
+                )
+            else:
+                char_tokens.append(tokens[i])
+        output_tokens = list(char_tokens)
+    else:
+        output_tokens = list(tokens)
+
+    masked_lm_positions = []
+    masked_lm_labels = []
+
+    if masked_lm_prob == 0:
+        return (output_tokens, masked_lm_positions, masked_lm_labels, token_boundary)
+
+    num_to_predict = min(max_predictions_per_seq, max(1, int(round(len(tokens) * masked_lm_prob))))
+
+    ngrams = np.arange(1, max_ngrams + 1, dtype=np.int64)
+    if not geometric_dist:
+        # Note(mingdachen):
+        # By default, we set the probilities to favor shorter ngram sequences.
+        pvals = 1.0 / np.arange(1, max_ngrams + 1)
+        pvals /= pvals.sum(keepdims=True)
+        if favor_longer_ngram:
+            pvals = pvals[::-1]
+
+    ngram_indexes = []
+    for idx in range(len(cand_indexes)):
+        ngram_index = []
+        for n in ngrams:
+            ngram_index.append(cand_indexes[idx : idx + n])
+        ngram_indexes.append(ngram_index)
+
+    np_rng.shuffle(ngram_indexes)
+
+    (masked_lms, masked_spans) = ([], [])
+    covered_indexes = set()
+    backup_output_tokens = list(output_tokens)
+    for cand_index_set in ngram_indexes:
+        if len(masked_lms) >= num_to_predict:
+            break
+        if not cand_index_set:
+            continue
+        # Note(mingdachen):
+        # Skip current piece if they are covered in lm masking or previous ngrams.
+        for index_set in cand_index_set[0]:
+            for index in index_set:
+                if index in covered_indexes:
+                    continue
+
+        if not geometric_dist:
+            n = np_rng.choice(
+                ngrams[: len(cand_index_set)],
+                p=pvals[: len(cand_index_set)] / pvals[: len(cand_index_set)].sum(keepdims=True),
+            )
+        else:
+            # Sampling "n" from the geometric distribution and clipping it to
+            # the max_ngrams. Using p=0.2 default from the SpanBERT paper
+            # https://arxiv.org/pdf/1907.10529.pdf (Sec 3.1)
+            n = min(np_rng.geometric(0.2), max_ngrams)
+
+        index_set = sum(cand_index_set[n - 1], [])
+        n -= 1
+        # Note(mingdachen):
+        # Repeatedly looking for a candidate that does not exceed the
+        # maximum number of predictions by trying shorter ngrams.
+        while len(masked_lms) + len(index_set) > num_to_predict:
+            if n == 0:
+                break
+            index_set = sum(cand_index_set[n - 1], [])
+            n -= 1
+        # If adding a whole-word mask would exceed the maximum number of
+        # predictions, then just skip this candidate.
+        if len(masked_lms) + len(index_set) > num_to_predict:
+            continue
+        is_any_index_covered = False
+        for index in index_set:
+            if index in covered_indexes:
+                is_any_index_covered = True
+                break
+        if is_any_index_covered:
+            continue
+        for index in index_set:
+            covered_indexes.add(index)
+            masked_token = None
+            if masking_style == "bert":
+                # 80% of the time, replace with [MASK]
+                if np_rng.random() < 0.8:
+                    masked_token = mask_id
+                else:
+                    # 10% of the time, keep original
+                    if np_rng.random() < 0.5:
+                        masked_token = output_tokens[index]
+                    # 10% of the time, replace with random word
+                    else:
+                        if inplace_random_mask:
+                            masked_token = backup_output_tokens[np_rng.randint(0, len(output_tokens))]
+                        else:
+                            masked_token = vocab_id_list[np_rng.randint(0, len(vocab_id_list))]
+            elif masking_style == "t5":
+                masked_token = mask_id
+            else:
+                raise ValueError("invalid value of masking style")
+
+            output_tokens[index] = masked_token
+            masked_lms.append(MaskedLmInstance(index=index, label=backup_output_tokens[index]))
+
+        masked_spans.append(
+            MaskedLmInstance(index=index_set, label=[backup_output_tokens[index] for index in index_set])
+        )
+
+    assert len(masked_lms) <= num_to_predict
+    np_rng.shuffle(ngram_indexes)
+
+    select_indexes = set()
+    if do_permutation:
+        for cand_index_set in ngram_indexes:
+            if len(select_indexes) >= num_to_predict:
+                break
+            if not cand_index_set:
+                continue
+            # Note(mingdachen):
+            # Skip current piece if they are covered in lm masking or previous ngrams.
+            for index_set in cand_index_set[0]:
+                for index in index_set:
+                    if index in covered_indexes or index in select_indexes:
+                        continue
+
+            n = np.random.choice(
+                ngrams[: len(cand_index_set)],
+                p=pvals[: len(cand_index_set)] / pvals[: len(cand_index_set)].sum(keepdims=True),
+            )
+            index_set = sum(cand_index_set[n - 1], [])
+            n -= 1
+
+            while len(select_indexes) + len(index_set) > num_to_predict:
+                if n == 0:
+                    break
+                index_set = sum(cand_index_set[n - 1], [])
+                n -= 1
+            # If adding a whole-word mask would exceed the maximum number of
+            # predictions, then just skip this candidate.
+            if len(select_indexes) + len(index_set) > num_to_predict:
+                continue
+            is_any_index_covered = False
+            for index in index_set:
+                if index in covered_indexes or index in select_indexes:
+                    is_any_index_covered = True
+                    break
+            if is_any_index_covered:
+                continue
+            for index in index_set:
+                select_indexes.add(index)
+        assert len(select_indexes) <= num_to_predict
+
+        select_indexes = sorted(select_indexes)
+        permute_indexes = list(select_indexes)
+        np_rng.shuffle(permute_indexes)
+        orig_token = list(output_tokens)
+
+        for src_i, tgt_i in zip(select_indexes, permute_indexes):
+            output_tokens[src_i] = orig_token[tgt_i]
+            masked_lms.append(MaskedLmInstance(index=src_i, label=orig_token[src_i]))
+
+    masked_lms = sorted(masked_lms, key=lambda x: x.index)
+    # Sort the spans by the index of the first span
+    masked_spans = sorted(masked_spans, key=lambda x: x.index[0])
+
+    for p in masked_lms:
+        masked_lm_positions.append(p.index)
+        masked_lm_labels.append(p.label)
+    return (output_tokens, masked_lm_positions, masked_lm_labels, token_boundary, masked_spans)
+
+
+def pad_and_convert_to_numpy(tokens, tokentypes, masked_positions, masked_labels, pad_id, max_seq_length):
+    """Pad sequences and convert them to numpy."""
+
+    # Some checks.
+    num_tokens = len(tokens)
+    padding_length = max_seq_length - num_tokens
+    assert padding_length >= 0
+    assert len(tokentypes) == num_tokens
+    assert len(masked_positions) == len(masked_labels)
+
+    # Tokens and token types.
+    filler = [pad_id] * padding_length
+    tokens_np = np.array(tokens + filler, dtype=np.int64)
+    tokentypes_np = np.array(tokentypes + filler, dtype=np.int64)
+
+    # Padding mask.
+    padding_mask_np = np.array([1] * num_tokens + [0] * padding_length, dtype=np.int64)
+
+    # Lables and loss mask.
+    labels = [-1] * max_seq_length
+    loss_mask = [0] * max_seq_length
+    for i in range(len(masked_positions)):
+        assert masked_positions[i] < num_tokens
+        labels[masked_positions[i]] = masked_labels[i]
+        loss_mask[masked_positions[i]] = 1
+    labels_np = np.array(labels, dtype=np.int64)
+    loss_mask_np = np.array(loss_mask, dtype=np.int64)
+
+    return tokens_np, tokentypes_np, labels_np, padding_mask_np, loss_mask_np
+
+
+def build_train_valid_test_datasets(
+    data_prefix,
+    args,
+    tokenizer,
+    splits_string,
+    train_valid_test_num_samples,
+    max_seq_length,
+    masked_lm_prob,
+    short_seq_prob,
+    seed,
+    skip_warmup,
+    binary_head=False,
+    max_seq_length_dec=None,
+    dataset_type="standard_bert",
+):
+
+    if len(data_prefix) == 1:
+        return _build_train_valid_test_datasets(
+            data_prefix[0],
+            args,
+            tokenizer,
+            splits_string,
+            train_valid_test_num_samples,
+            max_seq_length,
+            masked_lm_prob,
+            short_seq_prob,
+            seed,
+            skip_warmup,
+            binary_head,
+            max_seq_length_dec,
+            dataset_type=dataset_type,
+        )
+
+    # Blending dataset.
+    # Parse the values.
+    output = get_datasets_weights_and_num_samples(data_prefix, train_valid_test_num_samples)
+    prefixes, weights, datasets_train_valid_test_num_samples = output
+
+    # Build individual datasets.
+    train_datasets = []
+    valid_datasets = []
+    test_datasets = []
+    for i in range(len(prefixes)):
+        train_ds, valid_ds, test_ds = _build_train_valid_test_datasets(
+            prefixes[i],
+            args,
+            tokenizer,
+            splits_string,
+            datasets_train_valid_test_num_samples[i],
+            max_seq_length,
+            masked_lm_prob,
+            short_seq_prob,
+            seed,
+            skip_warmup,
+            binary_head,
+            max_seq_length_dec,
+            dataset_type=dataset_type,
+        )
+        if train_ds:
+            train_datasets.append(train_ds)
+        if valid_ds:
+            valid_datasets.append(valid_ds)
+        if test_ds:
+            test_datasets.append(test_ds)
+
+        # Blend.
+    blending_train_dataset = None
+    if train_datasets:
+        blending_train_dataset = BlendableDataset(train_datasets, weights)
+    blending_valid_dataset = None
+    if valid_datasets:
+        blending_valid_dataset = BlendableDataset(valid_datasets, weights)
+    blending_test_dataset = None
+    if test_datasets:
+        blending_test_dataset = BlendableDataset(test_datasets, weights)
+
+    return (blending_train_dataset, blending_valid_dataset, blending_test_dataset)
+
+
+def _build_train_valid_test_datasets(
+    data_prefix,
+    args,
+    tokenizer,
+    splits_string,
+    train_valid_test_num_samples,
+    max_seq_length,
+    masked_lm_prob,
+    short_seq_prob,
+    seed,
+    skip_warmup,
+    binary_head,
+    max_seq_length_dec,
+    dataset_type="standard_bert",
+):
+
+    if dataset_type not in DSET_TYPES:
+        raise ValueError("Invalid dataset_type: ", dataset_type)
+
+    # Indexed dataset.
+    indexed_dataset = get_indexed_dataset_(data_prefix, args.data_impl, skip_warmup)
+
+    # Get start and end indices of train/valid/train into doc-idx
+    # Note that doc-idx is desinged to be num-docs + 1 so we can
+    # easily iterate over it.
+    total_num_of_documents = indexed_dataset.doc_idx.shape[0] - 1
+    splits = get_train_valid_test_split_(splits_string, total_num_of_documents)
+
+    # Print stats about the splits.
+    print_rank_0(" > dataset split:")
+
+    def print_split_stats(name, index):
+        print_rank_0("    {}:".format(name))
+        print_rank_0(
+            "     document indices in [{}, {}) total of {} "
+            "documents".format(splits[index], splits[index + 1], splits[index + 1] - splits[index])
+        )
+        start_index = indexed_dataset.doc_idx[splits[index]]
+        end_index = indexed_dataset.doc_idx[splits[index + 1]]
+        print_rank_0(
+            "     sentence indices in [{}, {}) total of {} "
+            "sentences".format(start_index, end_index, end_index - start_index)
+        )
+
+    print_split_stats("train", 0)
+    print_split_stats("validation", 1)
+    print_split_stats("test", 2)
+
+    def build_dataset(index, name):
+        # from megatron.data.bert_dataset import BertDataset
+        # from megatron.data.t5_dataset import T5Dataset
+        # from .ernie_dataset import ErnieDataset
+
+        dataset = None
+        if splits[index + 1] > splits[index]:
+            # Get the pointer to the original doc-idx so we can set it later.
+            doc_idx_ptr = indexed_dataset.get_doc_idx()
+            # Slice the doc-idx
+            start_index = splits[index]
+            # Add +1 so we can index into the dataset to get the upper bound.
+            end_index = splits[index + 1] + 1
+            # New doc_idx view.
+            indexed_dataset.set_doc_idx(doc_idx_ptr[start_index:end_index])
+            # Build the dataset accordingly.
+            kwargs = dict(
+                name=name,
+                data_prefix=data_prefix,
+                num_epochs=None,
+                max_num_samples=train_valid_test_num_samples[index],
+                max_seq_length=max_seq_length,
+                seed=seed,
+                share_folder=args.share_folder,
+                args=args,
+            )
+            if dataset_type == DSET_TYPE_T5:
+                from t5_dataset import T5Dataset
+
+                dataset = T5Dataset(
+                    indexed_dataset=indexed_dataset,
+                    tokenizer=tokenizer,
+                    masked_lm_prob=masked_lm_prob,
+                    max_seq_length_dec=max_seq_length_dec,
+                    short_seq_prob=short_seq_prob,
+                    **kwargs,
+                )
+            # elif dataset_type == DSET_TYPE_BERT:
+            #     dataset = BertDataset(
+            #         indexed_dataset=indexed_dataset,
+            #         tokenizer=tokenizer,
+            #         masked_lm_prob=masked_lm_prob,
+            #         short_seq_prob=short_seq_prob,
+            #         binary_head=binary_head,
+            #         **kwargs,
+            #     )
+            elif dataset_type == DSET_TYPE_ERNIE:
+                from .ernie_dataset import ErnieDataset
+
+                dataset = ErnieDataset(
+                    indexed_dataset=indexed_dataset,
+                    tokenizer=tokenizer,
+                    masked_lm_prob=masked_lm_prob,
+                    short_seq_prob=short_seq_prob,
+                    binary_head=binary_head,
+                    **kwargs,
+                )
+            else:
+                raise NotImplementedError("Dataset type not fully implemented.")
+
+            # Set the original pointer so dataset remains the main dataset.
+            indexed_dataset.set_doc_idx(doc_idx_ptr)
+            # Checks.
+            assert indexed_dataset.doc_idx[0] == 0
+            assert indexed_dataset.doc_idx.shape[0] == (total_num_of_documents + 1)
+        return dataset
+
+    train_dataset = build_dataset(0, "train")
+    valid_dataset = build_dataset(1, "valid")
+    test_dataset = build_dataset(2, "test")
+
+    return (train_dataset, valid_dataset, test_dataset)
+
+
+def get_train_valid_test_split_(splits_string, size):
+    """Get dataset splits from comma or '/' separated string list."""
+
+    splits = []
+    if splits_string.find(",") != -1:
+        splits = [float(s) for s in splits_string.split(",")]
+    elif splits_string.find("/") != -1:
+        splits = [float(s) for s in splits_string.split("/")]
+    else:
+        splits = [float(splits_string)]
+    while len(splits) < 3:
+        splits.append(0.0)
+    splits = splits[:3]
+    splits_sum = sum(splits)
+    assert splits_sum > 0.0
+    splits = [split / splits_sum for split in splits]
+    splits_index = [0]
+    for index, split in enumerate(splits):
+        splits_index.append(splits_index[index] + int(round(split * float(size))))
+    diff = splits_index[-1] - size
+    for index in range(1, len(splits_index)):
+        splits_index[index] -= diff
+    assert len(splits_index) == 4
+    assert splits_index[-1] == size
+    return splits_index
+
+
+def get_samples_mapping(
+    indexed_dataset,
+    data_prefix,
+    num_epochs,
+    max_num_samples,
+    max_seq_length,
+    short_seq_prob,
+    seed,
+    name,
+    binary_head,
+    share_folder,
+):
+    """Get a list that maps a sample index to a starting sentence index, end sentence index, and length"""
+
+    if not num_epochs:
+        if not max_num_samples:
+            raise ValueError("Need to specify either max_num_samples " "or num_epochs")
+        num_epochs = np.iinfo(np.int32).max - 1
+    if not max_num_samples:
+        max_num_samples = np.iinfo(np.int64).max - 1
+
+    # Filename of the index mapping
+    indexmap_filename = data_prefix
+    indexmap_filename += "_{}_indexmap".format(name)
+    if num_epochs != (np.iinfo(np.int32).max - 1):
+        indexmap_filename += "_{}ep".format(num_epochs)
+    if max_num_samples != (np.iinfo(np.int64).max - 1):
+        indexmap_filename += "_{}mns".format(max_num_samples)
+    indexmap_filename += "_{}msl".format(max_seq_length)
+    indexmap_filename += "_{:0.2f}ssp".format(short_seq_prob)
+    indexmap_filename += "_{}s".format(seed)
+    indexmap_filename += ".npy"
+
+    local_rank = get_local_rank()
+    if share_folder:
+        local_rank = paddle.distributed.get_rank()
+    # Build the indexed mapping if not exist.
+
+    if local_rank == 0 and not os.path.isfile(indexmap_filename):
+        print(
+            " > WARNING: could not find index map file {}, building "
+            "the indices on rank 0 ...".format(indexmap_filename)
+        )
+
+        # Make sure the types match the helpers input types.
+        assert indexed_dataset.doc_idx.dtype == np.int64
+        print(indexed_dataset.sizes.dtype)
+        assert indexed_dataset.sizes.dtype == np.int32
+
+        # Build samples mapping
+        verbose = local_rank == 0
+        start_time = time.time()
+        print_rank_0(" > building sapmles index mapping for {} ...".format(name))
+        # First compile and then import.
+        try:
+            from fast_dataindex import helpers
+        except ModuleNotFoundError:
+            print_rank_0(" > missing fast_dataindex, pip install fast_dataindex please, try to compile locally.")
+            if local_rank == 0:
+                compile_helper()
+            import data_tools.helpers as helpers
+
+        samples_mapping = helpers.build_mapping(
+            indexed_dataset.doc_idx,
+            indexed_dataset.sizes,
+            num_epochs,
+            max_num_samples,
+            max_seq_length,
+            short_seq_prob,
+            seed,
+            verbose,
+            2 if binary_head else 1,
+        )
+        print_rank_0(" > done building sapmles index mapping")
+        np.save(indexmap_filename, samples_mapping, allow_pickle=True)
+        print_rank_0(" > saved the index mapping in {}".format(indexmap_filename))
+        # Make sure all the ranks have built the mapping
+        print_rank_0(
+            " > elapsed time to build and save samples mapping " "(seconds): {:4f}".format(time.time() - start_time)
+        )
+
+    else:
+        while True:
+            if not os.path.isfile(indexmap_filename):
+                time.sleep(3)
+            else:
+                try:
+                    np.load(indexmap_filename, allow_pickle=True, mmap_mode="r")
+                    break
+                except Exception:
+                    print("%s file is still writing or damaged, please wait a moment." % indexmap_filename)
+                    time.sleep(3)
+
+    # This should be a barrier but nccl barrier assumes
+    # device_index=rank which is not the case for model
+    # parallel case
+    if paddle.distributed.get_world_size() > 1:
+        if paddle.in_dynamic_mode():
+            paddle.distributed.barrier()
+
+    # Load indexed dataset.
+    print_rank_0(" > loading indexed mapping from {}".format(indexmap_filename))
+    start_time = time.time()
+    samples_mapping = np.load(indexmap_filename, allow_pickle=True, mmap_mode="r")
+    print_rank_0("    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time))
+    print_rank_0("    total number of samples: {}".format(samples_mapping.shape[0]))
+
+    return samples_mapping

--- a/slm/pipelines/pipelines/nodes/preprocessor/text_splitter.py
+++ b/slm/pipelines/pipelines/nodes/preprocessor/text_splitter.py
@@ -280,7 +280,7 @@ class SpacyTextSplitter(TextSplitter):
             raise ImportError("Spacy is not installed, please install it with `pip install spacy`.")
         try:
             self._tokenizer = spacy.load(pipeline)
-        except:
+        except Exception:
             spacy.cli.download(pipeline)
             self._tokenizer = spacy.load(pipeline)
 

--- a/slm/pipelines/pipelines/nodes/prompt/prompt_node.py
+++ b/slm/pipelines/pipelines/nodes/prompt/prompt_node.py
@@ -378,7 +378,7 @@ class PromptNode(BaseComponent):
         prompt_template_resolved: PromptTemplate = invocation_context.pop("prompt_template")
         try:
             output_variable = self.output_variable or prompt_template_resolved.output_variable or "results"
-        except:
+        except Exception:
             output_variable = "results"
         invocation_context[output_variable] = results
         invocation_context["prompts"] = prompt_collector


### PR DESCRIPTION
## What
Replace 207 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.