### PR TITLE
fix: replace bare except with ImportError in trainer.py

### DIFF
--- a/paddlenlp/trainer/trainer.py
+++ b/paddlenlp/trainer/trainer.py
@@ -46,12 +46,12 @@ from paddle.distributed.fleet.meta_parallel import PipelineLayer
 
 try:
     from paddle.distributed.fleet.meta_parallel import PipelineDatasetPreprocessor
-except:
+except ImportError:
     PipelineDatasetPreprocessor = None
 
 try:
     from paddle.base import core
-except:
+except ImportError:
     core = None
 from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
@@ -67,12 +67,12 @@ try:
     )
 
     _obtain_optimizer_parameters_list = obtain_optimizer_parameters_list
-except:
+except ImportError:
     try:
         from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
             _obtain_optimizer_parameters_list,
         )
-    except:
+    except ImportError:
         _obtain_optimizer_parameters_list = None
 
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
@@ -106,7 +106,7 @@ try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         register_sequence_parallel_allreduce_hooks,
     )
-except:
+except ImportError:
     pass
 
 from ..transformers.context_parallel_utils import split_inputs_sequence_dim_load_balance


### PR DESCRIPTION
## Motivation

The \	rainer.py\ file contains 5 bare except clauses (\except:\) which catch all exceptions including \SystemExit\ and \KeyboardInterrupt\. These are all import fallback patterns that should only catch \ImportError\.

## Changes

Replace 5 bare except clauses with specific \except ImportError:\:

1. Line 49: PipelineDatasetPreprocessor import fallback
2. Line 54: paddle.base.core import fallback
3. Line 70: obtain_optimizer_parameters_list import fallback (outer)
4. Line 75: _obtain_optimizer_parameters_list import fallback (inner)
5. Line 109: register_sequence_parallel_allreduce_hooks import fallback

## Testing

- No functional changes - only exception handling improvement
- Import fallback behavior is preserved
- Local environment limitations - relying on CI/CD automated testing

## Checklist

- [x] Code follows the project's coding standards
- [x] No new dependencies added
- [x] Commit messages follow conventional format