### PR TITLE
Fix bare except: use except Exception in background logging loop

### DIFF
--- a/paddlenlp/utils/log.py
+++ b/paddlenlp/utils/log.py
@@ -180,7 +180,7 @@ class MetricsDumper(object):
                     break
                 with open(self.filename, "a") as writer:
                     writer.write(json.dumps(metrics) + "\n")
-            except:
+            except Exception:
                 continue
 
     def _signal_handler(self, sig, frame):


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `paddlenlp/utils/log.py`.

In the background metrics logging thread loop, the bare `except:` catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`), which can interfere with graceful shutdown. `except Exception:` catches all real errors while allowing process signals to propagate correctly.