### PR TITLE
fix: prevent path traversal in /files endpoint

### DIFF
--- a/slm/pipelines/rest_api/controller/file_upload.py
+++ b/slm/pipelines/rest_api/controller/file_upload.py
@@ -224,7 +224,14 @@ def upload_file_splitter(
 
 @router.get("/files")
 def download_file(file_name: str = "1fc0aeac9900487a8c6cec8dda6499bd_demo_1.png"):
-    file_path = os.path.join(FILE_PARSE_PATH, file_name)
-    if os.path.exists(file_path):
-        return FileResponse(file_path)
+    # Prevent path traversal: resolve the path and verify it stays within
+    # the allowed directory. os.path.join with an absolute second argument
+    # discards the first, so absolute paths must be rejected explicitly.
+    if os.path.isabs(file_name):
+        raise HTTPException(status_code=400, detail="Invalid file name")
+    resolved = os.path.realpath(os.path.join(FILE_PARSE_PATH, file_name))
+    if not resolved.startswith(os.path.realpath(FILE_PARSE_PATH) + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid file name")
+    if os.path.exists(resolved):
+        return FileResponse(resolved)
     return {"message": "File not Found"}


### PR DESCRIPTION
## Summary

The `GET /files` endpoint in the pipelines REST API has an arbitrary file read vulnerability. The `file_name` query parameter is passed directly to `os.path.join(FILE_PARSE_PATH, file_name)` without any validation, allowing an attacker to:

1. **Absolute path override**: Pass `/etc/passwd` as `file_name` — `os.path.join` discards `FILE_PARSE_PATH` when the second argument is absolute
2. **Path traversal**: Pass `../../etc/passwd` to escape the intended directory

## Vulnerability Details

**Endpoint:** `GET /files?file_name=<payload>`  
**File:** `slm/pipelines/rest_api/controller/file_upload.py:227`  
**Impact:** Arbitrary file read on the server filesystem

### Before (vulnerable):
```python
file_path = os.path.join(FILE_PARSE_PATH, file_name)
if os.path.exists(file_path):
    return FileResponse(file_path)
```

### After (fixed):
```python
if os.path.isabs(file_name):
    raise HTTPException(status_code=400, detail="Invalid file name")
resolved = os.path.realpath(os.path.join(FILE_PARSE_PATH, file_name))
if not resolved.startswith(os.path.realpath(FILE_PARSE_PATH) + os.sep):
    raise HTTPException(status_code=400, detail="Invalid file name")
if os.path.exists(resolved):
    return FileResponse(resolved)
```

## Fix

1. **Reject absolute paths** — prevents `os.path.join` from discarding `FILE_PARSE_PATH`
2. **Resolve symlinks** with `os.path.realpath` — prevents symlink-based traversal
3. **Validate containment** — verify the resolved path starts with `FILE_PARSE_PATH`

## Test Plan

- [ ] `GET /files?file_name=../../etc/passwd` → 400 error
- [ ] `GET /files?file_name=/etc/passwd` → 400 error
- [ ] `GET /files?file_name=valid_document.pdf` → 200 (file returned) or 404

Closes #11236
