### PR TITLE
fix: prevent path traversal in /files download endpoint [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/slm/pipelines/rest_api/controller/file_upload.py
+++ b/slm/pipelines/rest_api/controller/file_upload.py
@@ -224,6 +224,7 @@ def upload_file_splitter(
 
 @router.get("/files")
 def download_file(file_name: str = "1fc0aeac9900487a8c6cec8dda6499bd_demo_1.png"):
+    file_name = os.path.basename(file_name)
     file_path = os.path.join(FILE_PARSE_PATH, file_name)
     if os.path.exists(file_path):
         return FileResponse(file_path)


### PR DESCRIPTION
## Summary

Fix a path traversal vulnerability in the `/files` download endpoint (`slm/pipelines/rest_api/controller/file_upload.py`).

## Vulnerability

`os.path.join(FILE_PARSE_PATH, file_name)` discards the base directory when `file_name` is an absolute path (e.g. `/etc/passwd`). An unauthenticated remote attacker can read any file readable by the server process.

## Fix

Use `os.path.basename(file_name)` to strip all directory components before joining with `FILE_PARSE_PATH`.

## PoC

```bash
# Before fix: reads arbitrary files
curl http://target:8000/files?file_name=/etc/passwd

# After fix: only returns files within FILE_PARSE_PATH
curl http://target:8000/files?file_name=/etc/passwd  # returns 404
```

Closes #11236