### PR TITLE
Revise SECURITY.md for clarity on versions and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable version of PaddleNLP receives security updates. Make sure you are running the most recent release.
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security problems. Instead, use GitHub's "Report a vulnerability" feature in the Security tab of this repository. We will review and respond as soon as possible.
+
+## Security Updates
+
+If we fix a vulnerability, we will announce it in the release notes. Keep your installation up to date to receive the latest fixes.


### PR DESCRIPTION
Also, would it be possible to enable GitHub’s “Report a vulnerability” feature for this repository? That would make it easier to submit security reports privately through GitHub Security Advisories.
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.
- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
Others

### PR changes
Docs

### Description
This PR updates the security reporting documentation and asks whether the maintainers could enable GitHub’s “Report a vulnerability” feature for this repository. This would make it easier for researchers to submit security reports privately through GitHub Security Advisories.