### PR TITLE
docs(inference): note OpenAI-compatible multi-model gateway example (DaoXE)

### DIFF
--- a/docs/en/get_started/inference.md
+++ b/docs/en/get_started/inference.md
@@ -73,6 +73,16 @@ if stream:
 else:
     print(completion.choices[0].message.content)
 ```
+
+The same OpenAI client pattern works against any OpenAI-compatible multi-model gateway. For example, point `base_url` at DaoXE (`https://api.daoxe.com/v1`) and use a key/model id issued by that endpoint:
+
+```python
+client = OpenAI(
+    api_key="YOUR_DAOXE_KEY",
+    base_url="https://api.daoxe.com/v1",
+)
+```
+
 3. You can also refer to the script invocation using the ./predict/request_flask_server.py file.
 ```bash
 # Under the PaddleNLP/llm directory


### PR DESCRIPTION
## Summary

The English inference quick-start already shows calling the local Flask server with the OpenAI Python client. This PR adds a short note that the same client pattern works against any OpenAI-compatible multi-model gateway — DaoXE (`https://api.daoxe.com/v1`) is one concrete example.

Docs only.

## Test plan
- [ ] Local OpenAI client example unchanged
- [ ] Gateway note is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>